### PR TITLE
LPS-82603

### DIFF
--- a/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/configuration/ClusterExecutorConfiguration.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/java/com/liferay/portal/cluster/multiple/configuration/ClusterExecutorConfiguration.java
@@ -29,6 +29,11 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 )
 public interface ClusterExecutorConfiguration {
 
+	@Meta.AD(
+		deflt = "1000", name = "cluster-node-address-timeout", required = false
+	)
+	public long clusterNodeAddressTimeout();
+
 	@Meta.AD(deflt = "false", name = "debug-enabled", required = false)
 	public boolean debugEnabled();
 

--- a/modules/apps/portal/portal-cluster-multiple/src/main/resources/content/Language.properties
+++ b/modules/apps/portal/portal-cluster-multiple/src/main/resources/content/Language.properties
@@ -1,4 +1,5 @@
 cluster-executor-configuration-name=Cluster Executor
+cluster-node-address-timeout=Cluster Node Address Timeout
 debug-enabled=Debug Enabled
 excluded-property-keys=Excluded Property Keys
 excluded-property-keys-help=Remove property keys for logging.

--- a/modules/apps/portal/portal-cluster-multiple/src/test/java/com/liferay/portal/cluster/multiple/internal/ClusterExecutorImplTest.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/test/java/com/liferay/portal/cluster/multiple/internal/ClusterExecutorImplTest.java
@@ -138,6 +138,11 @@ public class ClusterExecutorImplTest extends BaseClusterTestCase {
 			new ClusterExecutorConfiguration() {
 
 				@Override
+				public long clusterNodeAddressTimeout() {
+					return 100;
+				}
+
+				@Override
 				public boolean debugEnabled() {
 					return true;
 				}

--- a/modules/apps/portal/portal-cluster-multiple/src/test/java/com/liferay/portal/cluster/multiple/internal/ClusterMasterExecutorImplTest.java
+++ b/modules/apps/portal/portal-cluster-multiple/src/test/java/com/liferay/portal/cluster/multiple/internal/ClusterMasterExecutorImplTest.java
@@ -800,6 +800,11 @@ public class ClusterMasterExecutorImplTest extends BaseClusterTestCase {
 			clusterExecutorConfiguration = new ClusterExecutorConfiguration() {
 
 				@Override
+				public long clusterNodeAddressTimeout() {
+					return 100;
+				}
+
+				@Override
 				public boolean debugEnabled() {
 					return false;
 				}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-82603

https://github.com/tinatian/liferay-portal/pull/971

Since you wanted us to remove the synchronized block, I decided it would make sense to allow for the race condition, since the worst case is that it will wait for the full timeout. This is implemented without a map, and only runs the code if we're trying to get the cluster node ID for the master node.

To minimize the potential wait time in tests, the time unit has been changed to milliseconds, and the test timeout is smaller than the default timeout.

From @ericyanLr : 

> ## Brief Summary
> As discussed, this fix now consists of using synchronized blocks and CompletableFuture, so that:
> 
> 1. If a ClusterNode is not found, create a future
> 2. Introduce a timeout for the future, to avoid the no-delay loop
> 3. If a valid ClusterNode is found, complete the future so it will not have to wait the entire timeout
