### PR TITLE
LPS-82603

### DIFF
--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalService.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalService.java
@@ -2269,10 +2269,18 @@ public interface JournalArticleLocalService extends BaseLocalService,
 	* @param end the upper bound of the range of web content articles to
 	return (not inclusive)
 	* @return the matching web content articles
+	* @deprecated As of Judson (7.1.x), replaced by {@link
+	#search(long groupId, List folderIds, Locale locale,
+	int status, int start, int end)}
 	*/
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<JournalArticle> search(long groupId, List<Long> folderIds,
 		int status, int start, int end);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<JournalArticle> search(long groupId, List<Long> folderIds,
+		Locale locale, int status, int start, int end);
 
 	/**
 	* Returns a range of all the web content articles in a single folder

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceUtil.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceUtil.java
@@ -2623,11 +2623,22 @@ public class JournalArticleLocalServiceUtil {
 	* @param end the upper bound of the range of web content articles to
 	return (not inclusive)
 	* @return the matching web content articles
+	* @deprecated As of Judson (7.1.x), replaced by {@link
+	#search(long groupId, List folderIds, Locale locale,
+	int status, int start, int end)}
 	*/
+	@Deprecated
 	public static java.util.List<com.liferay.journal.model.JournalArticle> search(
 		long groupId, java.util.List<Long> folderIds, int status, int start,
 		int end) {
 		return getService().search(groupId, folderIds, status, start, end);
+	}
+
+	public static java.util.List<com.liferay.journal.model.JournalArticle> search(
+		long groupId, java.util.List<Long> folderIds, java.util.Locale locale,
+		int status, int start, int end) {
+		return getService()
+				   .search(groupId, folderIds, locale, status, start, end);
 	}
 
 	/**

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceWrapper.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceWrapper.java
@@ -2770,13 +2770,25 @@ public class JournalArticleLocalServiceWrapper
 	* @param end the upper bound of the range of web content articles to
 	return (not inclusive)
 	* @return the matching web content articles
+	* @deprecated As of Judson (7.1.x), replaced by {@link
+	#search(long groupId, List folderIds, Locale locale,
+	int status, int start, int end)}
 	*/
+	@Deprecated
 	@Override
 	public java.util.List<com.liferay.journal.model.JournalArticle> search(
 		long groupId, java.util.List<Long> folderIds, int status, int start,
 		int end) {
 		return _journalArticleLocalService.search(groupId, folderIds, status,
 			start, end);
+	}
+
+	@Override
+	public java.util.List<com.liferay.journal.model.JournalArticle> search(
+		long groupId, java.util.List<Long> folderIds, java.util.Locale locale,
+		int status, int start, int end) {
+		return _journalArticleLocalService.search(groupId, folderIds, locale,
+			status, start, end);
 	}
 
 	/**

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleService.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleService.java
@@ -579,7 +579,10 @@ public interface JournalArticleService extends BaseService {
 	* @param groupId the primary key of the web content article's group
 	* @param folderId the primary key of the web content article folder
 	* @return the matching web content articles
+	* @deprecated As of Judson (7.1.x), replaced by {@link
+	#getArticles(long groupId, long folderId, Locale locale)}
 	*/
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<JournalArticle> getArticles(long groupId, long folderId);
 
@@ -605,10 +608,31 @@ public interface JournalArticleService extends BaseService {
 	return (not inclusive)
 	* @param obc the comparator to order the web content articles
 	* @return the matching web content articles
+	* @deprecated As of Judson (7.1.x), replaced by {@link
+	#getArticles(long groupId, long folderId, Locale locale,
+	int start, int end, OrderByComparator obc)}
 	*/
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<JournalArticle> getArticles(long groupId, long folderId,
 		int start, int end, OrderByComparator<JournalArticle> obc);
