### PR TITLE
LPS-83545 Redundant null check in EntityCacheImpl.clearCache(Class<?>)

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -1038,21 +1038,21 @@ jdbc.counter.connectionProperties=oracle.jdbc.ReadTimeout=0;oracle.net.CONNECT_T
 			<delete file="@{patching.tool.dir}/default.properties" />
 
 			<if>
-				<equals arg1="${app.server.type}" arg2="weblogic" />
+				<equals arg1="${app.server.type}" arg2="tomcat" />
 				<then>
-					<echo file="@{patching.tool.dir}/default.properties">global.lib.path=${app.server.weblogic.lib.global.dir}
-liferay.home=${liferay.home}
-patching.mode=binary
-war.path=${app.server.weblogic.portal.dir}/</echo>
-
 					<execute dir="@{patching.tool.dir}" failonerror="true">
+						patching-tool${file.suffix.bat} auto-discovery
 						patching-tool${file.suffix.bat} install -force
 						patching-tool${file.suffix.bat} update-plugins
 					</execute>
 				</then>
 				<else>
+					<echo file="@{patching.tool.dir}/default.properties">global.lib.path=${app.server.lib.global.dir}
+liferay.home=${liferay.home}
+patching.mode=binary
+war.path=${app.server.portal.dir}/</echo>
+
 					<execute dir="@{patching.tool.dir}" failonerror="true">
-						patching-tool${file.suffix.bat} auto-discovery
 						patching-tool${file.suffix.bat} install -force
 						patching-tool${file.suffix.bat} update-plugins
 					</execute>

--- a/modules/apps/analytics/.gitrepo
+++ b/modules/apps/analytics/.gitrepo
@@ -1,8 +1,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = a641188e67b1cdbedbb9953bc96db91f3258a5f9
+	commit = bdcf5ce61415a4270947ca0ae57e9759766068bc
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 239a23e036b4a5f884f187068f421e38c944fa80
+	parent = 15aafd1e6dd5d6bc555e895e0910ce6d5f7b989e
 	remote = git@github.com:liferay/com-liferay-analytics.git

--- a/modules/apps/analytics/analytics-client-osgi-test/bnd.bnd
+++ b/modules/apps/analytics/analytics-client-osgi-test/bnd.bnd
@@ -1,3 +1,4 @@
 Bundle-Name: Liferay Analytics Client OSGi Test
 Bundle-SymbolicName: com.liferay.analytics.client.osgi.test
 Bundle-Version: 1.0.0
+-includeresource: test-classes/integration

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/configuration/ExportImportConfigurationParameterMapFactoryImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/configuration/ExportImportConfigurationParameterMapFactoryImpl.java
@@ -585,7 +585,7 @@ public class ExportImportConfigurationParameterMapFactoryImpl
 	 *
 	 * <ol>
 	 * <li>
-	 * The <code>PORTLET_DATA_portletId<code> remains the same.
+	 * The <code>PORTLET_DATA_portletId</code> remains the same.
 	 * </li>
 	 * <li>
 	 * The <code>PortletExportControllerImpl</code> and

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/configuration/ExportImportConfigurationParameterMapFactoryImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/configuration/ExportImportConfigurationParameterMapFactoryImpl.java
@@ -572,7 +572,7 @@ public class ExportImportConfigurationParameterMapFactoryImpl
 	 * <li>
 	 * Adds model specific parameters to be able to decide whether a model needs
 	 * to be exported in the changeset portlet data handler. For example:
