### PR TITLE
LPS-84064 Load appropriate resource bundle from portlets[TS] LPS-84064 Module containing multiple portlets and resource bundles will always read from first

### DIFF
--- a/util-taglib/src/com/liferay/taglib/util/TagResourceBundleUtil.java
+++ b/util-taglib/src/com/liferay/taglib/util/TagResourceBundleUtil.java
@@ -97,18 +97,29 @@ public class TagResourceBundleUtil {
 				WebKeys.RESOURCE_BUNDLE_LOADER);
 
 		if (resourceBundleLoader == null) {
-			ServletContext servletContext = request.getServletContext();
+			PortletConfig portletConfig = (PortletConfig)request.getAttribute(
+				JavaConstants.JAVAX_PORTLET_CONFIG);
 
-			String servletContextName = servletContext.getServletContextName();
-
-			if (Validator.isNull(servletContextName)) {
-				return null;
+			if (portletConfig != null) {
+				resourceBundleLoader = locale -> {
+					return portletConfig.getResourceBundle(locale);
+				};
 			}
+			else {
+				ServletContext servletContext = request.getServletContext();
 
-			resourceBundleLoader =
-				ResourceBundleLoaderUtil.
-					getResourceBundleLoaderByServletContextName(
-						servletContextName);
+				String servletContextName =
+					servletContext.getServletContextName();
+
+				if (Validator.isNull(servletContextName)) {
+					return null;
+				}
+
+				resourceBundleLoader =
+					ResourceBundleLoaderUtil.
+						getResourceBundleLoaderByServletContextName(
+							servletContextName);
+			}
 		}
 
 		if (resourceBundleLoader == null) {


### PR DESCRIPTION
Hi Tina,

I would like to ask for your kind help:
Please review my fix, and forward it to the next approver in case you find everything ok.
I have created this fix with the help of Minhchau Dang.
Link to my LPS:
LPS-84064
(Normally I am sending these pull requests to Tibor Lipusz but this week he is out of the office.)

Thank you,
Peter