+
+	/**
+	* Returns all the web content articles matching the group, folder and
+	* locale.
+	*
+	* @param groupId the primary key of the web content article's group
+	* @param folderId the primary key of the web content article folder
+	* @param locale current locale
+	* @return the matching web content articles
+	*/
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<JournalArticle> getArticles(long groupId, long folderId,
+		Locale locale);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<JournalArticle> getArticles(long groupId, long folderId,
+		Locale locale, int start, int end, OrderByComparator<JournalArticle> obc);
 
 	/**
 	* Returns an ordered range of all the web content articles matching the

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleService.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleService.java
@@ -617,15 +617,6 @@ public interface JournalArticleService extends BaseService {
 	public List<JournalArticle> getArticles(long groupId, long folderId,
 		int start, int end, OrderByComparator<JournalArticle> obc);
 
-	/**
-	* Returns all the web content articles matching the group, folder and
-	* locale.
-	*
-	* @param groupId the primary key of the web content article's group
-	* @param folderId the primary key of the web content article folder
-	* @param locale current locale
-	* @return the matching web content articles
-	*/
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<JournalArticle> getArticles(long groupId, long folderId,
 		Locale locale);

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleServiceUtil.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleServiceUtil.java
@@ -652,7 +652,10 @@ public class JournalArticleServiceUtil {
 	* @param groupId the primary key of the web content article's group
 	* @param folderId the primary key of the web content article folder
 	* @return the matching web content articles
+	* @deprecated As of Judson (7.1.x), replaced by {@link
+	#getArticles(long groupId, long folderId, Locale locale)}
 	*/
+	@Deprecated
 	public static java.util.List<com.liferay.journal.model.JournalArticle> getArticles(
 		long groupId, long folderId) {
 		return getService().getArticles(groupId, folderId);
@@ -680,11 +683,37 @@ public class JournalArticleServiceUtil {
 	return (not inclusive)
 	* @param obc the comparator to order the web content articles
 	* @return the matching web content articles
+	* @deprecated As of Judson (7.1.x), replaced by {@link
+	#getArticles(long groupId, long folderId, Locale locale,
+	int start, int end, OrderByComparator obc)}
 	*/
+	@Deprecated
 	public static java.util.List<com.liferay.journal.model.JournalArticle> getArticles(
 		long groupId, long folderId, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.journal.model.JournalArticle> obc) {
 		return getService().getArticles(groupId, folderId, start, end, obc);
+	}
+
+	/**
+	* Returns all the web content articles matching the group, folder and
+	* locale.
+	*
+	* @param groupId the primary key of the web content article's group
+	* @param folderId the primary key of the web content article folder
+	* @param locale current locale
+	* @return the matching web content articles
+	*/
+	public static java.util.List<com.liferay.journal.model.JournalArticle> getArticles(
+		long groupId, long folderId, java.util.Locale locale) {
+		return getService().getArticles(groupId, folderId, locale);
+	}
+
+	public static java.util.List<com.liferay.journal.model.JournalArticle> getArticles(
+		long groupId, long folderId, java.util.Locale locale, int start,
+		int end,
+		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.journal.model.JournalArticle> obc) {
+		return getService()
+				   .getArticles(groupId, folderId, locale, start, end, obc);
 	}
 
 	/**

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleServiceUtil.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleServiceUtil.java
@@ -694,15 +694,6 @@ public class JournalArticleServiceUtil {
 		return getService().getArticles(groupId, folderId, start, end, obc);
 	}
 
-	/**
-	* Returns all the web content articles matching the group, folder and
-	* locale.
-	*
-	* @param groupId the primary key of the web content article's group
-	* @param folderId the primary key of the web content article folder
-	* @param locale current locale
-	* @return the matching web content articles
-	*/
 	public static java.util.List<com.liferay.journal.model.JournalArticle> getArticles(
 		long groupId, long folderId, java.util.Locale locale) {
 		return getService().getArticles(groupId, folderId, locale);

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleServiceWrapper.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleServiceWrapper.java
@@ -650,7 +650,10 @@ public class JournalArticleServiceWrapper implements JournalArticleService,
 	* @param groupId the primary key of the web content article's group
 	* @param folderId the primary key of the web content article folder
 	* @return the matching web content articles
+	* @deprecated As of Judson (7.1.x), replaced by {@link
+	#getArticles(long groupId, long folderId, Locale locale)}
 	*/
+	@Deprecated
 	@Override
 	public java.util.List<com.liferay.journal.model.JournalArticle> getArticles(
 		long groupId, long folderId) {
@@ -679,13 +682,41 @@ public class JournalArticleServiceWrapper implements JournalArticleService,
 	return (not inclusive)
 	* @param obc the comparator to order the web content articles
 	* @return the matching web content articles
+	* @deprecated As of Judson (7.1.x), replaced by {@link
+	#getArticles(long groupId, long folderId, Locale locale,
+	int start, int end, OrderByComparator obc)}
 	*/
+	@Deprecated
 	@Override
 	public java.util.List<com.liferay.journal.model.JournalArticle> getArticles(
 		long groupId, long folderId, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.journal.model.JournalArticle> obc) {
 		return _journalArticleService.getArticles(groupId, folderId, start,
 			end, obc);
+	}
+
+	/**
+	* Returns all the web content articles matching the group, folder and
+	* locale.
+	*
+	* @param groupId the primary key of the web content article's group
+	* @param folderId the primary key of the web content article folder
+	* @param locale current locale
+	* @return the matching web content articles
+	*/
+	@Override
+	public java.util.List<com.liferay.journal.model.JournalArticle> getArticles(
+		long groupId, long folderId, java.util.Locale locale) {
+		return _journalArticleService.getArticles(groupId, folderId, locale);
+	}
+
+	@Override
+	public java.util.List<com.liferay.journal.model.JournalArticle> getArticles(
+		long groupId, long folderId, java.util.Locale locale, int start,
+		int end,
+		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.journal.model.JournalArticle> obc) {
+		return _journalArticleService.getArticles(groupId, folderId, locale,
+			start, end, obc);
 	}
 
 	/**

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleServiceWrapper.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleServiceWrapper.java
@@ -695,15 +695,6 @@ public class JournalArticleServiceWrapper implements JournalArticleService,
 			end, obc);
 	}
 
-	/**
-	* Returns all the web content articles matching the group, folder and
-	* locale.
-	*
-	* @param groupId the primary key of the web content article's group
-	* @param folderId the primary key of the web content article folder
-	* @param locale current locale
-	* @return the matching web content articles
-	*/
 	@Override
 	public java.util.List<com.liferay.journal.model.JournalArticle> getArticles(
 		long groupId, long folderId, java.util.Locale locale) {

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalArticleFinder.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalArticleFinder.java
@@ -117,6 +117,10 @@ public interface JournalArticleFinder {
 		long groupId, java.util.List<Long> folderIds,
 		com.liferay.portal.kernel.dao.orm.QueryDefinition<com.liferay.journal.model.JournalArticle> queryDefinition);
 
+	public java.util.List<com.liferay.journal.model.JournalArticle> filterFindByG_F_L(
+		long groupId, java.util.List<Long> folderIds, java.util.Locale locale,
+		com.liferay.portal.kernel.dao.orm.QueryDefinition<com.liferay.journal.model.JournalArticle> queryDefinition);
+
 	public java.util.List<com.liferay.journal.model.JournalArticle> filterFindByG_C_S(
 		long groupId, long classNameId, String ddmStructureKey,
 		com.liferay.portal.kernel.dao.orm.QueryDefinition<com.liferay.journal.model.JournalArticle> queryDefinition);
@@ -182,6 +186,10 @@ public interface JournalArticleFinder {
 
 	public java.util.List<com.liferay.journal.model.JournalArticle> findByG_F(
 		long groupId, java.util.List<Long> folderIds,
+		com.liferay.portal.kernel.dao.orm.QueryDefinition<com.liferay.journal.model.JournalArticle> queryDefinition);
+
+	public java.util.List<com.liferay.journal.model.JournalArticle> findByG_F_L(
+		long groupId, java.util.List<Long> folderIds, java.util.Locale locale,
 		com.liferay.portal.kernel.dao.orm.QueryDefinition<com.liferay.journal.model.JournalArticle> queryDefinition);
 
 	public java.util.List<com.liferay.journal.model.JournalArticle> findByG_C_S(

--- a/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/service/packageinfo
+++ b/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/service/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/service/persistence/packageinfo
+++ b/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/http/JournalArticleServiceHttp.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/http/JournalArticleServiceHttp.java
@@ -759,6 +759,63 @@ public class JournalArticleServiceHttp {
 		}
 	}
 
+	public static java.util.List<com.liferay.journal.model.JournalArticle> getArticles(
+		HttpPrincipal httpPrincipal, long groupId, long folderId,
+		java.util.Locale locale) {
+		try {
+			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
+					"getArticles", _getArticlesParameterTypes20);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
+					folderId, locale);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (java.util.List<com.liferay.journal.model.JournalArticle>)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static java.util.List<com.liferay.journal.model.JournalArticle> getArticles(
+		HttpPrincipal httpPrincipal, long groupId, long folderId,
+		java.util.Locale locale, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.journal.model.JournalArticle> obc) {
+		try {
+			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
+					"getArticles", _getArticlesParameterTypes21);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
+					folderId, locale, start, end, obc);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (java.util.List<com.liferay.journal.model.JournalArticle>)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
 	public static java.util.List<com.liferay.journal.model.JournalArticle> getArticlesByArticleId(
 		HttpPrincipal httpPrincipal, long groupId, String articleId, int start,
 		int end,
@@ -766,7 +823,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
 					"getArticlesByArticleId",
-					_getArticlesByArticleIdParameterTypes20);
+					_getArticlesByArticleIdParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					articleId, start, end, obc);
@@ -794,7 +851,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
 					"getArticlesByLayoutUuid",
-					_getArticlesByLayoutUuidParameterTypes21);
+					_getArticlesByLayoutUuidParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					layoutUuid);
@@ -824,7 +881,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
 					"getArticlesByStructureId",
-					_getArticlesByStructureIdParameterTypes22);
+					_getArticlesByStructureIdParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					classNameId, ddmStructureKey, status, start, end, obc);
@@ -854,7 +911,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
 					"getArticlesByStructureId",
-					_getArticlesByStructureIdParameterTypes23);
+					_getArticlesByStructureIdParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					ddmStructureKey, status, start, end, obc);
@@ -884,7 +941,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
 					"getArticlesByStructureId",