-	 * <"com.liferay.journal.model.JournalArticle", [<code>true</code>]>.
+	 * <code><com.liferay.journal.model.JournalArticle, true></code>.
 	 * </li>
 	 * <li>
 	 * Adds the original portlet ID parameter in case of portlet publication.

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/configuration/ExportImportConfigurationParameterMapFactoryImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/configuration/ExportImportConfigurationParameterMapFactoryImpl.java
@@ -557,21 +557,44 @@ public class ExportImportConfigurationParameterMapFactoryImpl
 	}
 
 	/**
-	 * In case of layout staging this method
-	 * 1. Removes PORTLET_DATA_portletId and PORTLET_DATA_ALL parameters in
-	 *    parameterMap and replaces them with PORTLET_DATA_changesetPortletId.
-	 * 2. Adds model specific parameters to be able to decide in changeset
-	 *    portlet data handler whether a model needs to be exported or not.
-	 *    For example: <"com.liferay.journal.model.JournalArticle",
-	 *    [<code>true</code>]>
-	 * 3. Adds originalPortletId parameter in case of portlet publication
+	 * Completes different actions depending on the following cases:
 	 *
-	 * In case of portlet staging
-	 * 1. PORTLET_DATA_portletId is kept as it is
-	 * 2. PortletExportControllerImpl and PortletImportControllerImpl calls the
-	 *    changeset portlet data handler directly
+	 * <p>
+	 * Layout Staging:
+	 * </p>
 	 *
-	 * @param parameterMap
+	 * <ol>
+	 * <li>
+	 * Removes the <code>PORTLET_DATA_portletId</code> and
+	 * <code>PORTLET_DATA_ALL</code> parameters in the parameter map and
+	 * replaces them with <code>PORTLET_DATA_changesetPortletId</code>.
+	 * </li>
+	 * <li>
+	 * Adds model specific parameters to be able to decide whether a model needs
+	 * to be exported in the changeset portlet data handler. For example:
+	 * <"com.liferay.journal.model.JournalArticle", [<code>true</code>]>.
+	 * </li>
+	 * <li>
+	 * Adds the original portlet ID parameter in case of portlet publication.
+	 * </li>
+	 * </ol>
+	 *
+	 * <p>
+	 * Portlet Staging:
+	 * </p>
+	 *
+	 * <ol>
+	 * <li>
+	 * The <code>PORTLET_DATA_portletId<code> remains the same.
+	 * </li>
+	 * <li>
+	 * The <code>PortletExportControllerImpl</code> and
+	 * <code>PortletImportControllerImpl</code> calls the changeset portlet data
+	 * handler directly.
+	 * </li>
+	 * </ol>
+	 *
+	 * @param parameterMap the parameter map
 	 */
 	private void _replaceParameterMap(Map<String, String[]> parameterMap) {
 		boolean portletPublish = false;

--- a/modules/apps/frontend-js/frontend-js-aui-web/build.gradle
+++ b/modules/apps/frontend-js/frontend-js-aui-web/build.gradle
@@ -7,7 +7,7 @@ configurations {
 
 task buildAlloyUI(type: Copy)
 
-String alloyUIVersion = "3.1.0-deprecated.44"
+String alloyUIVersion = "3.1.0-deprecated.45"
 
 File jsDestinationDir = file("tmp/META-INF/resources")
 

--- a/modules/apps/frontend-theme/frontend-theme-unstyled/build.gradle
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/build.gradle
@@ -15,7 +15,7 @@ task buildLexiconIcons(type: Copy)
 task buildTheme
 task publishNodeModule(type: PublishNodeModuleTask)
 
-String alloyUIVersion = "3.1.0-deprecated.44"
+String alloyUIVersion = "3.1.0-deprecated.45"
 String fontAwesomeVersion = "3.2.1"
 
 File themeDestinationDir = file("src/main/resources/META-INF/resources/_unstyled");

--- a/modules/apps/meris/meris-asset-category-demo-test/bnd.bnd
+++ b/modules/apps/meris/meris-asset-category-demo-test/bnd.bnd
@@ -1,3 +1,4 @@
 Bundle-Name: Liferay Meris Asset Category Demo Test
 Bundle-SymbolicName: com.liferay.meris.asset.category.demo.test
 Bundle-Version: 1.0.0
+-includeresource: test-classes/integration

--- a/modules/apps/portal-cache/portal-cache-impl/src/main/java/com/liferay/portal/cache/internal/dao/orm/EntityCacheImpl.java
+++ b/modules/apps/portal-cache/portal-cache-impl/src/main/java/com/liferay/portal/cache/internal/dao/orm/EntityCacheImpl.java
@@ -74,9 +74,7 @@ public class EntityCacheImpl
 
 		PortalCache<?, ?> portalCache = getPortalCache(clazz);
 
-		if (portalCache != null) {
-			portalCache.removeAll();
-		}
+		portalCache.removeAll();
 	}
 
 	@Override

--- a/modules/build-buildscript.gradle
+++ b/modules/build-buildscript.gradle
@@ -1,5 +1,5 @@
 dependencies {
-	classpath group: "com.liferay", name: "com.liferay.gradle.plugins.defaults", version: "5.4.84"
+	classpath group: "com.liferay", name: "com.liferay.gradle.plugins.defaults", version: "5.4.85"
 	classpath group: "com.liferay", name: "com.liferay.gradle.plugins.maven.plugin.builder", version: "1.2.0"
 	classpath group: "de.undercouch", name: "gradle-download-task", version: "3.3.0"
 	classpath group: "gradle.plugin.org.ysb33r.gradle", name: "gradletest", version: "1.1"

--- a/modules/sdk/gradle-plugins-defaults/bnd.bnd
+++ b/modules/sdk/gradle-plugins-defaults/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Gradle Plugins Defaults
 Bundle-SymbolicName: com.liferay.gradle.plugins.defaults
-Bundle-Version: 5.4.85
+Bundle-Version: 5.4.86
 Export-Package:\
 	com.liferay.gradle.plugins.defaults,\
 	com.liferay.gradle.plugins.defaults.extensions,\

--- a/modules/sdk/gradle-plugins-defaults/build.gradle
+++ b/modules/sdk/gradle-plugins-defaults/build.gradle
@@ -10,7 +10,7 @@ configurations {
 
 dependencies {
 	compile group: "com.gradle.publish", name: "plugin-publish-plugin", version: "0.9.9"
-	compile group: "com.liferay", name: "com.liferay.gradle.plugins", version: "3.12.79"
+	compile group: "com.liferay", name: "com.liferay.gradle.plugins", version: "3.12.80"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.app.javadoc.builder", version: "1.2.0"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.baseline", version: "1.3.1"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.cache", version: "1.0.12"

--- a/modules/sdk/gradle-plugins-target-platform/src/gradleTest/resolveBndrunFile/build.gradle
+++ b/modules/sdk/gradle-plugins-target-platform/src/gradleTest/resolveBndrunFile/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	dependencies {
-		classpath group: "com.liferay", name: "com.liferay.gradle.plugins", version: "3.12.79"
+		classpath group: "com.liferay", name: "com.liferay.gradle.plugins", version: "3.12.80"
 	}
 
 	repositories {

--- a/modules/sdk/gradle-plugins-target-platform/src/gradleTest/resolveBundles/build.gradle
+++ b/modules/sdk/gradle-plugins-target-platform/src/gradleTest/resolveBundles/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	dependencies {
-		classpath group: "com.liferay", name: "com.liferay.gradle.plugins", version: "3.12.79"
+		classpath group: "com.liferay", name: "com.liferay.gradle.plugins", version: "3.12.80"
 	}
 
 	repositories {

--- a/modules/sdk/gradle-plugins-target-platform/src/gradleTest/resolveMissing/build.gradle
+++ b/modules/sdk/gradle-plugins-target-platform/src/gradleTest/resolveMissing/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	dependencies {
-		classpath group: "com.liferay", name: "com.liferay.gradle.plugins", version: "3.12.79"
+		classpath group: "com.liferay", name: "com.liferay.gradle.plugins", version: "3.12.80"
 	}
 
 	repositories {

--- a/modules/sdk/gradle-plugins-target-platform/src/gradleTest/resolveSingle/build.gradle
+++ b/modules/sdk/gradle-plugins-target-platform/src/gradleTest/resolveSingle/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	dependencies {
-		classpath group: "com.liferay", name: "com.liferay.gradle.plugins", version: "3.12.79"
+		classpath group: "com.liferay", name: "com.liferay.gradle.plugins", version: "3.12.80"
 	}
 
 	repositories {

--- a/modules/sdk/gradle-plugins-test-integration/CHANGELOG.markdown
+++ b/modules/sdk/gradle-plugins-test-integration/CHANGELOG.markdown
@@ -67,6 +67,12 @@ a file already exists in the `osgi/test` directory before copying it from the
 - [LPS-78750]: Automatically set Tomcat's `.sh` files when executing the
 `setUpTestableTomcat` task.
 
+## 2.2.2 - 2018-07-17
+
+### Added
+- [LPS-83520]: Add the ability to set the application server host name by setting the
+property `testIntegrationTomcat.hostName`. The default value is `localhost`.
+
 [Liferay Portal Test]: https://github.com/liferay/liferay-portal/tree/master/portal-test
 [Liferay Portal Test Integration]: https://github.com/liferay/liferay-portal/tree/master/portal-test-integration
 [LPS-67573]: https://issues.liferay.com/browse/LPS-67573
@@ -78,3 +84,4 @@ a file already exists in the `osgi/test` directory before copying it from the
 [LPS-73525]: https://issues.liferay.com/browse/LPS-73525
 [LPS-75239]: https://issues.liferay.com/browse/LPS-75239
 [LPS-78750]: https://issues.liferay.com/browse/LPS-78750
+[LPS-83520]: https://issues.liferay.com/browse/LPS-83520

--- a/modules/sdk/gradle-plugins-test-integration/bnd.bnd
+++ b/modules/sdk/gradle-plugins-test-integration/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Gradle Plugins Test Integration
 Bundle-SymbolicName: com.liferay.gradle.plugins.test.integration
-Bundle-Version: 2.2.2
+Bundle-Version: 2.3.0
 Export-Package:\
 	com.liferay.gradle.plugins.test.integration,\
 	com.liferay.gradle.plugins.test.integration.tasks

--- a/modules/sdk/gradle-plugins-test-integration/bnd.bnd
+++ b/modules/sdk/gradle-plugins-test-integration/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Gradle Plugins Test Integration
 Bundle-SymbolicName: com.liferay.gradle.plugins.test.integration
-Bundle-Version: 2.3.0
+Bundle-Version: 2.3.1
 Export-Package:\
 	com.liferay.gradle.plugins.test.integration,\
 	com.liferay.gradle.plugins.test.integration.tasks

--- a/modules/sdk/gradle-plugins-test-integration/src/main/java/com/liferay/gradle/plugins/test/integration/TestIntegrationPlugin.java
+++ b/modules/sdk/gradle-plugins-test-integration/src/main/java/com/liferay/gradle/plugins/test/integration/TestIntegrationPlugin.java
@@ -610,6 +610,16 @@ public class TestIntegrationPlugin implements Plugin<Project> {
 
 			});
 
+		baseAppServerTask.setHostName(
+			new Callable<String>() {
+
+				@Override
+				public String call() throws Exception {
+					return testIntegrationTomcatExtension.getHostName();
+				}
+
+			});
+
 		baseAppServerTask.setPortNumber(
 			new Callable<Integer>() {
 

--- a/modules/sdk/gradle-plugins-test-integration/src/main/java/com/liferay/gradle/plugins/test/integration/TestIntegrationTomcatExtension.java
+++ b/modules/sdk/gradle-plugins-test-integration/src/main/java/com/liferay/gradle/plugins/test/integration/TestIntegrationTomcatExtension.java
@@ -37,6 +37,10 @@ public class TestIntegrationTomcatExtension {
 		return GradleUtil.toFile(_project, _dir);
 	}
 
+	public String getHostName() {
+		return GradleUtil.toString(_hostName);
+	}
+
 	public int getJmxRemotePort() {
 		return GradleUtil.toInteger(_jmxRemotePort);
 	}
@@ -79,6 +83,10 @@ public class TestIntegrationTomcatExtension {
 		_dir = dir;
 	}
 
+	public void setHostName(Object hostName) {
+		_hostName = hostName;
+	}
+
 	public void setJmxRemotePort(Object jmxRemotePort) {
 		_jmxRemotePort = jmxRemotePort;
 	}
@@ -105,6 +113,7 @@ public class TestIntegrationTomcatExtension {
 
 	private Object _checkPath = "/web/guest";
 	private Object _dir;
+	private Object _hostName = "localhost";
 	private Object _jmxRemotePort = 8099;
 	private Object _liferayHome;
 	private Object _managerPassword = "tomcat";

--- a/modules/sdk/gradle-plugins-test-integration/src/main/java/com/liferay/gradle/plugins/test/integration/tasks/BaseAppServerTask.java
+++ b/modules/sdk/gradle-plugins-test-integration/src/main/java/com/liferay/gradle/plugins/test/integration/tasks/BaseAppServerTask.java
@@ -87,6 +87,11 @@ public abstract class BaseAppServerTask extends DefaultTask {
 	}
 
 	@Input
+	public String getHostName() {
+		return GradleUtil.toString(_hostName);
+	}
+
+	@Input
 	public int getPortNumber() {
 		return GradleUtil.toInteger(_portNumber);
 	}
@@ -94,7 +99,7 @@ public abstract class BaseAppServerTask extends DefaultTask {
 	public boolean isReachable() {
 		try {
 			URL url = new URL(
-				"http", "localhost", getPortNumber(), getCheckPath());
+				"http", getHostName(), getPortNumber(), getCheckPath());
 
 			HttpURLConnection httpURLConnection =
 				(HttpURLConnection)url.openConnection();
@@ -141,6 +146,10 @@ public abstract class BaseAppServerTask extends DefaultTask {
 
 	public void setExecutableArgs(Object... executableArgs) {
 		setExecutableArgs(Arrays.asList(executableArgs));
+	}
+
+	public void setHostName(Object hostName) {
+		_hostName = hostName;
 	}
 
 	public void setPortNumber(Object portNumber) {
@@ -191,6 +200,7 @@ public abstract class BaseAppServerTask extends DefaultTask {
 	private long _checkTimeout = 10 * 60 * 1000;
 	private Object _executable;
 	private final List<Object> _executableArgs = new ArrayList<>();
+	private Object _hostName = "localhost";
 	private Object _portNumber;
 
 }

--- a/modules/sdk/gradle-plugins-test-integration/src/main/resources/com/liferay/gradle/plugins/test/integration/packageinfo
+++ b/modules/sdk/gradle-plugins-test-integration/src/main/resources/com/liferay/gradle/plugins/test/integration/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/sdk/gradle-plugins-test-integration/src/main/resources/com/liferay/gradle/plugins/test/integration/tasks/packageinfo
+++ b/modules/sdk/gradle-plugins-test-integration/src/main/resources/com/liferay/gradle/plugins/test/integration/tasks/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/modules/sdk/gradle-plugins-workspace/build.gradle
+++ b/modules/sdk/gradle-plugins-workspace/build.gradle
@@ -41,7 +41,7 @@ copyRepo {
 }
 
 dependencies {
-	compile group: "com.liferay", name: "com.liferay.gradle.plugins", version: "3.12.79"
+	compile group: "com.liferay", name: "com.liferay.gradle.plugins", version: "3.12.80"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.poshi.runner", version: "2.2.5"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.target.platform", version: "1.1.0"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.theme.builder", version: "2.0.3"

--- a/modules/sdk/gradle-plugins/bnd.bnd
+++ b/modules/sdk/gradle-plugins/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Gradle Plugins
 Bundle-SymbolicName: com.liferay.gradle.plugins
-Bundle-Version: 3.12.80
+Bundle-Version: 3.12.81
 Export-Package:\
 	com.liferay.gradle.plugins,\
 	com.liferay.gradle.plugins.extensions,\

--- a/modules/sdk/gradle-plugins/build.gradle
+++ b/modules/sdk/gradle-plugins/build.gradle
@@ -48,7 +48,7 @@ dependencies {
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.service.builder", version: "2.1.51"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.source.formatter", version: "2.3.213"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.soy", version: "3.1.6"
-	compile group: "com.liferay", name: "com.liferay.gradle.plugins.test.integration", version: "2.2.1"
+	compile group: "com.liferay", name: "com.liferay.gradle.plugins.test.integration", version: "2.3.0"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.tld.formatter", version: "1.0.7"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.tlddoc.builder", version: "1.3.0"
 	compile group: "com.liferay", name: "com.liferay.gradle.plugins.upgrade.table.builder", version: "2.0.1"

--- a/modules/util/portal-tools-target-platform-indexer-client/build.gradle
+++ b/modules/util/portal-tools-target-platform-indexer-client/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
-	compileOnly group: "org.osgi", name: "org.osgi.core", version: "6.0.0"
-	compileOnly project(":apps:static:portal-target-platform-indexer:portal-target-platform-indexer-api")
-	compileOnly project(":apps:static:portal-target-platform-indexer:portal-target-platform-indexer-impl")
+	compile group: "org.osgi", name: "org.osgi.core", version: "6.0.0"
+	compile project(":apps:static:portal-target-platform-indexer:portal-target-platform-indexer-api")
+	compile project(":apps:static:portal-target-platform-indexer:portal-target-platform-indexer-impl")
 }
 
 distributions {

--- a/portal-impl/src/com/liferay/portal/layoutconfiguration/util/PortletRenderer.java
+++ b/portal-impl/src/com/liferay/portal/layoutconfiguration/util/PortletRenderer.java
@@ -137,13 +137,15 @@ public class PortletRenderer {
 		while (attributeNames.hasMoreElements()) {
 			String attributeName = attributeNames.nextElement();
 
-			if (attributeName.startsWith("javax.portlet.faces")) {
+			if (attributeName.contains(
+					"javax.portlet.faces.renderResponseOutput")) {
+
 				headerRequestAttributes.put(
 					attributeName, request.getAttribute(attributeName));
 			}
 			else if (attributePrefixes != null) {
 				for (String attributePrefix : attributePrefixes) {
-					if (attributeName.startsWith(attributePrefix)) {
+					if (attributeName.contains(attributePrefix)) {
 						headerRequestAttributes.put(
 							attributeName, request.getAttribute(attributeName));
 

--- a/portal-impl/src/com/liferay/portlet/internal/ActionRequestImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/ActionRequestImpl.java
@@ -14,10 +14,24 @@
 
 package com.liferay.portlet.internal;
 
+import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.portlet.InvokerPortlet;
 import com.liferay.portal.kernel.portlet.LiferayActionRequest;
+import com.liferay.portal.kernel.util.PortalUtil;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
 
 import javax.portlet.ActionParameters;
+import javax.portlet.PortletContext;
+import javax.portlet.PortletMode;
+import javax.portlet.PortletPreferences;
 import javax.portlet.PortletRequest;
+import javax.portlet.RenderParameters;
+import javax.portlet.WindowState;
+
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * @author Brian Wing Shun Chan
@@ -28,12 +42,66 @@ public class ActionRequestImpl
 
 	@Override
 	public ActionParameters getActionParameters() {
-		throw new UnsupportedOperationException();
+		return _actionParameters;
 	}
 
 	@Override
 	public String getLifecycle() {
 		return PortletRequest.ACTION_PHASE;
 	}
+
+	@Override
+	public void init(
+		HttpServletRequest request, Portlet portlet,
+		InvokerPortlet invokerPortlet, PortletContext portletContext,
+		WindowState windowState, PortletMode portletMode,
+		PortletPreferences preferences, long plid) {
+
+		super.init(
+			request, portlet, invokerPortlet, portletContext, windowState,
+			portletMode, preferences, plid);
+
+		Map<String, String[]> actionParameterMap = new LinkedHashMap<>();
+		Map<String, String[]> parameterMap = getParameterMap();
+		String portletNamespace = PortalUtil.getPortletNamespace(
+			getPortletName());
+		Map<String, String[]> servletRequestParameterMap =
+			request.getParameterMap();
+		RenderParameters renderParameters = getRenderParameters();
+
+		Set<String> renderParameterNames = renderParameters.getNames();
+
+		for (Map.Entry<String, String[]> mapEntry : parameterMap.entrySet()) {
+			String name = mapEntry.getKey();
+
+			// If the parameter name is not a public/private render parameter,
+			// then it is an action parameter. Also, if the parameter name is
+			// prefixed with the portlet namespace in the original request, then
+			// it is to be regarded as an action parameter (even if it has the
+			// same name as a public render parameter). See: TCK
+			// V3PortletParametersTests_SPEC11_3_getNames
+
+			if (!renderParameterNames.contains(name)) {
+				actionParameterMap.put(name, mapEntry.getValue());
+			}
+			else {
+				String namespacedParameter = portletNamespace + name;
+
+				if (renderParameterNames.contains(name) &&
+					servletRequestParameterMap.containsKey(
+						namespacedParameter)) {
+
+					actionParameterMap.put(
+						name,
+						servletRequestParameterMap.get(namespacedParameter));
+				}
+			}
+		}
+
+		_actionParameters = new ActionParametersImpl(
+			actionParameterMap, portletNamespace);
+	}
+
+	private ActionParameters _actionParameters;
 
 }

--- a/portal-impl/src/com/liferay/portlet/internal/ActionRequestImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/ActionRequestImpl.java
@@ -79,7 +79,7 @@ public class ActionRequestImpl
 			// prefixed with the portlet namespace in the original request, then
 			// it is to be regarded as an action parameter (even if it has the
 			// same name as a public render parameter). See: TCK
-			// V3PortletParametersTests_SPEC11_3_getNames
+			// V3PortletParametersTests_SPEC11_3_getNames.
 
 			if (renderParameterNames.contains(name)) {
 				String[] values = servletRequestParameterMap.get(

--- a/portal-impl/src/com/liferay/portlet/internal/ActionRequestImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/ActionRequestImpl.java
@@ -82,14 +82,11 @@ public class ActionRequestImpl
 			// V3PortletParametersTests_SPEC11_3_getNames
 
 			if (renderParameterNames.contains(name)) {
-				String namespacedParameter = portletNamespace + name;
+				String[] values = servletRequestParameterMap.get(
+					portletNamespace.concat(name));
 
-				if (servletRequestParameterMap.containsKey(
-						namespacedParameter)) {
-
-					actionParameterMap.put(
-						name,
-						servletRequestParameterMap.get(namespacedParameter));
+				if (values != null) {
+					actionParameterMap.put(name, values);
 				}
 			}
 			else {

--- a/portal-impl/src/com/liferay/portlet/internal/ActionRequestImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/ActionRequestImpl.java
@@ -84,8 +84,7 @@ public class ActionRequestImpl
 			if (renderParameterNames.contains(name)) {
 				String namespacedParameter = portletNamespace + name;
 
-				if (renderParameterNames.contains(name) &&
-					servletRequestParameterMap.containsKey(
+				if (servletRequestParameterMap.containsKey(
 						namespacedParameter)) {
 
 					actionParameterMap.put(

--- a/portal-impl/src/com/liferay/portlet/internal/ActionRequestImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/ActionRequestImpl.java
@@ -81,10 +81,7 @@ public class ActionRequestImpl
 			// same name as a public render parameter). See: TCK
 			// V3PortletParametersTests_SPEC11_3_getNames
 
-			if (!renderParameterNames.contains(name)) {
-				actionParameterMap.put(name, mapEntry.getValue());
-			}
-			else {
+			if (renderParameterNames.contains(name)) {
 				String namespacedParameter = portletNamespace + name;
 
 				if (renderParameterNames.contains(name) &&
@@ -95,6 +92,9 @@ public class ActionRequestImpl
 						name,
 						servletRequestParameterMap.get(namespacedParameter));
 				}
+			}
+			else {
+				actionParameterMap.put(name, mapEntry.getValue());
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portlet/internal/PortletContainerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/PortletContainerImpl.java
@@ -554,7 +554,7 @@ public class PortletContainerImpl implements PortletContainer {
 			windowState = WindowState.MAXIMIZED;
 		}
 		else if (layoutTypePortlet.hasStateMinPortletId(
-					portlet.getPortletId())) {
+					 portlet.getPortletId())) {
 
 			windowState = WindowState.MINIMIZED;
 		}
@@ -568,37 +568,37 @@ public class PortletContainerImpl implements PortletContainer {
 			portletMode = LiferayPortletMode.ABOUT;
 		}
 		else if (layoutTypePortlet.hasModeConfigPortletId(
-					portlet.getPortletId())) {
+					 portlet.getPortletId())) {
 
 			portletMode = LiferayPortletMode.CONFIG;
 		}
 		else if (layoutTypePortlet.hasModeEditPortletId(
-					portlet.getPortletId())) {
+					 portlet.getPortletId())) {
 
 			portletMode = PortletMode.EDIT;
 		}
 		else if (layoutTypePortlet.hasModeEditDefaultsPortletId(
-					portlet.getPortletId())) {
+					 portlet.getPortletId())) {
 
 			portletMode = LiferayPortletMode.EDIT_DEFAULTS;
 		}
 		else if (layoutTypePortlet.hasModeEditGuestPortletId(
-					portlet.getPortletId())) {
+					 portlet.getPortletId())) {
 
 			portletMode = LiferayPortletMode.EDIT_GUEST;
 		}
 		else if (layoutTypePortlet.hasModeHelpPortletId(
-					portlet.getPortletId())) {
+					 portlet.getPortletId())) {
 
 			portletMode = PortletMode.HELP;
 		}
 		else if (layoutTypePortlet.hasModePreviewPortletId(
-					portlet.getPortletId())) {
+					 portlet.getPortletId())) {
 
 			portletMode = LiferayPortletMode.PREVIEW;
 		}
 		else if (layoutTypePortlet.hasModePrintPortletId(
-					portlet.getPortletId())) {
+					 portlet.getPortletId())) {
 
 			portletMode = LiferayPortletMode.PRINT;
 		}

--- a/portal-impl/src/com/liferay/portlet/internal/PortletContainerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/PortletContainerImpl.java
@@ -345,7 +345,8 @@ public class PortletContainerImpl implements PortletContainer {
 			request, layout, Arrays.asList(portlet),
 			themeDisplay.isLifecycleAction());
 
-		if (themeDisplay.isLifecycleRender() ||
+		if (themeDisplay.isHubAction() || themeDisplay.isHubPartialAction() ||
+			themeDisplay.isLifecycleRender() ||
 			themeDisplay.isLifecycleResource()) {
 
 			WindowState windowState = WindowStateFactory.getWindowState(
@@ -553,7 +554,7 @@ public class PortletContainerImpl implements PortletContainer {
 			windowState = WindowState.MAXIMIZED;
 		}
 		else if (layoutTypePortlet.hasStateMinPortletId(
-					 portlet.getPortletId())) {
+					portlet.getPortletId())) {
 
 			windowState = WindowState.MINIMIZED;
 		}
@@ -567,37 +568,37 @@ public class PortletContainerImpl implements PortletContainer {
 			portletMode = LiferayPortletMode.ABOUT;
 		}
 		else if (layoutTypePortlet.hasModeConfigPortletId(
-					 portlet.getPortletId())) {
+					portlet.getPortletId())) {
 
 			portletMode = LiferayPortletMode.CONFIG;
 		}
 		else if (layoutTypePortlet.hasModeEditPortletId(
-					 portlet.getPortletId())) {
+					portlet.getPortletId())) {
 
 			portletMode = PortletMode.EDIT;
 		}
 		else if (layoutTypePortlet.hasModeEditDefaultsPortletId(
-					 portlet.getPortletId())) {
+					portlet.getPortletId())) {
 
 			portletMode = LiferayPortletMode.EDIT_DEFAULTS;
 		}
 		else if (layoutTypePortlet.hasModeEditGuestPortletId(
-					 portlet.getPortletId())) {
+					portlet.getPortletId())) {
 
 			portletMode = LiferayPortletMode.EDIT_GUEST;
 		}
 		else if (layoutTypePortlet.hasModeHelpPortletId(
-					 portlet.getPortletId())) {
+					portlet.getPortletId())) {
 
 			portletMode = PortletMode.HELP;
 		}
 		else if (layoutTypePortlet.hasModePreviewPortletId(
-					 portlet.getPortletId())) {
+					portlet.getPortletId())) {
 
 			portletMode = LiferayPortletMode.PREVIEW;
 		}
 		else if (layoutTypePortlet.hasModePrintPortletId(
-					 portlet.getPortletId())) {
+					portlet.getPortletId())) {
 
 			portletMode = LiferayPortletMode.PRINT;
 		}

--- a/portal-impl/src/com/liferay/portlet/internal/PortletRequestImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/PortletRequestImpl.java
@@ -809,7 +809,7 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 		_locale = themeDisplay.getLocale();
 		_plid = plid;
 
-		// TODO: Set render parameter values
+		// TODO Set render parameter values
 
 		_renderParameters = new RenderParametersImpl(
 			new HashMap<>(), new HashSet<>(), portletNamespace);

--- a/portal-impl/src/com/liferay/portlet/internal/PortletRequestImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/PortletRequestImpl.java
@@ -484,7 +484,7 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 
 	@Override
 	public RenderParameters getRenderParameters() {
-		throw new UnsupportedOperationException();
+		return _renderParameters;
 	}
 
 	@Override
@@ -808,6 +808,11 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 
 		_locale = themeDisplay.getLocale();
 		_plid = plid;
+
+		// TODO: Set render parameter values
+
+		_renderParameters = new RenderParametersImpl(
+			new HashMap<>(), new HashSet<>(), portletNamespace);
 	}
 
 	@Override
@@ -1107,6 +1112,7 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 	private Profile _profile;
 	private String _remoteUser;
 	private long _remoteUserId;
+	private RenderParameters _renderParameters;
 	private HttpServletRequest _request;
 	private PortletSessionImpl _session;
 	private boolean _strutsPortlet;

--- a/portal-test-integration/src/com/liferay/portal/test/rule/callback/InjectTestBag.java
+++ b/portal-test-integration/src/com/liferay/portal/test/rule/callback/InjectTestBag.java
@@ -210,7 +210,7 @@ public class InjectTestBag {
 					StringBundler.concat(
 						"Stopped waiting for service ", className, " ",
 						filterString, " for field ", testClass.getName(), ".",
-						field.getName(), ", due to interruption."));
+						field.getName(), " due to interruption"));
 
 				break;
 			}

--- a/portal-test-integration/src/com/liferay/portal/test/rule/callback/InjectTestBag.java
+++ b/portal-test-integration/src/com/liferay/portal/test/rule/callback/InjectTestBag.java
@@ -206,6 +206,13 @@ public class InjectTestBag {
 				countDownLatch.await(_SLEEP_TIME, TimeUnit.MILLISECONDS);
 			}
 			catch (InterruptedException ie) {
+				System.out.println(
+					StringBundler.concat(
+						"Stopped waiting for service ", className, " ",
+						filterString, " for field ", testClass.getName(), ".",
+						field.getName(), ", due to interruption."));
+
+				break;
 			}
 
 			serviceReference = _getServiceReference(


### PR DESCRIPTION
@tinatian I removed the null check instead of fetching directly from the map because I saw https://issues.liferay.com/browse/LPS-29031 which introduced the create-if-absent logic to clearCache.