### PR TITLE
TCK3 LPS-74658

### DIFF
--- a/portal-impl/src/com/liferay/portlet/EventResponseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/EventResponseImpl.java
@@ -38,6 +38,11 @@ public class EventResponseImpl
 
 	@Override
 	public void setRenderParameters(EventRequest eventRequest) {
+		if (eventRequest == null) {
+			throw new IllegalArgumentException();
+		}
+
+		setRenderParameters(eventRequest.getParameterMap());
 	}
 
 	/**

--- a/portal-web/test/functional/com/liferay/portalweb/macros/MyAccount.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/MyAccount.macro
@@ -87,8 +87,14 @@
 	</command>
 
 	<command name="view">
-		<for list="Password,Organizations,Sites,User Groups,Roles,Categorization" param="key_panelHeading">
-			<execute function="AssertElementPresent" locator1="Panel#PANEL_HEADING_COLLAPSED" />
-		</for>
+		<execute function="AssertElementPresent" locator1="UsersAndOrganizationsEditUser#CATEGORIZATION_LABEL" />
+
+		<execute macro="UserNavigator#gotoOrganizations" />
+
+		<execute macro="UserNavigator#gotoMemberships" />
+
+		<execute macro="UserNavigator#gotoRoles" />
+
+		<execute macro="UserNavigator#gotoPassword" />
 	</command>
 </definition>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/usersandorganizations/UsersAndOrganizationsEditUser.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/usersandorganizations/UsersAndOrganizationsEditUser.path
@@ -309,6 +309,12 @@
 	<td></td>
 	<td></td>
 </tr>
+<!--CATEGORIZATION-->
+<tr>
+	<td>CATEGORIZATION_LABEL</td>
+	<td>//div/label[@class='control-label' and contains(.,'Categorization')]</td>
+	<td></td>
+</tr>
 <!--CUSTOM_FIELDS-->
 <tr>
 	<td>CUSTOM_FIELDS_LABEL</td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/deployment/setupwizard/SetupWizardMySQL.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/deployment/setupwizard/SetupWizardMySQL.testcase
@@ -14,8 +14,9 @@
 	</command>
 
 	<command name="MySQLtoMySQLEditedAdministratorUser" priority="4">
-		<execute macro="SetupWizard#viewDefaultPortalNamePG" />
 		<property name="test.name.skip.portal.instance" value="SetupWizardMySQL#MySQLtoMySQLEditAdministratorUser" />
+
+		<execute macro="SetupWizard#viewDefaultPortalNamePG" />
 
 		<execute macro="SetupWizard#configureSampleDataPG">
 			<var name="addSampleData" value="false" />


### PR DESCRIPTION
@tinatian 
Original pull:
https://github.com/tinatian/liferay-portal/pull/744
Your previous change:
https://github.com/tinatian/liferay-portal/pull/775

After reading the Spec and the Pluto code, I think it's enough to do
```
setParameterMap(eventRequest.getParameterMap())
```
and we shouldn't use `RenderParametersPool`, because:

- event processing can only be triggered by `StateAwareResponse.setEvent()` in the action phase or previous event processing cycles; in other words, **event phase is never triggered directly by URL, so there's no "event parameters"**;
- what `eventRequest.getParameterMap()` contains are the render parameters set on the response in the action phase or event processing cycles;
- action and event phase is meant to **change** the render state of a portlet, and this method is to **replace the render parameters set on the current response with the parameters in the event request**, while our `RenderParametersPool` is mainly used to keep states for portlets that are on the page but not targeted by the request;
- Pluto also does `setParameterMap(eventRequest.getParameterMap())`, and its `eventRequest.getParameterMap()` does the same thing for event phase as Liferay does.