-					_getArticlesByStructureIdParameterTypes24);
+					_getArticlesByStructureIdParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					ddmStructureKey, start, end, obc);
@@ -911,7 +968,7 @@ public class JournalArticleServiceHttp {
 		long groupId, long folderId) {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"getArticlesCount", _getArticlesCountParameterTypes25);
+					"getArticlesCount", _getArticlesCountParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					folderId);
@@ -938,7 +995,7 @@ public class JournalArticleServiceHttp {
 		long groupId, long folderId, int status) {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"getArticlesCount", _getArticlesCountParameterTypes26);
+					"getArticlesCount", _getArticlesCountParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					folderId, status);
@@ -966,7 +1023,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
 					"getArticlesCountByArticleId",
-					_getArticlesCountByArticleIdParameterTypes27);
+					_getArticlesCountByArticleIdParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					articleId);
@@ -995,7 +1052,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
 					"getArticlesCountByStructureId",
-					_getArticlesCountByStructureIdParameterTypes28);
+					_getArticlesCountByStructureIdParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					classNameId, ddmStructureKey, status);
@@ -1023,7 +1080,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
 					"getArticlesCountByStructureId",
-					_getArticlesCountByStructureIdParameterTypes29);
+					_getArticlesCountByStructureIdParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					ddmStructureKey);
@@ -1052,7 +1109,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
 					"getArticlesCountByStructureId",
-					_getArticlesCountByStructureIdParameterTypes30);
+					_getArticlesCountByStructureIdParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					ddmStructureKey, status);
@@ -1081,7 +1138,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
 					"getDisplayArticleByUrlTitle",
-					_getDisplayArticleByUrlTitleParameterTypes31);
+					_getDisplayArticleByUrlTitleParameterTypes33);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					urlTitle);
@@ -1113,7 +1170,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
 					"getFoldersAndArticlesCount",
-					_getFoldersAndArticlesCountParameterTypes32);
+					_getFoldersAndArticlesCountParameterTypes34);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					folderIds);
@@ -1144,7 +1201,7 @@ public class JournalArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"getGroupArticles", _getGroupArticlesParameterTypes33);
+					"getGroupArticles", _getGroupArticlesParameterTypes35);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					userId, rootFolderId, status, includeOwner, start, end,
@@ -1179,7 +1236,7 @@ public class JournalArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"getGroupArticles", _getGroupArticlesParameterTypes34);
+					"getGroupArticles", _getGroupArticlesParameterTypes36);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					userId, rootFolderId, status, start, end, orderByComparator);
@@ -1213,7 +1270,7 @@ public class JournalArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"getGroupArticles", _getGroupArticlesParameterTypes35);
+					"getGroupArticles", _getGroupArticlesParameterTypes37);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					userId, rootFolderId, start, end, orderByComparator);
@@ -1246,7 +1303,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
 					"getGroupArticlesCount",
-					_getGroupArticlesCountParameterTypes36);
+					_getGroupArticlesCountParameterTypes38);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					userId, rootFolderId);
@@ -1279,7 +1336,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
 					"getGroupArticlesCount",
-					_getGroupArticlesCountParameterTypes37);
+					_getGroupArticlesCountParameterTypes39);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					userId, rootFolderId, status);
@@ -1313,7 +1370,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
 					"getGroupArticlesCount",
-					_getGroupArticlesCountParameterTypes38);
+					_getGroupArticlesCountParameterTypes40);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					userId, rootFolderId, status, includeOwner);
@@ -1345,7 +1402,7 @@ public class JournalArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"getLatestArticle", _getLatestArticleParameterTypes39);
+					"getLatestArticle", _getLatestArticleParameterTypes41);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					resourcePrimKey);
@@ -1377,7 +1434,7 @@ public class JournalArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"getLatestArticle", _getLatestArticleParameterTypes40);
+					"getLatestArticle", _getLatestArticleParameterTypes42);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					articleId, status);
@@ -1410,7 +1467,7 @@ public class JournalArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"getLatestArticle", _getLatestArticleParameterTypes41);
+					"getLatestArticle", _getLatestArticleParameterTypes43);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					className, classPK);
@@ -1441,7 +1498,7 @@ public class JournalArticleServiceHttp {
 		HttpPrincipal httpPrincipal, long groupId) {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"getLayoutArticles", _getLayoutArticlesParameterTypes42);
+					"getLayoutArticles", _getLayoutArticlesParameterTypes44);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -1468,7 +1525,7 @@ public class JournalArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"moveArticle", _moveArticleParameterTypes43);
+					"moveArticle", _moveArticleParameterTypes45);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					articleId, newFolderId);
@@ -1497,7 +1554,7 @@ public class JournalArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"moveArticle", _moveArticleParameterTypes44);
+					"moveArticle", _moveArticleParameterTypes46);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					articleId, newFolderId, serviceContext);
@@ -1528,7 +1585,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
 					"moveArticleFromTrash",
-					_moveArticleFromTrashParameterTypes45);
+					_moveArticleFromTrashParameterTypes47);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					resourcePrimKey, newFolderId, serviceContext);
@@ -1563,7 +1620,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
 					"moveArticleFromTrash",
-					_moveArticleFromTrashParameterTypes46);
+					_moveArticleFromTrashParameterTypes48);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					articleId, newFolderId, serviceContext);
@@ -1595,7 +1652,7 @@ public class JournalArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"moveArticleToTrash", _moveArticleToTrashParameterTypes47);
+					"moveArticleToTrash", _moveArticleToTrashParameterTypes49);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					articleId);
@@ -1627,7 +1684,7 @@ public class JournalArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"removeArticleLocale", _removeArticleLocaleParameterTypes48);
+					"removeArticleLocale", _removeArticleLocaleParameterTypes50);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, languageId);
@@ -1656,7 +1713,7 @@ public class JournalArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"removeArticleLocale", _removeArticleLocaleParameterTypes49);
+					"removeArticleLocale", _removeArticleLocaleParameterTypes51);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					articleId, version, languageId);
@@ -1689,7 +1746,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
 					"restoreArticleFromTrash",
-					_restoreArticleFromTrashParameterTypes50);
+					_restoreArticleFromTrashParameterTypes52);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					resourcePrimKey);
@@ -1718,7 +1775,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
 					"restoreArticleFromTrash",
-					_restoreArticleFromTrashParameterTypes51);
+					_restoreArticleFromTrashParameterTypes53);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					articleId);
@@ -1747,7 +1804,7 @@ public class JournalArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"search", _searchParameterTypes52);
+					"search", _searchParameterTypes54);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					creatorUserId, status, start, end);
@@ -1783,7 +1840,7 @@ public class JournalArticleServiceHttp {
 		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.journal.model.JournalArticle> obc) {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"search", _searchParameterTypes53);
