### PR TITLE
LPS-82603

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
@@ -930,6 +930,7 @@ while (manageableCalendarsIterator.hasNext()) {
 
 	<%
 	defaultEndTimeJCalendar = (java.util.Calendar)defaultStartTimeJCalendar.clone();
+
 	defaultEndTimeJCalendar.add(java.util.Calendar.MINUTE, defaultDuration);
 	%>
 

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
@@ -939,53 +939,33 @@ while (manageableCalendarsIterator.hasNext()) {
 			var endDateContainer = A.one('#<portlet:namespace />endDateContainer');
 			var startDateContainer = A.one('#<portlet:namespace />startDateContainer');
 
-			var endDatePicker = intervalSelector.get('endDatePicker');
-			var startDatePicker = intervalSelector.get('startDatePicker');
-
-			var endDate = endDatePicker.getDate();
-			var startDate = startDatePicker.getDate();
-
-			var endTimePicker = intervalSelector.get('endTimePicker');
-			var startTimePicker = intervalSelector.get('startTimePicker');
+			var endTimeHours;
+			var endTimeMinutes;
+			var startTimeHours;
+			var startTimeMinutes;
 
 			var checked = allDayCheckbox.get('checked');
 
 			if (checked) {
 				placeholderSchedulerEvent.set('allDay', true);
 
-				startDate.setHours(0);
-				startDate.setMinutes(0);
-
-				endDate.setHours(23);
-				endDate.setMinutes(59);
-
-				intervalSelector.setDuration(endDate.valueOf() - startDate.valueOf());
-
-				startTimePicker.selectDates([startDate]);
-				endTimePicker.selectDates([endDate]);
+				startTimeHours = 0;
+				startTimeMinutes = 0;
+				endTimeHours = 23;
+				endTimeMinutes = 59;
 			}
 			else {
 				placeholderSchedulerEvent.set('allDay', false);
 
-				var startDateHours = <%= defaultStartTimeJCalendar.get(java.util.Calendar.HOUR_OF_DAY) %>;
-				var startDateMinutes = <%= defaultStartTimeJCalendar.get(java.util.Calendar.MINUTE) %>;
-
-				var endDateHours = <%= defaultEndTimeJCalendar.get(java.util.Calendar.HOUR_OF_DAY) %>;
-				var endDateMinutes = <%= defaultEndTimeJCalendar.get(java.util.Calendar.MINUTE) %>;
-
-				startDate.setHours(startDateHours);
-				startDate.setMinutes(startDateMinutes);
-
-				endDate.setHours(endDateHours);
-				endDate.setMinutes(endDateMinutes);
-
-				intervalSelector.setDuration(endDate.valueOf() - startDate.valueOf());
-
-				startTimePicker.selectDates([startDate]);
-				endTimePicker.selectDates([endDate]);
-
 				endDateContainer.show();
+
+				startTimeHours = <%= defaultStartTimeJCalendar.get(java.util.Calendar.HOUR_OF_DAY) %>;
+				startTimeMinutes = <%= defaultStartTimeJCalendar.get(java.util.Calendar.MINUTE) %>;
+				endTimeHours = <%= defaultEndTimeJCalendar.get(java.util.Calendar.HOUR_OF_DAY) %>;
+				endTimeMinutes = <%= defaultEndTimeJCalendar.get(java.util.Calendar.MINUTE) %>;
 			}
+
+			updateTimePickersValues(startTimeHours, startTimeMinutes, endTimeHours, endTimeMinutes);
 
 			endDateContainer.toggleClass('allday-class-active', checked);
 			startDateContainer.toggleClass('allday-class-active', checked);
@@ -993,6 +973,28 @@ while (manageableCalendarsIterator.hasNext()) {
 			scheduler.syncEventsUI();
 		}
 	);
+
+	var updateTimePickersValues = function(startTimeHours, startTimeMinutes, endTimeHours, endTimeMinutes) {
+		var endDatePicker = intervalSelector.get('endDatePicker');
+		var startDatePicker = intervalSelector.get('startDatePicker');
+
+		var endDate = endDatePicker.getDate();
+		var startDate = startDatePicker.getDate();
+
+		startDate.setHours(startTimeHours);
+		startDate.setMinutes(startTimeMinutes);
+
+		endDate.setHours(endTimeHours);
+		endDate.setMinutes(endTimeMinutes);
+
+		intervalSelector.setDuration(endDate.valueOf() - startDate.valueOf());
+
+		var endTimePicker = intervalSelector.get('endTimePicker');
+		var startTimePicker = intervalSelector.get('startTimePicker');
+
+		startTimePicker.selectDates([startDate]);
+		endTimePicker.selectDates([endDate]);
+	};
 
 	scheduler.load();
 </aui:script>

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
@@ -869,7 +869,7 @@ while (manageableCalendarsIterator.hasNext()) {
 
 		var inviteResourcesInput = A.one('#<portlet:namespace />inviteResource');
 
-		<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="calendarResources" var="calendarResourcesURL"></liferay-portlet:resourceURL>
+		<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="calendarResources" var="calendarResourcesURL" />
 
 		calendarContainer.createCalendarsAutoComplete(
 			'<%= calendarResourcesURL %>',

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
@@ -928,19 +928,61 @@ while (manageableCalendarsIterator.hasNext()) {
 
 	var allDayCheckbox = A.one('#<portlet:namespace />allDay');
 
+	<%
+	defaultEndTimeJCalendar = (java.util.Calendar)defaultStartTimeJCalendar.clone();
+	defaultEndTimeJCalendar.add(java.util.Calendar.MINUTE, defaultDuration);
+	%>
+
 	allDayCheckbox.after(
 		'click',
 		function() {
 			var endDateContainer = A.one('#<portlet:namespace />endDateContainer');
 			var startDateContainer = A.one('#<portlet:namespace />startDateContainer');
 
+			var endDatePicker = intervalSelector.get('endDatePicker');
+			var startDatePicker = intervalSelector.get('startDatePicker');
+
+			var endDate = endDatePicker.getDate();
+			var startDate = startDatePicker.getDate();
+
+			var endTimePicker = intervalSelector.get('endTimePicker');
+			var startTimePicker = intervalSelector.get('startTimePicker');
+
 			var checked = allDayCheckbox.get('checked');
 
 			if (checked) {
 				placeholderSchedulerEvent.set('allDay', true);
+
+				startDate.setHours(0);
+				startDate.setMinutes(0);
+
+				endDate.setHours(23);
+				endDate.setMinutes(59);
+
+				intervalSelector.setDuration(endDate.valueOf() - startDate.valueOf());
+
+				startTimePicker.selectDates([startDate]);
+				endTimePicker.selectDates([endDate]);
 			}
 			else {
 				placeholderSchedulerEvent.set('allDay', false);
+
+				var startDateHours = <%= defaultStartTimeJCalendar.get(java.util.Calendar.HOUR_OF_DAY) %>;
+				var startDateMinutes = <%= defaultStartTimeJCalendar.get(java.util.Calendar.MINUTE) %>;
+
+				var endDateHours = <%= defaultEndTimeJCalendar.get(java.util.Calendar.HOUR_OF_DAY) %>;
+				var endDateMinutes = <%= defaultEndTimeJCalendar.get(java.util.Calendar.MINUTE) %>;
+
+				startDate.setHours(startDateHours);
+				startDate.setMinutes(startDateMinutes);
+
+				endDate.setHours(endDateHours);
+				endDate.setMinutes(endDateMinutes);
+
+				intervalSelector.setDuration(endDate.valueOf() - startDate.valueOf());
+
+				startTimePicker.selectDates([startDate]);
+				endTimePicker.selectDates([endDate]);
 
 				endDateContainer.show();
 			}

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/interval_selector.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/interval_selector.js
@@ -73,6 +73,11 @@ AUI.add(
 						instance.eventHandlers = null;
 					},
 
+					setDuration: function(duration) {
+						var instance = this;
+						instance._duration = duration;
+					},
+
 					startDurationPreservation: function() {
 						var instance = this;
 

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/interval_selector.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/interval_selector.js
@@ -75,6 +75,7 @@ AUI.add(
 
 					setDuration: function(duration) {
 						var instance = this;
+
 						instance._duration = duration;
 					},
 

--- a/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/configuration/ClusterExecutorConfiguration.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/configuration/ClusterExecutorConfiguration.java
@@ -29,6 +29,11 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 )
 public interface ClusterExecutorConfiguration {
 
+	@Meta.AD(
+		deflt = "1", name = "cluster-node-address-timeout", required = false
+	)
+	public long clusterNodeAddressTimeout();
+
 	@Meta.AD(deflt = "false", name = "debug-enabled", required = false)
 	public boolean debugEnabled();
 

--- a/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/ClusterExecutorImpl.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/internal/ClusterExecutorImpl.java
@@ -55,6 +55,7 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -62,9 +63,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
@@ -366,15 +369,38 @@ public class ClusterExecutorImpl implements ClusterExecutor {
 	}
 
 	protected ClusterNode getClusterNode(Address address) {
-		for (ClusterNodeStatus clusterNodeStatus :
-				_clusterNodeStatuses.values()) {
+		CompletableFuture<ClusterNode> completableFuture;
 
-			if (address.equals(clusterNodeStatus.getAddress())) {
-				return clusterNodeStatus.getClusterNode();
+		synchronized (_clusterNodeCompletableFutures) {
+			for (ClusterNodeStatus clusterNodeStatus :
+					_clusterNodeStatuses.values()) {
+
+				if (address.equals(clusterNodeStatus.getAddress())) {
+					return clusterNodeStatus.getClusterNode();
+				}
+			}
+
+			completableFuture = _clusterNodeCompletableFutures.get(address);
+
+			if (completableFuture == null) {
+				completableFuture = new CompletableFuture<>();
+
+				_clusterNodeCompletableFutures.put(address, completableFuture);
 			}
 		}
 
-		_log.error("Unable to get cluster node with address " + address);
+		try {
+			return completableFuture.get(
+				clusterExecutorConfiguration.clusterNodeAddressTimeout(),
+				TimeUnit.SECONDS);
+		}
+		catch (Exception e) {
+			_log.error("Unable to get cluster node with address " + address);
+
+			synchronized (_clusterNodeCompletableFutures) {
+				_clusterNodeCompletableFutures.remove(address);
+			}
+		}
 
 		return null;
 	}
@@ -552,8 +578,20 @@ public class ClusterExecutorImpl implements ClusterExecutor {
 	}
 
 	protected boolean memberJoined(ClusterNodeStatus clusterNodeStatus) {
-		ClusterNodeStatus oldClusterNodeStatus = _clusterNodeStatuses.put(
-			clusterNodeStatus.getClusterNodeId(), clusterNodeStatus);
+		ClusterNodeStatus oldClusterNodeStatus;
+
+		synchronized (_clusterNodeCompletableFutures) {
+			oldClusterNodeStatus = _clusterNodeStatuses.put(
+				clusterNodeStatus.getClusterNodeId(), clusterNodeStatus);
+
+			CompletableFuture<ClusterNode> completableFuture =
+				_clusterNodeCompletableFutures.remove(
+					clusterNodeStatus.getAddress());
+
+			if (completableFuture != null) {
+				completableFuture.complete(clusterNodeStatus.getClusterNode());
+			}
+		}
 
 		if (oldClusterNodeStatus != null) {
 			if (!oldClusterNodeStatus.equals(clusterNodeStatus)) {
@@ -653,6 +691,8 @@ public class ClusterExecutorImpl implements ClusterExecutor {
 	private ClusterChannelFactory _clusterChannelFactory;
 	private final CopyOnWriteArrayList<ClusterEventListener>
 		_clusterEventListeners = new CopyOnWriteArrayList<>();
+	private final Map<Address, CompletableFuture<ClusterNode>>
+		_clusterNodeCompletableFutures = new HashMap<>();
 	private final Map<String, ClusterNodeStatus> _clusterNodeStatuses =
 		new ConcurrentHashMap<>();
 	private ClusterEventListener _debugClusterEventListener;

--- a/modules/apps/portal/portal-cluster-multiple/src/main/resources/content/Language.properties
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/resources/content/Language.properties
@@ -1,4 +1,5 @@
 cluster-executor-configuration-name=Cluster Executor
+cluster-node-address-timeout=Cluster Node Address Timeout
 debug-enabled=Debug Enabled
 excluded-property-keys=Excluded Property Keys
 excluded-property-keys-help=Remove property keys for logging.

--- a/modules/apps/portal/portal-cluster-multiple/src/test/java/com/liferay/portal/cluster/multiple/internal/ClusterExecutorImplTest.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/test/java/com/liferay/portal/cluster/multiple/internal/ClusterExecutorImplTest.java
@@ -138,6 +138,11 @@ public class ClusterExecutorImplTest extends BaseClusterTestCase {
 			new ClusterExecutorConfiguration() {
 
 				@Override
+				public long clusterNodeAddressTimeout() {
+					return 1;
+				}
+
+				@Override
 				public boolean debugEnabled() {
 					return true;
 				}

--- a/modules/apps/portal/portal-cluster-multiple/src/test/java/com/liferay/portal/cluster/multiple/internal/ClusterMasterExecutorImplTest.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/test/java/com/liferay/portal/cluster/multiple/internal/ClusterMasterExecutorImplTest.java
@@ -800,6 +800,11 @@ public class ClusterMasterExecutorImplTest extends BaseClusterTestCase {
 			clusterExecutorConfiguration = new ClusterExecutorConfiguration() {
 
 				@Override
+				public long clusterNodeAddressTimeout() {
+					return 1;
+				}
+
+				@Override
 				public boolean debugEnabled() {
 					return false;
 				}

--- a/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
+++ b/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
@@ -16,13 +16,13 @@ package com.liferay.portal.language;
 
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.cluster.ClusterExecutorUtil;
-import com.liferay.portal.kernel.cluster.ClusterInvokeThreadLocal;
-import com.liferay.portal.kernel.cluster.ClusterRequest;
+import com.liferay.portal.kernel.cache.MultiVMPoolUtil;
+import com.liferay.portal.kernel.cache.PortalCache;
+import com.liferay.portal.kernel.cache.PortalCacheMapSynchronizeUtil;
+import com.liferay.portal.kernel.cache.PortalCacheMapSynchronizeUtil.Synchronizer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.language.LanguageWrapper;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -39,8 +39,6 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.MethodHandler;
-import com.liferay.portal.kernel.util.MethodKey;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -109,6 +107,23 @@ import javax.servlet.http.HttpServletResponse;
 public class LanguageImpl implements Language, Serializable {
 
 	public void afterPropertiesSet() {
+		_companyLocalesPortalCache = MultiVMPoolUtil.getPortalCache(
+			_COMPANY_LOCALES_PORTAL_CACHE_NAME);
+
+		PortalCacheMapSynchronizeUtil.synchronize(
+			_companyLocalesPortalCache, _companyLocalesBags,
+			_removeSynchronizer);
+
+		_groupLocalesPortalCache = MultiVMPoolUtil.getPortalCache(
+			_GROUP_LOCALES_PORTAL_CACHE_NAME);
+
+		PortalCacheMapSynchronizeUtil.synchronize(
+			_groupLocalesPortalCache, _groupLanguageCodeLocalesMapMap,
+			_removeSynchronizer);
+
+		PortalCacheMapSynchronizeUtil.synchronize(
+			_groupLocalesPortalCache, _groupLanguageIdLocalesMap,
+			_removeSynchronizer);
 	}
 
 	/**
@@ -1556,18 +1571,12 @@ public class LanguageImpl implements Language, Serializable {
 
 	@Override
 	public void resetAvailableGroupLocales(long groupId) {
-		_groupLanguageCodeLocalesMapMap.remove(groupId);
-		_groupLanguageIdLocalesMap.remove(groupId);
-
-		_sendClearCacheClusterMessage(_resetAvailableGroupLocales, groupId);
+		_resetAvailableGroupLocales(groupId);
 	}
 
 	@Override
 	public void resetAvailableLocales(long companyId) {
-		_companyLocalesBags.remove(companyId);
-
-		_sendClearCacheClusterMessage(
-			_resetAvailableLocalesMethodKey, companyId);
+		_resetAvailableLocales(companyId);
 	}
 
 	@Override
@@ -1609,21 +1618,6 @@ public class LanguageImpl implements Language, Serializable {
 		}
 
 		return companyLocalesBag;
-	}
-
-	private static void _sendClearCacheClusterMessage(
-		MethodKey methodKey, long argument) {
-
-		if (!ClusterInvokeThreadLocal.isEnabled()) {
-			return;
-		}
-
-		ClusterRequest clusterRequest = ClusterRequest.createMulticastRequest(
-			new MethodHandler(methodKey, argument), true);
-
-		clusterRequest.setFireAndForget(true);
-
-		ClusterExecutorUtil.execute(clusterRequest);
 	}
 
 	private ObjectValuePair<HashMap<String, Locale>, HashMap<String, Locale>>
@@ -1858,16 +1852,41 @@ public class LanguageImpl implements Language, Serializable {
 		return locale;
 	}
 
+	private void _resetAvailableGroupLocales(long groupId) {
+		_groupLocalesPortalCache.remove(groupId);
+	}
+
+	private void _resetAvailableLocales(long companyId) {
+		_companyLocalesPortalCache.remove(companyId);
+	}
+
+	private static final String _COMPANY_LOCALES_PORTAL_CACHE_NAME =
+		LanguageImpl.class.getName() + "._companyLocalesPortalCache";
+
+	private static final String _GROUP_LOCALES_PORTAL_CACHE_NAME =
+		LanguageImpl.class.getName() + "._groupLocalesPortalCache";
+
 	private static final Log _log = LogFactoryUtil.getLog(LanguageImpl.class);
 
 	private static final Map<Long, CompanyLocalesBag> _companyLocalesBags =
 		new ConcurrentHashMap<>();
+	private static PortalCache<Long, Serializable> _companyLocalesPortalCache;
+	private static PortalCache<Long, Serializable> _groupLocalesPortalCache;
 	private static final Pattern _pattern = Pattern.compile(
 		"Liferay\\.Language\\.get\\([\"']([^)]+)[\"']\\)");
-	private static final MethodKey _resetAvailableGroupLocales = new MethodKey(
-		LanguageUtil.class, "resetAvailableGroupLocales", long.class);
-	private static final MethodKey _resetAvailableLocalesMethodKey =
-		new MethodKey(LanguageUtil.class, "resetAvailableLocales", long.class);
+
+	private static final Synchronizer<Long, Serializable> _removeSynchronizer =
+		new Synchronizer<Long, Serializable>() {
+
+			@Override
+			public void onSynchronize(
+				Map<? extends Long, ? extends Serializable> map, Long key,
+				Serializable value, int timeToLive) {
+
+				map.remove(key);
+			}
+
+		};
 
 	private final Map<Long, HashMap<String, Locale>>
 		_groupLanguageCodeLocalesMapMap = new ConcurrentHashMap<>();

--- a/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
+++ b/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
@@ -1612,9 +1612,7 @@ public class LanguageImpl implements Language, Serializable {
 	private static void _sendClearCacheClusterMessage(
 		MethodKey methodKey, long argument) {
 
-		if (!ClusterExecutorUtil.isEnabled() ||
-			!ClusterInvokeThreadLocal.isEnabled()) {
-
+		if (!ClusterInvokeThreadLocal.isEnabled()) {
 			return;
 		}
 

--- a/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
+++ b/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
@@ -108,6 +108,9 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class LanguageImpl implements Language, Serializable {
 
+	public void afterPropertiesSet() {
+	}
+
 	/**
 	 * Returns the translated pattern using the current request's locale or, if
 	 * the current request locale is not available, the server's default locale.

--- a/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
+++ b/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
@@ -1556,8 +1556,7 @@ public class LanguageImpl implements Language, Serializable {
 		_groupLanguageCodeLocalesMapMap.remove(groupId);
 		_groupLanguageIdLocalesMap.remove(groupId);
 
-		_sendClearCacheClusterMessage(
-			_resetAvailableGroupLocalesMethodKey, groupId);
+		_sendClearCacheClusterMessage(_resetAvailableGroupLocales, groupId);
 	}
 
 	@Override
@@ -1862,9 +1861,8 @@ public class LanguageImpl implements Language, Serializable {
 		new ConcurrentHashMap<>();
 	private static final Pattern _pattern = Pattern.compile(
 		"Liferay\\.Language\\.get\\([\"']([^)]+)[\"']\\)");
-	private static final MethodKey _resetAvailableGroupLocalesMethodKey =
-		new MethodKey(
-			LanguageUtil.class, "resetAvailableGroupLocales", long.class);
+	private static final MethodKey _resetAvailableGroupLocales = new MethodKey(
+		LanguageUtil.class, "resetAvailableGroupLocales", long.class);
 	private static final MethodKey _resetAvailableLocalesMethodKey =
 		new MethodKey(LanguageUtil.class, "resetAvailableLocales", long.class);
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-82603

https://github.com/tinatian/liferay-portal/pull/961

We have updated the timeout to be configurable. All we have is the Address, which we cannot convert into a clusterNodeId to add as a key into the existing `_clusterNodeStatuses` map, so this implementation still uses two maps.

From @ericyanLr : 

> ## Brief Summary
> As discussed, this fix now consists of using synchronized blocks and CompletableFuture, so that:
> 
> 1. If a ClusterNode is not found, create a future
> 2. Introduce a timeout for the future, to avoid the no-delay loop
> 3. If a valid ClusterNode is found, complete the future so it will not have to wait the entire timeout
