### PR TITLE
LPS-71758 Validate and print warning if module.framework.base.dir contains character that Equinox doesn't support.

### DIFF
--- a/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
+++ b/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
@@ -56,6 +56,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
+import java.net.MalformedURLException;
 import java.net.URL;
 
 import java.nio.file.DirectoryStream;
@@ -250,6 +251,8 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 		if (_log.isDebugEnabled()) {
 			_log.debug("Initializing the OSGi framework");
 		}
+
+		_validateModuleFrameworkBaseDir();
 
 		_initRequiredStartupDirs();
 
@@ -1541,6 +1544,32 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 							" is already unregistered");
 				}
 			}
+		}
+	}
+
+	private void _validateModuleFrameworkBaseDir()
+		throws MalformedURLException {
+
+		File baseDirFile = new File(PropsValues.MODULE_FRAMEWORK_BASE_DIR);
+
+		baseDirFile = baseDirFile.getAbsoluteFile();
+
+		URL baseDirURL = baseDirFile.toURL();
+
+		File baseDirURLFile = new File(baseDirURL.getFile());
+
+		if (!baseDirFile.equals(baseDirURLFile)) {
+			StringBundler sb = new StringBundler(7);
+
+			sb.append("\n\n\n ###### Warning ######\n");
+			sb.append(" The module.framework.base.dir path \"");
+			sb.append(baseDirFile);
+			sb.append("\" contains character that Equinox doesn't support; ");
+			sb.append("the osgi persistence dir will be created as \"");
+			sb.append(baseDirURLFile);
+			sb.append("\".\n\n\n");
+
+			System.out.println(sb.toString());
 		}
 	}
 


### PR DESCRIPTION
@tinatian 
Implemented according to Shuyang's email.

Equinox does more checking than ours, for example, replacing "@user.home" to actual $USER.HOME, or checking whether the string starts with `file:`. However, in lots of places in our code, we treat `PropsValues.MODULE_FRAMEWORK_BASE_DIR` as a file path, so I didn't include the checking above.