+					"search", _searchParameterTypes55);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, groupId, folderIds, classNameId, keywords,
@@ -1818,7 +1875,7 @@ public class JournalArticleServiceHttp {
 		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.journal.model.JournalArticle> obc) {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"search", _searchParameterTypes54);
+					"search", _searchParameterTypes56);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, groupId, folderIds, classNameId, articleId,
@@ -1854,7 +1911,7 @@ public class JournalArticleServiceHttp {
 		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.journal.model.JournalArticle> obc) {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"search", _searchParameterTypes55);
+					"search", _searchParameterTypes57);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, groupId, folderIds, classNameId, articleId,
@@ -1887,7 +1944,7 @@ public class JournalArticleServiceHttp {
 		java.util.Date displayDateLT, int status, java.util.Date reviewDate) {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"searchCount", _searchCountParameterTypes56);
+					"searchCount", _searchCountParameterTypes58);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, groupId, folderIds, classNameId, keywords,
@@ -1920,7 +1977,7 @@ public class JournalArticleServiceHttp {
 		java.util.Date reviewDate, boolean andOperator) {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"searchCount", _searchCountParameterTypes57);
+					"searchCount", _searchCountParameterTypes59);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, groupId, folderIds, classNameId, articleId,
@@ -1954,7 +2011,7 @@ public class JournalArticleServiceHttp {
 		java.util.Date reviewDate, boolean andOperator) {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"searchCount", _searchCountParameterTypes58);
+					"searchCount", _searchCountParameterTypes60);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, groupId, folderIds, classNameId, articleId,
@@ -1985,7 +2042,7 @@ public class JournalArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"subscribe", _subscribeParameterTypes59);
+					"subscribe", _subscribeParameterTypes61);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					articleId);
@@ -2013,7 +2070,7 @@ public class JournalArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"subscribeStructure", _subscribeStructureParameterTypes60);
+					"subscribeStructure", _subscribeStructureParameterTypes62);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					userId, ddmStructureId);
@@ -2041,7 +2098,7 @@ public class JournalArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"unsubscribe", _unsubscribeParameterTypes61);
+					"unsubscribe", _unsubscribeParameterTypes63);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					articleId);
@@ -2070,7 +2127,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
 					"unsubscribeStructure",
-					_unsubscribeStructureParameterTypes62);
+					_unsubscribeStructureParameterTypes64);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					userId, ddmStructureId);
@@ -2103,7 +2160,7 @@ public class JournalArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"updateArticle", _updateArticleParameterTypes63);
+					"updateArticle", _updateArticleParameterTypes65);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, userId,
 					groupId, folderId, articleId, version, titleMap,
@@ -2150,7 +2207,7 @@ public class JournalArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"updateArticle", _updateArticleParameterTypes64);
+					"updateArticle", _updateArticleParameterTypes66);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					folderId, articleId, version, titleMap, descriptionMap,
@@ -2204,7 +2261,7 @@ public class JournalArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"updateArticle", _updateArticleParameterTypes65);
+					"updateArticle", _updateArticleParameterTypes67);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					folderId, articleId, version, titleMap, descriptionMap,
@@ -2246,7 +2303,7 @@ public class JournalArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"updateArticle", _updateArticleParameterTypes66);
+					"updateArticle", _updateArticleParameterTypes68);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					folderId, articleId, version, content, serviceContext);
@@ -2283,7 +2340,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
 					"updateArticleTranslation",
