### PR TITLE
Lps 79076 removedeprecated portletconstants

### DIFF
--- a/modules/apps/foundation/alloy/alloy-mvc/src/main/java/com/liferay/alloy/mvc/AlloyFriendlyURLMapper.java
+++ b/modules/apps/foundation/alloy/alloy-mvc/src/main/java/com/liferay/alloy/mvc/AlloyFriendlyURLMapper.java
@@ -118,7 +118,7 @@ public abstract class AlloyFriendlyURLMapper extends DefaultFriendlyURLMapper {
 			return;
 		}
 
-		String portletId = getPortletId(routeParameters);
+		String portletId = getPortletInstanceKey(routeParameters);
 
 		if (portletId == null) {
 			return;

--- a/modules/apps/foundation/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/util/JSPRenderer.java
+++ b/modules/apps/foundation/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/util/JSPRenderer.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.PortletConstants;
 import com.liferay.portal.kernel.portlet.PortletBag;
 import com.liferay.portal.kernel.portlet.PortletBagPool;
+import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -78,7 +79,7 @@ public class JSPRenderer {
 		String portletId = _portal.getPortletId(request);
 
 		if (Validator.isNotNull(portletId)) {
-			String rootPortletId = PortletConstants.getRootPortletId(portletId);
+			String rootPortletId = PortletIdCodec.decodePortletName(portletId);
 
 			PortletBag portletBag = PortletBagPool.get(rootPortletId);
 

--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v0_0_5/UpgradeJournalArticles.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v0_0_5/UpgradeJournalArticles.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.PortletConstants;
+import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
@@ -33,6 +34,7 @@ import com.liferay.portal.kernel.upgrade.BaseUpgradePortletId;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portlet.PortletPreferencesImpl;
 
 import java.sql.PreparedStatement;
@@ -222,11 +224,12 @@ public class UpgradeJournalArticles extends BaseUpgradePortletId {
 
 				String newPreferences = getNewPreferences(plid, preferences);
 
-				long userId = PortletConstants.getUserId(portletId);
-				String instanceId = PortletConstants.getInstanceId(portletId);
+				long userId = PortletIdCodec.decodeUserId(portletId);
+				String instanceId = PortletIdCodec.decodeInstanceId(portletId);
 
-				String newPortletId = PortletConstants.assemblePortletId(
-					_PORTLET_ID_ASSET_PUBLISHER, userId, instanceId);
+				String newPortletId = PortletIdCodec.encode(
+					PortletIdCodec.decodePortletName(portletId), userId,
+					instanceId);
 
 				updatePortletPreference(
 					portletPreferencesId, newPortletId, newPreferences);

--- a/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalContentSearchLocalServiceImpl.java
+++ b/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalContentSearchLocalServiceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.model.PortletConstants;
 import com.liferay.portal.kernel.portlet.DisplayInformationProvider;
+import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.util.PortletKeys;
 
 import java.util.ArrayList;
@@ -94,7 +95,7 @@ public class JournalContentSearchLocalServiceImpl
 			List<String> portletIds = layoutTypePortlet.getPortletIds();
 
 			for (String portletId : portletIds) {
-				String rootPortletId = PortletConstants.getRootPortletId(
+				String rootPortletId = PortletIdCodec.decodePortletName(
 					portletId);
 
 				DisplayInformationProvider displayInformationProvider =

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/DefaultFriendlyURLMapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/DefaultFriendlyURLMapper.java
@@ -155,7 +155,7 @@ public class DefaultFriendlyURLMapper extends BaseFriendlyURLMapper {
 
 		String namespace = null;
 
-		String portletInstanceKey = getPortletId(routeParameters);
+		String portletInstanceKey = getPortletInstanceKey(routeParameters);
 
 		if (Validator.isNotNull(portletInstanceKey)) {
 			namespace = PortalUtil.getPortletNamespace(portletInstanceKey);


### PR DESCRIPTION
Hi Tina, the second commit are the two files for URLMapper, they are using getPortletId in their own class that are also deprecated, the replacement seems straight forward but I don't know if we should include it under this ticket, thanks!