### PR TITLE
TCK3 LPS-74355 8-29

### DIFF
--- a/portal-impl/src/com/liferay/portlet/PortletRequestImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletRequestImpl.java
@@ -412,25 +412,61 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 
 	@Override
 	public Enumeration<String> getProperties(String name) {
-		List<String> values = new ArrayList<>();
+		List<String> properties = new ArrayList<>();
+
+		Enumeration<String> headersEnumeration = _request.getHeaders(name);
+
+		if (headersEnumeration != null) {
+			while (headersEnumeration.hasMoreElements()) {
+				String header = headersEnumeration.nextElement();
+
+				properties.add(header);
+			}
+		}
 
 		String value = _portalContext.getProperty(name);
 
 		if (value != null) {
-			values.add(value);
+			properties.add(value);
 		}
 
-		return Collections.enumeration(values);
+		return Collections.enumeration(properties);
 	}
 
 	@Override
 	public String getProperty(String name) {
-		return _portalContext.getProperty(name);
+		String property = _request.getHeader(name);
+
+		if (property == null) {
+			property = _portalContext.getProperty(name);
+		}
+
+		return property;
 	}
 
 	@Override
 	public Enumeration<String> getPropertyNames() {
-		return _portalContext.getPropertyNames();
+		List<String> propertyNames = new ArrayList<>();
+
+		Enumeration<String> headerNameEnumeration = _request.getHeaderNames();
+		Enumeration<String> propertyNameEnumeration =
+			_portalContext.getPropertyNames();
+
+		if (headerNameEnumeration != null) {
+			while (headerNameEnumeration.hasMoreElements()) {
+				String headerName = headerNameEnumeration.nextElement();
+
+				propertyNames.add(headerName);
+			}
+		}
+
+		while (propertyNameEnumeration.hasMoreElements()) {
+			String propertyName = propertyNameEnumeration.nextElement();
+
+			propertyNames.add(propertyName);
+		}
+
+		return Collections.enumeration(propertyNames);
 	}
 
 	@Override


### PR DESCRIPTION
@tinatian 

For the `getProperties()` method, in 14.1.3 the spec states:

> A portlet can access portal/portlet container specific properties and, if available, the headers of the HTTP client request through the following PortletRequest methods: getProperty(), getProperties(), getPropertyNames().
> A property with a given name can have multiple values. If the property has multiple values, the getProperty method returns the first property value. The getProperties method allows access to **all the property values** associated with a particular property name by returning an Enumeration of String objects.

I think in this case we should include property values from both the servlet request headers and the portal context.