-					_updateArticleTranslationParameterTypes67);
+					_updateArticleTranslationParameterTypes69);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					articleId, version, locale, title, description, content,
@@ -2317,7 +2374,7 @@ public class JournalArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"updateContent", _updateContentParameterTypes68);
+					"updateContent", _updateContentParameterTypes70);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					articleId, version, content);
@@ -2351,7 +2408,7 @@ public class JournalArticleServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(JournalArticleServiceUtil.class,
-					"updateStatus", _updateStatusParameterTypes69);
+					"updateStatus", _updateStatusParameterTypes71);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					articleId, version, status, articleURL, serviceContext);
@@ -2471,119 +2528,126 @@ public class JournalArticleServiceHttp {
 			long.class, long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getArticlesByArticleIdParameterTypes20 = new Class[] {
+	private static final Class<?>[] _getArticlesParameterTypes20 = new Class[] {
+			long.class, long.class, java.util.Locale.class
+		};
+	private static final Class<?>[] _getArticlesParameterTypes21 = new Class[] {
+			long.class, long.class, java.util.Locale.class, int.class, int.class,
+			com.liferay.portal.kernel.util.OrderByComparator.class
+		};
+	private static final Class<?>[] _getArticlesByArticleIdParameterTypes22 = new Class[] {
 			long.class, String.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getArticlesByLayoutUuidParameterTypes21 = new Class[] {
+	private static final Class<?>[] _getArticlesByLayoutUuidParameterTypes23 = new Class[] {
 			long.class, String.class
 		};
-	private static final Class<?>[] _getArticlesByStructureIdParameterTypes22 = new Class[] {
+	private static final Class<?>[] _getArticlesByStructureIdParameterTypes24 = new Class[] {
 			long.class, long.class, String.class, int.class, int.class,
 			int.class, com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getArticlesByStructureIdParameterTypes23 = new Class[] {
+	private static final Class<?>[] _getArticlesByStructureIdParameterTypes25 = new Class[] {
 			long.class, String.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getArticlesByStructureIdParameterTypes24 = new Class[] {
+	private static final Class<?>[] _getArticlesByStructureIdParameterTypes26 = new Class[] {
 			long.class, String.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getArticlesCountParameterTypes25 = new Class[] {
+	private static final Class<?>[] _getArticlesCountParameterTypes27 = new Class[] {
 			long.class, long.class
 		};
-	private static final Class<?>[] _getArticlesCountParameterTypes26 = new Class[] {
+	private static final Class<?>[] _getArticlesCountParameterTypes28 = new Class[] {
 			long.class, long.class, int.class
 		};
-	private static final Class<?>[] _getArticlesCountByArticleIdParameterTypes27 =
-		new Class[] { long.class, String.class };
-	private static final Class<?>[] _getArticlesCountByStructureIdParameterTypes28 =
-		new Class[] { long.class, long.class, String.class, int.class };
-	private static final Class<?>[] _getArticlesCountByStructureIdParameterTypes29 =
+	private static final Class<?>[] _getArticlesCountByArticleIdParameterTypes29 =
 		new Class[] { long.class, String.class };
 	private static final Class<?>[] _getArticlesCountByStructureIdParameterTypes30 =
-		new Class[] { long.class, String.class, int.class };
-	private static final Class<?>[] _getDisplayArticleByUrlTitleParameterTypes31 =
+		new Class[] { long.class, long.class, String.class, int.class };
+	private static final Class<?>[] _getArticlesCountByStructureIdParameterTypes31 =
 		new Class[] { long.class, String.class };
-	private static final Class<?>[] _getFoldersAndArticlesCountParameterTypes32 = new Class[] {
+	private static final Class<?>[] _getArticlesCountByStructureIdParameterTypes32 =
+		new Class[] { long.class, String.class, int.class };
+	private static final Class<?>[] _getDisplayArticleByUrlTitleParameterTypes33 =
+		new Class[] { long.class, String.class };
+	private static final Class<?>[] _getFoldersAndArticlesCountParameterTypes34 = new Class[] {
 			long.class, java.util.List.class
 		};
-	private static final Class<?>[] _getGroupArticlesParameterTypes33 = new Class[] {
+	private static final Class<?>[] _getGroupArticlesParameterTypes35 = new Class[] {
 			long.class, long.class, long.class, int.class, boolean.class,
 			int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupArticlesParameterTypes34 = new Class[] {
+	private static final Class<?>[] _getGroupArticlesParameterTypes36 = new Class[] {
 			long.class, long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupArticlesParameterTypes35 = new Class[] {
+	private static final Class<?>[] _getGroupArticlesParameterTypes37 = new Class[] {
 			long.class, long.class, long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupArticlesCountParameterTypes36 = new Class[] {
+	private static final Class<?>[] _getGroupArticlesCountParameterTypes38 = new Class[] {
 			long.class, long.class, long.class
 		};
-	private static final Class<?>[] _getGroupArticlesCountParameterTypes37 = new Class[] {
+	private static final Class<?>[] _getGroupArticlesCountParameterTypes39 = new Class[] {
 			long.class, long.class, long.class, int.class
 		};
-	private static final Class<?>[] _getGroupArticlesCountParameterTypes38 = new Class[] {
+	private static final Class<?>[] _getGroupArticlesCountParameterTypes40 = new Class[] {
 			long.class, long.class, long.class, int.class, boolean.class
 		};
-	private static final Class<?>[] _getLatestArticleParameterTypes39 = new Class[] {
+	private static final Class<?>[] _getLatestArticleParameterTypes41 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _getLatestArticleParameterTypes40 = new Class[] {
+	private static final Class<?>[] _getLatestArticleParameterTypes42 = new Class[] {
 			long.class, String.class, int.class
 		};
-	private static final Class<?>[] _getLatestArticleParameterTypes41 = new Class[] {
+	private static final Class<?>[] _getLatestArticleParameterTypes43 = new Class[] {
 			long.class, String.class, long.class
 		};
-	private static final Class<?>[] _getLayoutArticlesParameterTypes42 = new Class[] {
+	private static final Class<?>[] _getLayoutArticlesParameterTypes44 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _moveArticleParameterTypes43 = new Class[] {
+	private static final Class<?>[] _moveArticleParameterTypes45 = new Class[] {
 			long.class, String.class, long.class
 		};
-	private static final Class<?>[] _moveArticleParameterTypes44 = new Class[] {
+	private static final Class<?>[] _moveArticleParameterTypes46 = new Class[] {
 			long.class, String.class, long.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _moveArticleFromTrashParameterTypes45 = new Class[] {
+	private static final Class<?>[] _moveArticleFromTrashParameterTypes47 = new Class[] {
 			long.class, long.class, long.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _moveArticleFromTrashParameterTypes46 = new Class[] {
+	private static final Class<?>[] _moveArticleFromTrashParameterTypes48 = new Class[] {
 			long.class, String.class, long.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _moveArticleToTrashParameterTypes47 = new Class[] {
+	private static final Class<?>[] _moveArticleToTrashParameterTypes49 = new Class[] {
 			long.class, String.class
 		};
-	private static final Class<?>[] _removeArticleLocaleParameterTypes48 = new Class[] {
+	private static final Class<?>[] _removeArticleLocaleParameterTypes50 = new Class[] {
 			long.class, String.class
 		};
-	private static final Class<?>[] _removeArticleLocaleParameterTypes49 = new Class[] {
+	private static final Class<?>[] _removeArticleLocaleParameterTypes51 = new Class[] {
 			long.class, String.class, double.class, String.class
 		};
-	private static final Class<?>[] _restoreArticleFromTrashParameterTypes50 = new Class[] {
+	private static final Class<?>[] _restoreArticleFromTrashParameterTypes52 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _restoreArticleFromTrashParameterTypes51 = new Class[] {
+	private static final Class<?>[] _restoreArticleFromTrashParameterTypes53 = new Class[] {
 			long.class, String.class
 		};
-	private static final Class<?>[] _searchParameterTypes52 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes54 = new Class[] {
 			long.class, long.class, int.class, int.class, int.class
 		};
-	private static final Class<?>[] _searchParameterTypes53 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes55 = new Class[] {
 			long.class, long.class, java.util.List.class, long.class,
 			String.class, Double.class, String.class, String.class,
 			java.util.Date.class, java.util.Date.class, int.class,
 			java.util.Date.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _searchParameterTypes54 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes56 = new Class[] {
 			long.class, long.class, java.util.List.class, long.class,
 			String.class, Double.class, String.class, String.class, String.class,
 			String.class, String.class, java.util.Date.class,
@@ -2591,7 +2655,7 @@ public class JournalArticleServiceHttp {
 			int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _searchParameterTypes55 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes57 = new Class[] {
 			long.class, long.class, java.util.List.class, long.class,
 			String.class, Double.class, String.class, String.class, String.class,
 			String[].class, String[].class, java.util.Date.class,
@@ -2599,42 +2663,42 @@ public class JournalArticleServiceHttp {
 			int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _searchCountParameterTypes56 = new Class[] {
+	private static final Class<?>[] _searchCountParameterTypes58 = new Class[] {
 			long.class, long.class, java.util.List.class, long.class,
 			String.class, Double.class, String.class, String.class,
 			java.util.Date.class, java.util.Date.class, int.class,
 			java.util.Date.class
 		};
-	private static final Class<?>[] _searchCountParameterTypes57 = new Class[] {
+	private static final Class<?>[] _searchCountParameterTypes59 = new Class[] {
 			long.class, long.class, java.util.List.class, long.class,
 			String.class, Double.class, String.class, String.class, String.class,
 			String.class, String.class, java.util.Date.class,
 			java.util.Date.class, int.class, java.util.Date.class, boolean.class
 		};
-	private static final Class<?>[] _searchCountParameterTypes58 = new Class[] {
+	private static final Class<?>[] _searchCountParameterTypes60 = new Class[] {
 			long.class, long.class, java.util.List.class, long.class,
 			String.class, Double.class, String.class, String.class, String.class,
 			String[].class, String[].class, java.util.Date.class,
 			java.util.Date.class, int.class, java.util.Date.class, boolean.class
 		};
-	private static final Class<?>[] _subscribeParameterTypes59 = new Class[] {
+	private static final Class<?>[] _subscribeParameterTypes61 = new Class[] {
 			long.class, long.class
 		};
-	private static final Class<?>[] _subscribeStructureParameterTypes60 = new Class[] {
+	private static final Class<?>[] _subscribeStructureParameterTypes62 = new Class[] {
 			long.class, long.class, long.class
 		};
-	private static final Class<?>[] _unsubscribeParameterTypes61 = new Class[] {
+	private static final Class<?>[] _unsubscribeParameterTypes63 = new Class[] {
 			long.class, long.class
 		};
-	private static final Class<?>[] _unsubscribeStructureParameterTypes62 = new Class[] {
+	private static final Class<?>[] _unsubscribeStructureParameterTypes64 = new Class[] {
 			long.class, long.class, long.class
 		};
-	private static final Class<?>[] _updateArticleParameterTypes63 = new Class[] {
+	private static final Class<?>[] _updateArticleParameterTypes65 = new Class[] {
 			long.class, long.class, long.class, String.class, double.class,
 			java.util.Map.class, java.util.Map.class, String.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateArticleParameterTypes64 = new Class[] {
+	private static final Class<?>[] _updateArticleParameterTypes66 = new Class[] {
 			long.class, long.class, String.class, double.class,
 			java.util.Map.class, java.util.Map.class, java.util.Map.class,
 			String.class, String.class, String.class, String.class, int.class,
@@ -2644,7 +2708,7 @@ public class JournalArticleServiceHttp {
 			boolean.class, String.class, java.io.File.class, java.util.Map.class,
 			String.class, com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateArticleParameterTypes65 = new Class[] {
+	private static final Class<?>[] _updateArticleParameterTypes67 = new Class[] {
 			long.class, long.class, String.class, double.class,
 			java.util.Map.class, java.util.Map.class, String.class, String.class,
 			String.class, String.class, int.class, int.class, int.class,
@@ -2654,19 +2718,19 @@ public class JournalArticleServiceHttp {
 			java.io.File.class, java.util.Map.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateArticleParameterTypes66 = new Class[] {
+	private static final Class<?>[] _updateArticleParameterTypes68 = new Class[] {
 			long.class, long.class, String.class, double.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateArticleTranslationParameterTypes67 = new Class[] {
+	private static final Class<?>[] _updateArticleTranslationParameterTypes69 = new Class[] {
 			long.class, String.class, double.class, java.util.Locale.class,
 			String.class, String.class, String.class, java.util.Map.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateContentParameterTypes68 = new Class[] {
+	private static final Class<?>[] _updateContentParameterTypes70 = new Class[] {
 			long.class, String.class, double.class, String.class
 		};
-	private static final Class<?>[] _updateStatusParameterTypes69 = new Class[] {
+	private static final Class<?>[] _updateStatusParameterTypes71 = new Class[] {
 			long.class, String.class, double.class, int.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/http/JournalArticleServiceSoap.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/http/JournalArticleServiceSoap.java
@@ -544,15 +544,6 @@ public class JournalArticleServiceSoap {
 		}
 	}
 
-	/**
-	* Returns all the web content articles matching the group, folder and
-	* locale.
-	*
-	* @param groupId the primary key of the web content article's group
-	* @param folderId the primary key of the web content article folder
-	* @param locale current locale
-	* @return the matching web content articles
-	*/
 	public static com.liferay.journal.model.JournalArticleSoap[] getArticles(
 		long groupId, long folderId, String locale) throws RemoteException {
 		try {

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/http/JournalArticleServiceSoap.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/http/JournalArticleServiceSoap.java
@@ -21,6 +21,7 @@ import com.liferay.journal.service.JournalArticleServiceUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 
 import java.rmi.RemoteException;
@@ -479,7 +480,10 @@ public class JournalArticleServiceSoap {
 	* @param groupId the primary key of the web content article's group
 	* @param folderId the primary key of the web content article folder
 	* @return the matching web content articles
+	* @deprecated As of Judson (7.1.x), replaced by {@link
+	#getArticles(long groupId, long folderId, Locale locale)}
 	*/
+	@Deprecated
 	public static com.liferay.journal.model.JournalArticleSoap[] getArticles(
 		long groupId, long folderId) throws RemoteException {
 		try {
@@ -517,7 +521,11 @@ public class JournalArticleServiceSoap {
 	return (not inclusive)
 	* @param obc the comparator to order the web content articles
 	* @return the matching web content articles
+	* @deprecated As of Judson (7.1.x), replaced by {@link
+	#getArticles(long groupId, long folderId, Locale locale,
+	int start, int end, OrderByComparator obc)}
 	*/
+	@Deprecated
 	public static com.liferay.journal.model.JournalArticleSoap[] getArticles(
 		long groupId, long folderId, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.journal.model.JournalArticle> obc)
@@ -526,6 +534,49 @@ public class JournalArticleServiceSoap {
 			java.util.List<com.liferay.journal.model.JournalArticle> returnValue =
 				JournalArticleServiceUtil.getArticles(groupId, folderId, start,
 					end, obc);
+
+			return com.liferay.journal.model.JournalArticleSoap.toSoapModels(returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
+	/**
+	* Returns all the web content articles matching the group, folder and
+	* locale.
+	*
+	* @param groupId the primary key of the web content article's group
+	* @param folderId the primary key of the web content article folder
+	* @param locale current locale
+	* @return the matching web content articles
+	*/
+	public static com.liferay.journal.model.JournalArticleSoap[] getArticles(
+		long groupId, long folderId, String locale) throws RemoteException {
+		try {
+			java.util.List<com.liferay.journal.model.JournalArticle> returnValue =
+				JournalArticleServiceUtil.getArticles(groupId, folderId,
+					LocaleUtil.fromLanguageId(locale));
+
+			return com.liferay.journal.model.JournalArticleSoap.toSoapModels(returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
+	public static com.liferay.journal.model.JournalArticleSoap[] getArticles(
+		long groupId, long folderId, String locale, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.journal.model.JournalArticle> obc)
+		throws RemoteException {
+		try {
+			java.util.List<com.liferay.journal.model.JournalArticle> returnValue =
+				JournalArticleServiceUtil.getArticles(groupId, folderId,
+					LocaleUtil.fromLanguageId(locale), start, end, obc);
 
 			return com.liferay.journal.model.JournalArticleSoap.toSoapModels(returnValue);
 		}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -4238,8 +4238,10 @@ public class JournalArticleLocalServiceImpl
 		QueryDefinition<JournalArticle> queryDefinition = new QueryDefinition<>(
 			status, start, end, null);
 
-		return journalArticleFinder.findByG_F(
-			groupId, folderIds, queryDefinition);
+		Locale siteDefaultLocale = LocaleUtil.getSiteDefault();
+
+		return journalArticleFinder.findByG_F_L(
+			groupId, folderIds, siteDefaultLocale, queryDefinition);
 	}
 
 	/**

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -4230,18 +4230,31 @@ public class JournalArticleLocalServiceImpl
 	 * @param  end the upper bound of the range of web content articles to
 	 *         return (not inclusive)
 	 * @return the matching web content articles
+	 *
+	 * @deprecated As of Judson (7.1.x), replaced by {@link
+	 *  		   #search(long groupId, List folderIds, Locale locale,
+	 *  		   int status, int start, int end)}
 	 */
+	@Deprecated
 	@Override
 	public List<JournalArticle> search(
 		long groupId, List<Long> folderIds, int status, int start, int end) {
 
+		Locale locale = LocaleUtil.getMostRelevantLocale();
+
+		return search(groupId, folderIds, locale, status, start, end);
+	}
+
+	@Override
+	public List<JournalArticle> search(
+		long groupId, List<Long> folderIds, Locale locale, int status,
+		int start, int end) {
+
 		QueryDefinition<JournalArticle> queryDefinition = new QueryDefinition<>(
 			status, start, end, null);
 
-		Locale siteDefaultLocale = LocaleUtil.getSiteDefault();
-
 		return journalArticleFinder.findByG_F_L(
-			groupId, folderIds, siteDefaultLocale, queryDefinition);
+			groupId, folderIds, locale, queryDefinition);
 	}
 
 	/**

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleServiceImpl.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.security.permission.resource.PortletResourcePer
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
@@ -804,8 +805,10 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 
 		folderIds.add(folderId);
 
-		return journalArticleFinder.filterFindByG_F(
-			groupId, folderIds, queryDefinition);
+		Locale siteDefaultLocale = LocaleUtil.getSiteDefault();
+
+		return journalArticleFinder.filterFindByG_F_L(
+			groupId, folderIds, siteDefaultLocale, queryDefinition);
 	}
 
 	/**
@@ -843,8 +846,10 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 
 		folderIds.add(folderId);
 
-		return journalArticleFinder.filterFindByG_F(
-			groupId, folderIds, queryDefinition);
+		Locale siteDefaultLocale = LocaleUtil.getSiteDefault();
+
+		return journalArticleFinder.filterFindByG_F_L(
+			groupId, folderIds, siteDefaultLocale, queryDefinition);
 	}
 
 	/**

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleServiceImpl.java
@@ -845,15 +845,6 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 		return getArticles(groupId, folderId, locale, start, end, obc);
 	}
 
-	/**
-	 * Returns all the web content articles matching the group, folder and
-	 * locale.
-	 *
-	 * @param  groupId the primary key of the web content article's group
-	 * @param  folderId the primary key of the web content article folder
-	 * @param  locale current locale
-	 * @return the matching web content articles
-	 */
 	public List<JournalArticle> getArticles(
 		long groupId, long folderId, Locale locale) {
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleServiceImpl.java
@@ -795,20 +795,16 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 	 * @param  groupId the primary key of the web content article's group
 	 * @param  folderId the primary key of the web content article folder
 	 * @return the matching web content articles
+	 *
+	 * @deprecated As of Judson (7.1.x), replaced by {@link
+	 * 			   #getArticles(long groupId, long folderId, Locale locale)}
 	 */
+	@Deprecated
 	@Override
 	public List<JournalArticle> getArticles(long groupId, long folderId) {
-		QueryDefinition<JournalArticle> queryDefinition = new QueryDefinition<>(
-			WorkflowConstants.STATUS_ANY);
+		Locale locale = LocaleUtil.getMostRelevantLocale();
 
-		List<Long> folderIds = new ArrayList<>();
-
-		folderIds.add(folderId);
-
-		Locale siteDefaultLocale = LocaleUtil.getSiteDefault();
-
-		return journalArticleFinder.filterFindByG_F_L(
-			groupId, folderIds, siteDefaultLocale, queryDefinition);
+		return getArticles(groupId, folderId, locale);
 	}
 
 	/**
@@ -833,10 +829,48 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 	 *         return (not inclusive)
 	 * @param  obc the comparator to order the web content articles
 	 * @return the matching web content articles
+	 *
+	 * @deprecated As of Judson (7.1.x), replaced by {@link
+	 * 			   #getArticles(long groupId, long folderId, Locale locale,
+	 * 			   int start, int end, OrderByComparator obc)}
 	 */
+	@Deprecated
 	@Override
 	public List<JournalArticle> getArticles(
 		long groupId, long folderId, int start, int end,
+		OrderByComparator<JournalArticle> obc) {
+
+		Locale locale = LocaleUtil.getMostRelevantLocale();
+
+		return getArticles(groupId, folderId, locale, start, end, obc);
+	}
+
+	/**
+	 * Returns all the web content articles matching the group, folder and
+	 * locale.
+	 *
+	 * @param  groupId the primary key of the web content article's group
+	 * @param  folderId the primary key of the web content article folder
+	 * @param  locale current locale
+	 * @return the matching web content articles
+	 */
+	public List<JournalArticle> getArticles(
+		long groupId, long folderId, Locale locale) {
+
+		QueryDefinition<JournalArticle> queryDefinition = new QueryDefinition<>(
+			WorkflowConstants.STATUS_ANY);
+
+		List<Long> folderIds = new ArrayList<>();
+
+		folderIds.add(folderId);
+
+		return journalArticleFinder.filterFindByG_F_L(
+			groupId, folderIds, locale, queryDefinition);
+	}
+
+	@Override
+	public List<JournalArticle> getArticles(
+		long groupId, long folderId, Locale locale, int start, int end,
 		OrderByComparator<JournalArticle> obc) {
 
 		QueryDefinition<JournalArticle> queryDefinition = new QueryDefinition<>(
@@ -846,10 +880,8 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 
 		folderIds.add(folderId);
 
-		Locale siteDefaultLocale = LocaleUtil.getSiteDefault();
-
 		return journalArticleFinder.filterFindByG_F_L(
-			groupId, folderIds, siteDefaultLocale, queryDefinition);
+			groupId, folderIds, locale, queryDefinition);
 	}
 
 	/**

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleServiceImpl.java
@@ -857,12 +857,12 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 	public List<JournalArticle> getArticles(
 		long groupId, long folderId, Locale locale) {
 
-		QueryDefinition<JournalArticle> queryDefinition = new QueryDefinition<>(
-			WorkflowConstants.STATUS_ANY);
-
 		List<Long> folderIds = new ArrayList<>();
 
 		folderIds.add(folderId);
+
+		QueryDefinition<JournalArticle> queryDefinition = new QueryDefinition<>(
+			WorkflowConstants.STATUS_ANY);
 
 		return journalArticleFinder.filterFindByG_F_L(
 			groupId, folderIds, locale, queryDefinition);
@@ -873,12 +873,12 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 		long groupId, long folderId, Locale locale, int start, int end,
 		OrderByComparator<JournalArticle> obc) {
 
-		QueryDefinition<JournalArticle> queryDefinition = new QueryDefinition<>(
-			WorkflowConstants.STATUS_ANY, start, end, obc);
-
 		List<Long> folderIds = new ArrayList<>();
 
 		folderIds.add(folderId);
+
+		QueryDefinition<JournalArticle> queryDefinition = new QueryDefinition<>(
+			WorkflowConstants.STATUS_ANY, start, end, obc);
 
 		return journalArticleFinder.filterFindByG_F_L(
 			groupId, folderIds, locale, queryDefinition);
@@ -1076,12 +1076,12 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 	 */
 	@Override
 	public int getArticlesCount(long groupId, long folderId, int status) {
-		QueryDefinition<JournalArticle> queryDefinition = new QueryDefinition<>(
-			status);
-
 		List<Long> folderIds = new ArrayList<>();
 
 		folderIds.add(folderId);
+
+		QueryDefinition<JournalArticle> queryDefinition = new QueryDefinition<>(
+			status);
 
 		return journalArticleFinder.filterCountByG_F(
 			groupId, folderIds, queryDefinition);

--- a/modules/apps/journal/journal-service/src/main/resources/META-INF/custom-sql/default.xml
+++ b/modules/apps/journal/journal-service/src/main/resources/META-INF/custom-sql/default.xml
@@ -197,6 +197,39 @@
 				JournalArticle.id_ ASC
 		]]>
 	</sql>
+	<sql id="com.liferay.journal.service.persistence.JournalArticleFinder.findByG_F_L">
+		<![CDATA[
+			SELECT
+				JournalArticle.*
+			FROM
+				JournalArticle
+			LEFT JOIN
+				JournalArticle tempJournalArticle ON
+					[$STATUS_JOIN$] AND
+					(JournalArticle.groupId = tempJournalArticle.groupId) AND
+					(JournalArticle.articleId = tempJournalArticle.articleId) AND
+					(JournalArticle.version < tempJournalArticle.version)
+			LEFT JOIN
+				(
+					SELECT
+						JournalArticleLocalization.companyId, JournalArticleLocalization.articlePK, JournalArticleLocalization.title, JournalArticleLocalization.languageId
+					FROM
+						JournalArticleLocalization
+					GROUP BY
+						JournalArticleLocalization.companyId, JournalArticleLocalization.articlePK, JournalArticleLocalization.title, JournalArticleLocalization.languageId
+				) JournalArticleLocalization ON
+					(JournalArticle.companyId = JournalArticleLocalization.companyId) AND
+					(JournalArticle.id_ = JournalArticleLocalization.articlePK) AND
+					(JournalArticleLocalization.languageId = ?)
+			WHERE
+				(JournalArticle.groupId = ?) AND
+				([$STATUS$]) AND
+				[$FOLDER_ID$] AND
+				(tempJournalArticle.id_ IS NULL)
+			ORDER BY
+				JournalArticle.id_ ASC
+		]]>
+	</sql>
 	<sql id="com.liferay.journal.service.persistence.JournalArticleFinder.findByG_C_S">
 		<![CDATA[
 			SELECT

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalArticleFinderTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalArticleFinderTest.java
@@ -41,6 +41,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -597,8 +598,10 @@ public class JournalArticleFinderTest {
 
 		Assert.assertEquals(expectedCount, actualCount);
 
-		List<JournalArticle> articles = _journalArticleFinder.findByG_F(
-			groupId, folderIds, queryDefinition);
+		Locale siteDefaultLocale = LocaleUtil.getSiteDefault();
+
+		List<JournalArticle> articles = _journalArticleFinder.findByG_F_L(
+			groupId, folderIds, siteDefaultLocale, queryDefinition);
 
 		actualCount = articles.size();
 
@@ -627,8 +630,11 @@ public class JournalArticleFinderTest {
 			Collections.reverse(expectedArticles);
 		}
 
-		List<JournalArticle> actualArticles = _journalArticleFinder.findByG_F(
-			_group.getGroupId(), _folderIds, queryDefinition);
+		Locale siteDefaultLocale = LocaleUtil.getSiteDefault();
+
+		List<JournalArticle> actualArticles = _journalArticleFinder.findByG_F_L(
+			_group.getGroupId(), _folderIds, siteDefaultLocale,
+			queryDefinition);
 
 		Assert.assertEquals(expectedArticles, actualArticles);
 	}

--- a/modules/apps/portal-scheduler/portal-scheduler-multiple/src/main/java/com/liferay/portal/scheduler/multiple/internal/ClusterSchedulerEngine.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-multiple/src/main/java/com/liferay/portal/scheduler/multiple/internal/ClusterSchedulerEngine.java
@@ -44,6 +44,7 @@ import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.Props;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.ThreadUtil;
 
 import java.util.Date;
 import java.util.Iterator;
@@ -573,6 +574,20 @@ public class ClusterSchedulerEngine
 
 				List<SchedulerResponse> schedulerResponses = future.get(
 					_callMasterTimeout, TimeUnit.SECONDS);
+
+				if (schedulerResponses == null) {
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							StringBundler.concat(
+								"Missing response, will wait ",
+								String.valueOf(_callMasterTimeout),
+								" seconds before trying again"));
+					}
+
+					ThreadUtil.sleep(_callMasterTimeout * 1000);
+
+					continue;
+				}
 
 				_memoryClusteredJobs.clear();
 

--- a/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/ClusterMasterExecutorImpl.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/ClusterMasterExecutorImpl.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.resiliency.spi.SPIUtil;
 import com.liferay.portal.kernel.util.MethodHandler;
 import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.ThreadUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.HashSet;
@@ -203,8 +204,11 @@ public class ClusterMasterExecutorImpl implements ClusterMasterExecutor {
 					StringBundler.concat(
 						"Unable to get cluster node information for ",
 						"coordinator address ",
-						String.valueOf(coordinatorAddress), ". Trying again."));
+						String.valueOf(coordinatorAddress),
+						". Trying again in 1 second."));
 			}
+
+			ThreadUtil.sleep(1000);
 		}
 
 		if (master == _master) {

--- a/modules/apps/portal/portal-cluster-multiple/src/test/java/com/liferay/portal/cluster/multiple/internal/ClusterMasterExecutorImplTest.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/test/java/com/liferay/portal/cluster/multiple/internal/ClusterMasterExecutorImplTest.java
@@ -452,7 +452,7 @@ public class ClusterMasterExecutorImplTest extends BaseClusterTestCase {
 					Assert.assertEquals(
 						"Unable to get cluster node information for " +
 							"coordinator address " + _TEST_ADDRESS +
-								". Trying again.",
+								". Trying again in 1 second.",
 						logRecord.getMessage());
 				}
 			}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/ThreadUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/ThreadUtil.java
@@ -57,6 +57,14 @@ public class ThreadUtil {
 		return threads;
 	}
 
+	public static void sleep(long milliseconds) {
+		try {
+			Thread.sleep(milliseconds);
+		}
+		catch (InterruptedException ie) {
+		}
+	}
+
 	public static String threadDump() {
 		String threadDump = _getThreadDumpFromJstack();
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-82603

Resend of https://github.com/tinatian/liferay-portal/pull/907 which achieves the 100% line coverage by moving the try-catch of the InterruptedException to another class.

Other than squashing commits and changing one more instance of the try-catch of the InterruptedException to call the new `ThreadUtil.sleep` method, this is identical to https://github.com/ericyanLr/liferay-portal/pull/74 where the relevant CI tests passed.