### PR TITLE
LPS-83545 Remove redundant null check in clearCache(Class<?>) method in EntityCacheImpl and FinderCacheImpl

### DIFF
--- a/modules/apps/portal-cache/portal-cache-impl/src/main/java/com/liferay/portal/cache/internal/dao/orm/EntityCacheImpl.java
+++ b/modules/apps/portal-cache/portal-cache-impl/src/main/java/com/liferay/portal/cache/internal/dao/orm/EntityCacheImpl.java
@@ -74,9 +74,7 @@ public class EntityCacheImpl
 
 		PortalCache<?, ?> portalCache = getPortalCache(clazz);
 
-		if (portalCache != null) {
-			portalCache.removeAll();
-		}
+		portalCache.removeAll();
 	}
 
 	@Override

--- a/modules/apps/portal-cache/portal-cache-impl/src/main/java/com/liferay/portal/cache/internal/dao/orm/FinderCacheImpl.java
+++ b/modules/apps/portal-cache/portal-cache-impl/src/main/java/com/liferay/portal/cache/internal/dao/orm/FinderCacheImpl.java
@@ -82,9 +82,7 @@ public class FinderCacheImpl
 
 		PortalCache<?, ?> portalCache = _getPortalCache(className);
 
-		if (portalCache != null) {
-			portalCache.removeAll();
-		}
+		portalCache.removeAll();
 	}
 
 	@Override


### PR DESCRIPTION
@tinatian I removed the null check instead of fetching directly from the map because I saw https://issues.liferay.com/browse/LPS-29031 which introduced the create-if-absent logic to clearCache.

FinderCacheImpl also has this logic so I also removed the null check from it.