### PR TITLE
Lps 85441 Setup API to replace mockito

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-blogs-editor-configuration/src/test/java/com/liferay/adaptive/media/blogs/editor/configuration/internal/AMBlogsEditorConfigContributorTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-blogs-editor-configuration/src/test/java/com/liferay/adaptive/media/blogs/editor/configuration/internal/AMBlogsEditorConfigContributorTest.java
@@ -700,10 +700,7 @@ public class AMBlogsEditorConfigContributorTest extends PowerMockito {
 	@Mock
 	private PortletURL _portletURL;
 
-	@Mock
 	private RequestBackedPortletURLFactory _requestBackedPortletURLFactory;
-
-	@Mock
 	private ThemeDisplay _themeDisplay;
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-blogs-editor-configuration/src/test/java/com/liferay/adaptive/media/blogs/editor/configuration/internal/AMBlogsEditorConfigContributorTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-blogs-editor-configuration/src/test/java/com/liferay/adaptive/media/blogs/editor/configuration/internal/AMBlogsEditorConfigContributorTest.java
@@ -29,6 +29,7 @@ import com.liferay.portal.json.JSONFactoryImpl;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 
@@ -75,13 +76,9 @@ public class AMBlogsEditorConfigContributorTest extends PowerMockito {
 	public void testAdaptiveMediaFileEntryAttributeNameIsAdded()
 		throws Exception {
 
-		PortletURL itemSelectorPortletURL = mock(PortletURL.class);
-
-		when(
-			itemSelectorPortletURL.toString()
-		).thenReturn(
-			"itemSelectorPortletURL"
-		);
+		PortletURL itemSelectorPortletURL =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				PortletURL.class, "toString", "itemSelectorPortletURL");
 
 		when(
 			_itemSelector.getItemSelectorURL(
@@ -129,13 +126,9 @@ public class AMBlogsEditorConfigContributorTest extends PowerMockito {
 
 	@Test
 	public void testAdaptiveMediaIsAddedToExtraPlugins() throws Exception {
-		PortletURL itemSelectorPortletURL = mock(PortletURL.class);
-
-		when(
-			itemSelectorPortletURL.toString()
-		).thenReturn(
-			"itemSelectorPortletURL"
-		);
+		PortletURL itemSelectorPortletURL =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				PortletURL.class, "toString", "itemSelectorPortletURL");
 
 		when(
 			_itemSelector.getItemSelectorURL(
@@ -182,13 +175,9 @@ public class AMBlogsEditorConfigContributorTest extends PowerMockito {
 
 	@Test
 	public void testAdaptiveMediaIsExtraPlugins() throws Exception {
-		PortletURL itemSelectorPortletURL = mock(PortletURL.class);
-
-		when(
-			itemSelectorPortletURL.toString()
-		).thenReturn(
-			"itemSelectorPortletURL"
-		);
+		PortletURL itemSelectorPortletURL =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				PortletURL.class, "toString", "itemSelectorPortletURL");
 
 		when(
 			_itemSelector.getItemSelectorURL(
@@ -304,11 +293,8 @@ public class AMBlogsEditorConfigContributorTest extends PowerMockito {
 			_portletURL
 		);
 
-		when(
-			_portletURL.toString()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_portletURL, "toString", RandomTestUtil.randomString());
 
 		AMBlogsEditorConfigContributor amBlogsEditorConfigContributor =
 			new AMBlogsEditorConfigContributor();
@@ -517,13 +503,9 @@ public class AMBlogsEditorConfigContributorTest extends PowerMockito {
 	public void testItemSelectorURLWithBlogsItemSelectorCriterion()
 		throws Exception {
 
-		PortletURL itemSelectorPortletURL = mock(PortletURL.class);
-
-		when(
-			itemSelectorPortletURL.toString()
-		).thenReturn(
-			"itemSelectorPortletURL"
-		);
+		PortletURL itemSelectorPortletURL =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				PortletURL.class, "toString", "itemSelectorPortletURL");
 
 		when(
 			_itemSelector.getItemSelectorURL(
@@ -576,13 +558,9 @@ public class AMBlogsEditorConfigContributorTest extends PowerMockito {
 	public void testItemSelectorURLWithFileItemSelectorCriterion()
 		throws Exception {
 
-		PortletURL itemSelectorPortletURL = mock(PortletURL.class);
-
-		when(
-			itemSelectorPortletURL.toString()
-		).thenReturn(
-			"itemSelectorPortletURL"
-		);
+		PortletURL itemSelectorPortletURL =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				PortletURL.class, "toString", "itemSelectorPortletURL");
 
 		when(
 			_itemSelector.getItemSelectorURL(
@@ -697,9 +675,8 @@ public class AMBlogsEditorConfigContributorTest extends PowerMockito {
 	@Mock
 	private ItemSelector _itemSelector;
 
-	@Mock
-	private PortletURL _portletURL;
-
+	private final PortletURL _portletURL = MockHelperUtil.initMock(
+		PortletURL.class);
 	private RequestBackedPortletURLFactory _requestBackedPortletURLFactory;
 	private ThemeDisplay _themeDisplay;
 

--- a/modules/apps/adaptive-media/adaptive-media-blogs-web/src/test/java/com/liferay/adaptive/media/blogs/web/internal/exportimport/content/processor/AMBlogsEntryExportImportContentProcessorTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-blogs-web/src/test/java/com/liferay/adaptive/media/blogs/web/internal/exportimport/content/processor/AMBlogsEntryExportImportContentProcessorTest.java
@@ -18,6 +18,7 @@ import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.exportimport.content.processor.ExportImportContentProcessor;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 
 import org.junit.Assert;
@@ -155,14 +156,15 @@ public class AMBlogsEntryExportImportContentProcessorTest {
 	private final AMBlogsEntryExportImportContentProcessor
 		_amBlogsEntryExportImportContentProcessor =
 			new AMBlogsEntryExportImportContentProcessor();
-	private final BlogsEntry _blogsEntry = Mockito.mock(BlogsEntry.class);
+	private final BlogsEntry _blogsEntry = MockHelperUtil.initMock(
+		BlogsEntry.class);
 	private final ExportImportContentProcessor<String>
 		_blogsEntryExportImportContentProcessor = Mockito.mock(
 			ExportImportContentProcessor.class);
 	private final ExportImportContentProcessor<String>
 		_htmlExportImportContentProcessor = Mockito.mock(
 			ExportImportContentProcessor.class);
-	private final PortletDataContext _portletDataContext = Mockito.mock(
-		PortletDataContext.class);
+	private final PortletDataContext _portletDataContext =
+		MockHelperUtil.initMock(PortletDataContext.class);
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-document-library-thumbnails/src/test/java/com/liferay/adaptive/media/document/library/thumbnails/internal/processor/AMImageEntryProcessorTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-document-library-thumbnails/src/test/java/com/liferay/adaptive/media/document/library/thumbnails/internal/processor/AMImageEntryProcessorTest.java
@@ -21,6 +21,7 @@ import com.liferay.adaptive.media.image.validator.AMImageValidator;
 import com.liferay.adaptive.media.processor.AMAsyncProcessor;
 import com.liferay.adaptive.media.processor.AMAsyncProcessorLocator;
 import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -86,11 +87,9 @@ public class AMImageEntryProcessorTest {
 			invocation -> Stream.empty()
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", true,
+			String.class);
 
 		Mockito.when(
 			_amImageValidator.isValid(_fileVersion)
@@ -117,11 +116,9 @@ public class AMImageEntryProcessorTest {
 			invocation -> Stream.empty()
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			false
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", false,
+			String.class);
 
 		_amImageEntryProcessor.getPreviewAsStream(_fileVersion);
 
@@ -142,11 +139,9 @@ public class AMImageEntryProcessorTest {
 			invocation -> Stream.empty()
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", true,
+			String.class);
 
 		Mockito.when(
 			_amImageValidator.isValid(_fileVersion)
@@ -198,11 +193,9 @@ public class AMImageEntryProcessorTest {
 			invocation -> Stream.empty()
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", true,
+			String.class);
 
 		Mockito.when(
 			_amImageValidator.isValid(_fileVersion)
@@ -229,11 +222,9 @@ public class AMImageEntryProcessorTest {
 			invocation -> Stream.empty()
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			false
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", false,
+			String.class);
 
 		_amImageEntryProcessor.getPreviewFileSize(_fileVersion);
 
@@ -254,11 +245,9 @@ public class AMImageEntryProcessorTest {
 			invocation -> Stream.empty()
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", true,
+			String.class);
 
 		Mockito.when(
 			_amImageValidator.isValid(_fileVersion)
@@ -304,11 +293,9 @@ public class AMImageEntryProcessorTest {
 			invocation -> Stream.empty()
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", true,
+			String.class);
 
 		Mockito.when(
 			_amImageValidator.isValid(_fileVersion)
@@ -335,11 +322,9 @@ public class AMImageEntryProcessorTest {
 			invocation -> Stream.empty()
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			false
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", false,
+			String.class);
 
 		_amImageEntryProcessor.getThumbnailAsStream(_fileVersion, 0);
 
@@ -360,11 +345,9 @@ public class AMImageEntryProcessorTest {
 			invocation -> Stream.empty()
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", true,
+			String.class);
 
 		Mockito.when(
 			_amImageValidator.isValid(_fileVersion)
@@ -416,11 +399,9 @@ public class AMImageEntryProcessorTest {
 			invocation -> Stream.empty()
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", true,
+			String.class);
 
 		Mockito.when(
 			_amImageValidator.isValid(_fileVersion)
@@ -447,11 +428,9 @@ public class AMImageEntryProcessorTest {
 			invocation -> Stream.empty()
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			false
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", false,
+			String.class);
 
 		_amImageEntryProcessor.getThumbnailFileSize(_fileVersion, 0);
 
@@ -472,11 +451,9 @@ public class AMImageEntryProcessorTest {
 			invocation -> Stream.empty()
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", true,
+			String.class);
 
 		Mockito.when(
 			_amImageValidator.isValid(_fileVersion)
@@ -522,11 +499,9 @@ public class AMImageEntryProcessorTest {
 			invocation -> Stream.empty()
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", true,
+			String.class);
 
 		Mockito.when(
 			_amImageValidator.isValid(_fileVersion)
@@ -553,11 +528,9 @@ public class AMImageEntryProcessorTest {
 			invocation -> Stream.empty()
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			false
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", false,
+			String.class);
 
 		_amImageEntryProcessor.hasImages(_fileVersion);
 
@@ -578,11 +551,9 @@ public class AMImageEntryProcessorTest {
 			invocation -> Stream.empty()
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", true,
+			String.class);
 
 		Mockito.when(
 			_amImageValidator.isValid(_fileVersion)
@@ -610,9 +581,10 @@ public class AMImageEntryProcessorTest {
 	private final AMImageFinder _amImageFinder = Mockito.mock(
 		AMImageFinder.class);
 	private final AMImageMimeTypeProvider _amImageMimeTypeProvider =
-		Mockito.mock(AMImageMimeTypeProvider.class);
+		MockHelperUtil.initMock(AMImageMimeTypeProvider.class);
 	private final AMImageValidator _amImageValidator = Mockito.mock(
 		AMImageValidator.class);
-	private final FileVersion _fileVersion = Mockito.mock(FileVersion.class);
+	private final FileVersion _fileVersion = MockHelperUtil.initMock(
+		FileVersion.class);
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-image-content-transformer-backwards-compatibility/src/test/java/com/liferay/adaptive/media/image/content/transformer/backwards/compatibility/internal/AMBackwardsCompatibilityHtmlContentTransformerTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-content-transformer-backwards-compatibility/src/test/java/com/liferay/adaptive/media/image/content/transformer/backwards/compatibility/internal/AMBackwardsCompatibilityHtmlContentTransformerTest.java
@@ -19,6 +19,7 @@ import com.liferay.adaptive.media.image.html.AMImageHTMLTagFactory;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 
 import org.junit.Assert;
@@ -34,12 +35,9 @@ public class AMBackwardsCompatibilityHtmlContentTransformerTest {
 
 	@Before
 	public void setUp() throws Exception {
-		Mockito.when(
-			_amImageHTMLTagFactory.create(
-				Mockito.anyString(), Mockito.any(FileEntry.class))
-		).thenReturn(
-			"[REPLACED]"
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageHTMLTagFactory, "create", "[REPLACED]", String.class,
+			FileEntry.class);
 
 		_contentTransformer.setAMImageHTMLTagFactory(_amImageHTMLTagFactory);
 
@@ -138,13 +136,14 @@ public class AMBackwardsCompatibilityHtmlContentTransformerTest {
 		_CONTENT_PREFIX + "<img src='/documents/20138/0/sample.jpg?t=" +
 			"1506075653544' />" + _CONTENT_SUFFIX;
 
-	private final AMImageHTMLTagFactory _amImageHTMLTagFactory = Mockito.mock(
-		AMImageHTMLTagFactory.class);
+	private final AMImageHTMLTagFactory _amImageHTMLTagFactory =
+		MockHelperUtil.initMock(AMImageHTMLTagFactory.class);
 	private final AMBackwardsCompatibilityHtmlContentTransformer
 		_contentTransformer =
 			new AMBackwardsCompatibilityHtmlContentTransformer();
 	private final DLAppLocalService _dlAppLocalService = Mockito.mock(
 		DLAppLocalService.class);
-	private final FileEntry _fileEntry = Mockito.mock(FileEntry.class);
+	private final FileEntry _fileEntry = MockHelperUtil.initMock(
+		FileEntry.class);
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-image-content-transformer/src/test/java/com/liferay/adaptive/media/image/content/transformer/internal/HtmlContentTransformerImplTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-content-transformer/src/test/java/com/liferay/adaptive/media/image/content/transformer/internal/HtmlContentTransformerImplTest.java
@@ -227,9 +227,7 @@ public class HtmlContentTransformerImplTest {
 	@Mock
 	private DLAppLocalService _dlAppLocalService;
 
-	@Mock
 	private FileEntry _fileEntry;
-
 	private final HtmlContentTransformerImpl _htmlContentTransformer =
 		new HtmlContentTransformerImpl();
 

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/finder/AMImageFinderImplTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/finder/AMImageFinderImplTest.java
@@ -31,6 +31,7 @@ import com.liferay.adaptive.media.image.url.AMImageURLFactory;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 
@@ -90,11 +91,9 @@ public class AMImageFinderImplTest {
 			PortalException.class
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", true,
+			String.class);
 
 		Stream<AdaptiveMedia<AMImageProcessor>> adaptiveMediaStream =
 			_amImageFinderImpl.getAdaptiveMediaStream(
@@ -129,17 +128,11 @@ public class AMImageFinderImplTest {
 			_fileVersion
 		);
 
-		Mockito.when(
-			_fileVersion.getFileName()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getFileName", RandomTestUtil.randomString());
 
-		Mockito.when(
-			_fileVersion.getMimeType()
-		).thenReturn(
-			"image/jpeg"
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getMimeType", "image/jpeg");
 
 		AMImageEntry amImageEntry = _mockImage(800, 900, 1000L);
 
@@ -151,11 +144,9 @@ public class AMImageFinderImplTest {
 			amImageEntry
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", true,
+			String.class);
 
 		Stream<AdaptiveMedia<AMImageProcessor>> adaptiveMediaStream =
 			_amImageFinderImpl.getAdaptiveMediaStream(
@@ -184,17 +175,11 @@ public class AMImageFinderImplTest {
 			Collections.singleton(amImageConfigurationEntry)
 		);
 
-		Mockito.when(
-			_fileVersion.getFileName()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getFileName", RandomTestUtil.randomString());
 
-		Mockito.when(
-			_fileVersion.getMimeType()
-		).thenReturn(
-			"image/jpeg"
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getMimeType", "image/jpeg");
 
 		AMImageEntry amImageEntry = _mockImage(99, 199, 1000L);
 
@@ -206,11 +191,9 @@ public class AMImageFinderImplTest {
 			amImageEntry
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", true,
+			String.class);
 
 		Stream<AdaptiveMedia<AMImageProcessor>> adaptiveMediaStream =
 			_amImageFinderImpl.getAdaptiveMediaStream(
@@ -269,17 +252,11 @@ public class AMImageFinderImplTest {
 			amImageConfigurationEntries
 		);
 
-		Mockito.when(
-			_fileVersion.getFileName()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getFileName", RandomTestUtil.randomString());
 
-		Mockito.when(
-			_fileVersion.getMimeType()
-		).thenReturn(
-			"image/jpeg"
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getMimeType", "image/jpeg");
 
 		AMImageEntry amImageEntry1 = _mockImage(99, 199, 1000L);
 
@@ -311,11 +288,9 @@ public class AMImageFinderImplTest {
 			amImageEntry3
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", true,
+			String.class);
 
 		Stream<AdaptiveMedia<AMImageProcessor>> adaptiveMediaStream =
 			_amImageFinderImpl.getAdaptiveMediaStream(
@@ -388,17 +363,11 @@ public class AMImageFinderImplTest {
 			amImageConfigurationEntries
 		);
 
-		Mockito.when(
-			_fileVersion.getFileName()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getFileName", RandomTestUtil.randomString());
 
-		Mockito.when(
-			_fileVersion.getMimeType()
-		).thenReturn(
-			"image/jpeg"
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getMimeType", "image/jpeg");
 
 		AMImageEntry amImageEntry1 = _mockImage(99, 199, 1000L);
 
@@ -430,11 +399,9 @@ public class AMImageFinderImplTest {
 			amImageEntry3
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", true,
+			String.class);
 
 		Stream<AdaptiveMedia<AMImageProcessor>> adaptiveMediaStream =
 			_amImageFinderImpl.getAdaptiveMediaStream(
@@ -498,11 +465,9 @@ public class AMImageFinderImplTest {
 			AMRuntimeException.InvalidConfiguration.class
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", true,
+			String.class);
 
 		_amImageFinderImpl.getAdaptiveMediaStream(
 			amImageQueryBuilder -> amImageQueryBuilder.forFileVersion(
@@ -528,17 +493,11 @@ public class AMImageFinderImplTest {
 			Collections.singleton(amImageConfigurationEntry)
 		);
 
-		Mockito.when(
-			_fileVersion.getFileName()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getFileName", RandomTestUtil.randomString());
 
-		Mockito.when(
-			_fileVersion.getMimeType()
-		).thenReturn(
-			"image/jpeg"
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getMimeType", "image/jpeg");
 
 		AMImageEntry amImageEntry = _mockImage(800, 900, 1000L);
 
@@ -550,11 +509,9 @@ public class AMImageFinderImplTest {
 			amImageEntry
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", true,
+			String.class);
 
 		InputStream inputStream = Mockito.mock(InputStream.class);
 
@@ -601,17 +558,11 @@ public class AMImageFinderImplTest {
 			Collections.singleton(amImageConfigurationEntry)
 		);
 
-		Mockito.when(
-			_fileVersion.getFileName()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getFileName", RandomTestUtil.randomString());
 
-		Mockito.when(
-			_fileVersion.getMimeType()
-		).thenReturn(
-			"image/jpeg"
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getMimeType", "image/jpeg");
 
 		AMImageEntry amImageEntry = _mockImage(99, 1000, 1000L);
 
@@ -623,11 +574,9 @@ public class AMImageFinderImplTest {
 			amImageEntry
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", true,
+			String.class);
 
 		Stream<AdaptiveMedia<AMImageProcessor>> adaptiveMediaStream =
 			_amImageFinderImpl.getAdaptiveMediaStream(
@@ -679,17 +628,11 @@ public class AMImageFinderImplTest {
 				amImageConfigurationEntry1, amImageConfigurationEntry2)
 		);
 
-		Mockito.when(
-			_fileVersion.getFileName()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getFileName", RandomTestUtil.randomString());
 
-		Mockito.when(
-			_fileVersion.getMimeType()
-		).thenReturn(
-			"image/jpeg"
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getMimeType", "image/jpeg");
 
 		AMImageEntry amImageEntry1 = _mockImage(99, 199, 1000L);
 
@@ -711,11 +654,9 @@ public class AMImageFinderImplTest {
 			amImageEntry2
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", true,
+			String.class);
 
 		Stream<AdaptiveMedia<AMImageProcessor>> adaptiveMediaStream =
 			_amImageFinderImpl.getAdaptiveMediaStream(
@@ -771,17 +712,11 @@ public class AMImageFinderImplTest {
 				amImageConfigurationEntry1, amImageConfigurationEntry2)
 		);
 
-		Mockito.when(
-			_fileVersion.getFileName()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getFileName", RandomTestUtil.randomString());
 
-		Mockito.when(
-			_fileVersion.getMimeType()
-		).thenReturn(
-			"image/jpeg"
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getMimeType", "image/jpeg");
 
 		AMImageEntry amImageEntry1 = _mockImage(99, 199, 1000L);
 
@@ -803,11 +738,9 @@ public class AMImageFinderImplTest {
 			amImageEntry2
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", true,
+			String.class);
 
 		Stream<AdaptiveMedia<AMImageProcessor>> adaptiveMediaStream =
 			_amImageFinderImpl.getAdaptiveMediaStream(
@@ -863,17 +796,11 @@ public class AMImageFinderImplTest {
 				amImageConfigurationEntry1, amImageConfigurationEntry2)
 		);
 
-		Mockito.when(
-			_fileVersion.getFileName()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getFileName", RandomTestUtil.randomString());
 
-		Mockito.when(
-			_fileVersion.getMimeType()
-		).thenReturn(
-			"image/jpeg"
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getMimeType", "image/jpeg");
 
 		AMImageEntry amImageEntry1 = _mockImage(99, 199, 1000L);
 
@@ -895,11 +822,9 @@ public class AMImageFinderImplTest {
 			amImageEntry2
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", true,
+			String.class);
 
 		Stream<AdaptiveMedia<AMImageProcessor>> adaptiveMediaStream =
 			_amImageFinderImpl.getAdaptiveMediaStream(
@@ -955,17 +880,11 @@ public class AMImageFinderImplTest {
 				amImageConfigurationEntry1, amImageConfigurationEntry2)
 		);
 
-		Mockito.when(
-			_fileVersion.getFileName()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getFileName", RandomTestUtil.randomString());
 
-		Mockito.when(
-			_fileVersion.getMimeType()
-		).thenReturn(
-			"image/jpeg"
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getMimeType", "image/jpeg");
 
 		AMImageEntry amImageEntry1 = _mockImage(99, 199, 1000L);
 
@@ -987,11 +906,9 @@ public class AMImageFinderImplTest {
 			amImageEntry2
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", true,
+			String.class);
 
 		Stream<AdaptiveMedia<AMImageProcessor>> adaptiveMediaStream =
 			_amImageFinderImpl.getAdaptiveMediaStream(
@@ -1058,17 +975,11 @@ public class AMImageFinderImplTest {
 			Arrays.asList(amImageConfigurationEntry1)
 		);
 
-		Mockito.when(
-			_fileVersion.getFileName()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getFileName", RandomTestUtil.randomString());
 
-		Mockito.when(
-			_fileVersion.getMimeType()
-		).thenReturn(
-			"image/jpeg"
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getMimeType", "image/jpeg");
 
 		AMImageEntry amImageEntry1 = _mockImage(99, 199, 1000L);
 
@@ -1090,11 +1001,9 @@ public class AMImageFinderImplTest {
 			amImageEntry2
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", true,
+			String.class);
 
 		Stream<AdaptiveMedia<AMImageProcessor>> adaptiveMediaStream =
 			_amImageFinderImpl.getAdaptiveMediaStream(
@@ -1205,17 +1114,11 @@ public class AMImageFinderImplTest {
 				amImageConfigurationEntry1, amImageConfigurationEntry2)
 		);
 
-		Mockito.when(
-			_fileVersion.getFileName()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getFileName", RandomTestUtil.randomString());
 
-		Mockito.when(
-			_fileVersion.getMimeType()
-		).thenReturn(
-			"image/jpeg"
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getMimeType", "image/jpeg");
 
 		AMImageEntry amImageEntry1 = _mockImage(100, 1000, 1000L);
 
@@ -1237,11 +1140,9 @@ public class AMImageFinderImplTest {
 			amImageEntry2
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", true,
+			String.class);
 
 		Stream<AdaptiveMedia<AMImageProcessor>> adaptiveMediaStream =
 			_amImageFinderImpl.getAdaptiveMediaStream(
@@ -1337,17 +1238,11 @@ public class AMImageFinderImplTest {
 				amImageConfigurationEntry1, amImageConfigurationEntry2)
 		);
 
-		Mockito.when(
-			_fileVersion.getFileName()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getFileName", RandomTestUtil.randomString());
 
-		Mockito.when(
-			_fileVersion.getMimeType()
-		).thenReturn(
-			"image/jpeg"
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getMimeType", "image/jpeg");
 
 		AMImageEntry amImageEntry1 = _mockImage(99, 1000, 1000L);
 
@@ -1369,11 +1264,9 @@ public class AMImageFinderImplTest {
 			amImageEntry2
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", true,
+			String.class);
 
 		Stream<AdaptiveMedia<AMImageProcessor>> adaptiveMediaStream =
 			_amImageFinderImpl.getAdaptiveMediaStream(
@@ -1407,11 +1300,9 @@ public class AMImageFinderImplTest {
 
 	@Test
 	public void testGetMediaWhenNotSupported() throws Exception {
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			false
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", false,
+			String.class);
 
 		Stream<AdaptiveMedia<AMImageProcessor>> adaptiveMediaStream =
 			_amImageFinderImpl.getAdaptiveMediaStream(
@@ -1450,17 +1341,11 @@ public class AMImageFinderImplTest {
 			Collections.singleton(amImageConfigurationEntry)
 		);
 
-		Mockito.when(
-			_fileVersion.getFileName()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getFileName", RandomTestUtil.randomString());
 
-		Mockito.when(
-			_fileVersion.getMimeType()
-		).thenReturn(
-			"image/jpeg"
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getMimeType", "image/jpeg");
 
 		AMImageEntry amImageEntry = _mockImage(99, 99, 1000L);
 
@@ -1472,11 +1357,9 @@ public class AMImageFinderImplTest {
 			amImageEntry
 		);
 
-		Mockito.when(
-			_amImageMimeTypeProvider.isMimeTypeSupported(Mockito.anyString())
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_amImageMimeTypeProvider, "isMimeTypeSupported", true,
+			String.class);
 
 		Stream<AdaptiveMedia<AMImageProcessor>> adaptiveMediaStream =
 			_amImageFinderImpl.getAdaptiveMediaStream(
@@ -1499,26 +1382,19 @@ public class AMImageFinderImplTest {
 		);
 	}
 
-	private AMImageEntry _mockImage(int height, int width, long size) {
-		AMImageEntry amImageEntry = Mockito.mock(AMImageEntry.class);
+	private AMImageEntry _mockImage(int height, int width, long size)
+		throws Exception {
 
-		Mockito.when(
-			amImageEntry.getHeight()
-		).thenReturn(
-			height
-		);
+		AMImageEntry amImageEntry = MockHelperUtil.initMock(AMImageEntry.class);
 
-		Mockito.when(
-			amImageEntry.getWidth()
-		).thenReturn(
-			width
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			amImageEntry, "getHeight", height);
 
-		Mockito.when(
-			amImageEntry.getSize()
-		).thenReturn(
-			size
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			amImageEntry, "getWidth", width);
+
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			amImageEntry, "getSize", size);
 
 		return amImageEntry;
 	}
@@ -1530,10 +1406,11 @@ public class AMImageFinderImplTest {
 	private final AMImageFinderImpl _amImageFinderImpl =
 		new AMImageFinderImpl();
 	private final AMImageMimeTypeProvider _amImageMimeTypeProvider =
-		Mockito.mock(AMImageMimeTypeProvider.class);
-	private final AMImageURLFactory _amImageURLFactory = Mockito.mock(
-		AMImageURLFactory.class);
+		MockHelperUtil.initMock(AMImageMimeTypeProvider.class);
+	private final AMImageURLFactory _amImageURLFactory =
+		MockHelperUtil.initMock(AMImageURLFactory.class);
 	private final FileEntry _fileEntry = Mockito.mock(FileEntry.class);
-	private final FileVersion _fileVersion = Mockito.mock(FileVersion.class);
+	private final FileVersion _fileVersion = MockHelperUtil.initMock(
+		FileVersion.class);
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/finder/AMImageQueryBuilderImplTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/finder/AMImageQueryBuilderImplTest.java
@@ -22,6 +22,7 @@ import com.liferay.adaptive.media.image.processor.AMImageAttribute;
 import com.liferay.adaptive.media.image.processor.AMImageProcessor;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 
 import java.util.Collections;
@@ -32,8 +33,6 @@ import java.util.function.Predicate;
 import org.junit.Assert;
 import org.junit.Test;
 
-import org.mockito.Mockito;
-
 /**
  * @author Adolfo Pérez
  */
@@ -41,7 +40,7 @@ public class AMImageQueryBuilderImplTest {
 
 	@Test
 	public void testFileEntryQueryReturnsLatestFileVersion() throws Exception {
-		FileEntry fileEntry = Mockito.mock(FileEntry.class);
+		FileEntry fileEntry = MockHelperUtil.initMock(FileEntry.class);
 
 		_amImageQueryBuilderImpl.forFileEntry(fileEntry);
 
@@ -54,7 +53,7 @@ public class AMImageQueryBuilderImplTest {
 	public void testFileEntryWithAttributesQueryReturnsLatestFileVersion()
 		throws Exception {
 
-		FileEntry fileEntry = Mockito.mock(FileEntry.class);
+		FileEntry fileEntry = MockHelperUtil.initMock(FileEntry.class);
 
 		_amImageQueryBuilderImpl.forFileEntry(
 			fileEntry
@@ -67,7 +66,7 @@ public class AMImageQueryBuilderImplTest {
 
 	@Test
 	public void testMatchingConfigurationAttributeQuery() {
-		FileVersion fileVersion = Mockito.mock(FileVersion.class);
+		FileVersion fileVersion = MockHelperUtil.initMock(FileVersion.class);
 
 		_amImageQueryBuilderImpl.forFileVersion(
 			fileVersion
@@ -88,7 +87,7 @@ public class AMImageQueryBuilderImplTest {
 
 	@Test
 	public void testNonmatchingConfigurationAttributeQuery() {
-		FileVersion fileVersion = Mockito.mock(FileVersion.class);
+		FileVersion fileVersion = MockHelperUtil.initMock(FileVersion.class);
 
 		_amImageQueryBuilderImpl.forFileVersion(
 			fileVersion
@@ -109,7 +108,7 @@ public class AMImageQueryBuilderImplTest {
 
 	@Test
 	public void testNonnullOptionalAttributeQuery() {
-		FileVersion fileVersion = Mockito.mock(FileVersion.class);
+		FileVersion fileVersion = MockHelperUtil.initMock(FileVersion.class);
 
 		_amImageQueryBuilderImpl.forFileVersion(
 			fileVersion
@@ -126,7 +125,7 @@ public class AMImageQueryBuilderImplTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testNullAttributeFailsWhenOrderingByIt() {
-		FileVersion fileVersion = Mockito.mock(FileVersion.class);
+		FileVersion fileVersion = MockHelperUtil.initMock(FileVersion.class);
 
 		_amImageQueryBuilderImpl.forFileVersion(
 			fileVersion
@@ -137,7 +136,7 @@ public class AMImageQueryBuilderImplTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testNullAttributeValueFailsWhenQueryingAttributes() {
-		FileVersion fileVersion = Mockito.mock(FileVersion.class);
+		FileVersion fileVersion = MockHelperUtil.initMock(FileVersion.class);
 
 		_amImageQueryBuilderImpl.forFileVersion(
 			fileVersion
@@ -153,7 +152,7 @@ public class AMImageQueryBuilderImplTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testNullConfigurationUUIDFailsWhenQueryingAttributes() {
-		FileVersion fileVersion = Mockito.mock(FileVersion.class);
+		FileVersion fileVersion = MockHelperUtil.initMock(FileVersion.class);
 
 		_amImageQueryBuilderImpl.forFileVersion(
 			fileVersion
@@ -184,7 +183,7 @@ public class AMImageQueryBuilderImplTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testNullOptionalAttributeValueFailsWhenQueryingAttributes() {
-		FileVersion fileVersion = Mockito.mock(FileVersion.class);
+		FileVersion fileVersion = MockHelperUtil.initMock(FileVersion.class);
 
 		_amImageQueryBuilderImpl.forFileVersion(
 			fileVersion

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/media/query/MediaQueryProviderImplTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/media/query/MediaQueryProviderImplTest.java
@@ -809,9 +809,7 @@ public class MediaQueryProviderImplTest {
 	@Mock
 	private FileEntry _fileEntry;
 
-	@Mock
 	private FileVersion _fileVersion;
-
 	private final MediaQueryProviderImpl _mediaQueryProvider =
 		new MediaQueryProviderImpl();
 

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/media/query/MediaQueryProviderImplTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/media/query/MediaQueryProviderImplTest.java
@@ -33,6 +33,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 
 import java.net.URI;
 
@@ -61,24 +62,18 @@ import org.mockito.runners.MockitoJUnitRunner;
 public class MediaQueryProviderImplTest {
 
 	@Before
-	public void setUp() throws PortalException {
+	public void setUp() throws Exception {
 		Mockito.when(
 			_amImageFinder.getAdaptiveMediaStream(Mockito.any(Function.class))
 		).thenAnswer(
 			invocation -> Stream.empty()
 		);
 
-		Mockito.when(
-			_fileEntry.getCompanyId()
-		).thenReturn(
-			_COMPANY_ID
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileEntry, "getCompanyId", _COMPANY_ID);
 
-		Mockito.when(
-			_fileEntry.getFileVersion()
-		).thenReturn(
-			_fileVersion
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileEntry, "getFileVersion", _fileVersion);
 
 		_mediaQueryProvider.setAMImageConfigurationHelper(
 			_amImageConfigurationHelper);
@@ -806,9 +801,8 @@ public class MediaQueryProviderImplTest {
 	@Mock
 	private AMImageURLFactory _amImageURLFactory;
 
-	@Mock
-	private FileEntry _fileEntry;
-
+	private final FileEntry _fileEntry = MockHelperUtil.initMock(
+		FileEntry.class);
 	private FileVersion _fileVersion;
 	private final MediaQueryProviderImpl _mediaQueryProvider =
 		new MediaQueryProviderImpl();

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/processor/AMImageProcessorImplTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/processor/AMImageProcessorImplTest.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.image.ImageTool;
 import com.liferay.portal.kernel.image.ImageToolUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 
 import java.io.InputStream;
@@ -163,17 +164,11 @@ public class AMImageProcessorImplTest {
 			Mockito.mock(AMImageEntry.class)
 		);
 
-		Mockito.when(
-			_fileVersion.getFileEntry()
-		).thenReturn(
-			_fileEntry
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getFileEntry", _fileEntry);
 
-		Mockito.when(
-			_fileEntry.isCheckedOut()
-		).thenReturn(
-			false
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileEntry, "isCheckedOut", false);
 
 		_amImageProcessorImpl.process(
 			_fileVersion, RandomTestUtil.randomString());
@@ -213,17 +208,11 @@ public class AMImageProcessorImplTest {
 			Mockito.mock(AMImageEntry.class)
 		);
 
-		Mockito.when(
-			_fileVersion.getFileEntry()
-		).thenReturn(
-			_fileEntry
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getFileEntry", _fileEntry);
 
-		Mockito.when(
-			_fileEntry.isCheckedOut()
-		).thenReturn(
-			true
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileEntry, "isCheckedOut", true);
 
 		Mockito.when(
 			_amImageScalerTracker.getAMImageScaler(Mockito.anyString())
@@ -635,8 +624,10 @@ public class AMImageProcessorImplTest {
 		AMImageScalerTracker.class);
 	private final AMImageValidator _amImageValidator = Mockito.mock(
 		AMImageValidator.class);
-	private final FileEntry _fileEntry = Mockito.mock(FileEntry.class);
-	private final FileVersion _fileVersion = Mockito.mock(FileVersion.class);
+	private final FileEntry _fileEntry = MockHelperUtil.initMock(
+		FileEntry.class);
+	private final FileVersion _fileVersion = MockHelperUtil.initMock(
+		FileVersion.class);
 	private ImageTool _imageTool;
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/processor/AMImageProcessorImplTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/processor/AMImageProcessorImplTest.java
@@ -637,6 +637,6 @@ public class AMImageProcessorImplTest {
 		AMImageValidator.class);
 	private final FileEntry _fileEntry = Mockito.mock(FileEntry.class);
 	private final FileVersion _fileVersion = Mockito.mock(FileVersion.class);
-	private final ImageTool _imageTool = Mockito.mock(ImageTool.class);
+	private ImageTool _imageTool;
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/url/AMImageURLFactoryImplTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/url/AMImageURLFactoryImplTest.java
@@ -18,6 +18,7 @@ import com.liferay.adaptive.media.AMURIResolver;
 import com.liferay.adaptive.media.image.configuration.AMImageConfigurationEntry;
 import com.liferay.adaptive.media.image.internal.configuration.AMImageConfigurationEntryImpl;
 import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 
 import java.net.URI;
 
@@ -40,23 +41,14 @@ public class AMImageURLFactoryImplTest {
 
 	@Before
 	public void setUp() throws Exception {
-		Mockito.when(
-			_fileVersion.getFileEntryId()
-		).thenReturn(
-			1L
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getFileEntryId", 1L);
 
-		Mockito.when(
-			_fileVersion.getFileName()
-		).thenReturn(
-			"fileName"
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getFileName", "fileName");
 
-		Mockito.when(
-			_fileVersion.getFileVersionId()
-		).thenReturn(
-			2L
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileVersion, "getFileVersionId", 2L);
 
 		Mockito.when(
 			_amURIResolver.resolveURI(Mockito.any(URI.class))
@@ -94,7 +86,7 @@ public class AMImageURLFactoryImplTest {
 	@Mock
 	private AMURIResolver _amURIResolver;
 
-	@Mock
-	private FileVersion _fileVersion;
+	private final FileVersion _fileVersion = MockHelperUtil.initMock(
+		FileVersion.class);
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-image-web/src/test/java/com/liferay/adaptive/media/image/web/internal/html/AMImageHTMLTagFactoryImplTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-web/src/test/java/com/liferay/adaptive/media/image/web/internal/html/AMImageHTMLTagFactoryImplTest.java
@@ -19,8 +19,8 @@ import com.liferay.adaptive.media.image.media.query.MediaQuery;
 import com.liferay.adaptive.media.image.media.query.MediaQueryProvider;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 
 import java.util.Arrays;
@@ -42,14 +42,11 @@ import org.mockito.runners.MockitoJUnitRunner;
 public class AMImageHTMLTagFactoryImplTest {
 
 	@Before
-	public void setUp() throws PortalException {
+	public void setUp() throws Exception {
 		_amImageHTMLTagFactory.setMediaQueryProvider(_mediaQueryProvider);
 
-		Mockito.when(
-			_fileEntry.getFileEntryId()
-		).thenReturn(
-			1234L
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_fileEntry, "getFileEntryId", 1234L);
 	}
 
 	@Test
@@ -198,9 +195,8 @@ public class AMImageHTMLTagFactoryImplTest {
 
 	private final AMImageHTMLTagFactoryImpl _amImageHTMLTagFactory =
 		new AMImageHTMLTagFactoryImpl();
-
-	@Mock
-	private FileEntry _fileEntry;
+	private final FileEntry _fileEntry = MockHelperUtil.initMock(
+		FileEntry.class);
 
 	@Mock
 	private MediaQueryProvider _mediaQueryProvider;

--- a/modules/apps/adaptive-media/adaptive-media-journal-editor-configuration/src/test/java/com/liferay/adaptive/media/journal/editor/configuration/internal/AMJournalEditorConfigContributorTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-journal-editor-configuration/src/test/java/com/liferay/adaptive/media/journal/editor/configuration/internal/AMJournalEditorConfigContributorTest.java
@@ -594,10 +594,7 @@ public class AMJournalEditorConfigContributorTest extends PowerMockito {
 	@Mock
 	private ItemSelector _itemSelector;
 
-	@Mock
 	private RequestBackedPortletURLFactory _requestBackedPortletURLFactory;
-
-	@Mock
 	private ThemeDisplay _themeDisplay;
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-journal-editor-configuration/src/test/java/com/liferay/adaptive/media/journal/editor/configuration/internal/AMJournalEditorConfigContributorTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-journal-editor-configuration/src/test/java/com/liferay/adaptive/media/journal/editor/configuration/internal/AMJournalEditorConfigContributorTest.java
@@ -27,6 +27,7 @@ import com.liferay.portal.json.JSONFactoryImpl;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 
 import java.util.ArrayList;
@@ -70,13 +71,9 @@ public class AMJournalEditorConfigContributorTest extends PowerMockito {
 	public void testAdaptiveMediaFileEntryAttributeNameIsAdded()
 		throws Exception {
 
-		PortletURL itemSelectorPortletURL = mock(PortletURL.class);
-
-		when(
-			itemSelectorPortletURL.toString()
-		).thenReturn(
-			"itemSelectorPortletURL"
-		);
+		PortletURL itemSelectorPortletURL =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				PortletURL.class, "toString", "itemSelectorPortletURL");
 
 		when(
 			_itemSelector.getItemSelectorURL(
@@ -124,13 +121,9 @@ public class AMJournalEditorConfigContributorTest extends PowerMockito {
 
 	@Test
 	public void testAdaptiveMediaIsAddedToExtraPlugins() throws Exception {
-		PortletURL itemSelectorPortletURL = mock(PortletURL.class);
-
-		when(
-			itemSelectorPortletURL.toString()
-		).thenReturn(
-			"itemSelectorPortletURL"
-		);
+		PortletURL itemSelectorPortletURL =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				PortletURL.class, "toString", "itemSelectorPortletURL");
 
 		when(
 			_itemSelector.getItemSelectorURL(
@@ -177,13 +170,9 @@ public class AMJournalEditorConfigContributorTest extends PowerMockito {
 
 	@Test
 	public void testAdaptiveMediaIsExtraPlugins() throws Exception {
-		PortletURL itemSelectorPortletURL = mock(PortletURL.class);
-
-		when(
-			itemSelectorPortletURL.toString()
-		).thenReturn(
-			"itemSelectorPortletURL"
-		);
+		PortletURL itemSelectorPortletURL =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				PortletURL.class, "toString", "itemSelectorPortletURL");
 
 		when(
 			_itemSelector.getItemSelectorURL(
@@ -423,13 +412,9 @@ public class AMJournalEditorConfigContributorTest extends PowerMockito {
 	public void testItemSelectorURLWithBlogsItemSelectorCriterion()
 		throws Exception {
 
-		PortletURL itemSelectorPortletURL = mock(PortletURL.class);
-
-		when(
-			itemSelectorPortletURL.toString()
-		).thenReturn(
-			"itemSelectorPortletURL"
-		);
+		PortletURL itemSelectorPortletURL =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				PortletURL.class, "toString", "itemSelectorPortletURL");
 
 		when(
 			_itemSelector.getItemSelectorURL(
@@ -482,13 +467,9 @@ public class AMJournalEditorConfigContributorTest extends PowerMockito {
 	public void testItemSelectorURLWithFileItemSelectorCriterion()
 		throws Exception {
 
-		PortletURL itemSelectorPortletURL = mock(PortletURL.class);
-
-		when(
-			itemSelectorPortletURL.toString()
-		).thenReturn(
-			"itemSelectorPortletURL"
-		);
+		PortletURL itemSelectorPortletURL =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				PortletURL.class, "toString", "itemSelectorPortletURL");
 
 		when(
 			_itemSelector.getItemSelectorURL(

--- a/modules/apps/adaptive-media/adaptive-media-upload/src/test/java/com/liferay/adaptive/media/upload/web/internal/attachment/AMHTMLImageAttachmentElementHandlerTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-upload/src/test/java/com/liferay/adaptive/media/upload/web/internal/attachment/AMHTMLImageAttachmentElementHandlerTest.java
@@ -15,6 +15,7 @@
 package com.liferay.adaptive.media.upload.web.internal.attachment;
 
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.upload.AttachmentElementReplacer;
 
@@ -32,14 +33,9 @@ import org.powermock.api.mockito.PowerMockito;
 public class AMHTMLImageAttachmentElementHandlerTest extends PowerMockito {
 
 	@Before
-	public void setUp() {
-		_fileEntry = mock(FileEntry.class);
-
-		when(
-			_fileEntry.getFileEntryId()
-		).thenReturn(
-			_IMAGE_FILE_ENTRY_ID
-		);
+	public void setUp() throws Exception {
+		_fileEntry = MockHelperUtil.setMethodAlwaysReturnExpected(
+			FileEntry.class, "getFileEntryId", _IMAGE_FILE_ENTRY_ID);
 
 		_defaultAttachmentElementReplacer = mock(
 			AttachmentElementReplacer.class);

--- a/modules/apps/adaptive-media/adaptive-media-web/src/test/java/com/liferay/adaptive/media/web/internal/processor/DefaultAMURIResolverTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/test/java/com/liferay/adaptive/media/web/internal/processor/DefaultAMURIResolverTest.java
@@ -18,6 +18,7 @@ import com.liferay.adaptive.media.AMURIResolver;
 import com.liferay.adaptive.media.web.internal.constants.AMWebConstants;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -27,8 +28,6 @@ import java.net.URI;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import org.mockito.Mockito;
 
 /**
  * @author Adolfo Pérez
@@ -45,14 +44,11 @@ public class DefaultAMURIResolverTest {
 	}
 
 	@Test
-	public void testMediaURIWhenPathDoesNotEndInSlash() {
+	public void testMediaURIWhenPathDoesNotEndInSlash() throws Exception {
 		String pathModule = StringPool.SLASH + RandomTestUtil.randomString();
 
-		Mockito.when(
-			_portal.getPathModule()
-		).thenReturn(
-			pathModule
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_portal, "getPathModule", pathModule);
 
 		URI relativeURI = URI.create(RandomTestUtil.randomString());
 
@@ -68,15 +64,12 @@ public class DefaultAMURIResolverTest {
 	}
 
 	@Test
-	public void testMediaURIWhenPathEndsInSlash() {
+	public void testMediaURIWhenPathEndsInSlash() throws Exception {
 		String pathModule =
 			StringPool.SLASH + RandomTestUtil.randomString() + StringPool.SLASH;
 
-		Mockito.when(
-			_portal.getPathModule()
-		).thenReturn(
-			pathModule
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_portal, "getPathModule", pathModule);
 
 		URI relativeURI = URI.create(RandomTestUtil.randomString());
 
@@ -92,6 +85,6 @@ public class DefaultAMURIResolverTest {
 	}
 
 	private final AMURIResolver _amURIResolver = new DefaultAMURIResolver();
-	private final Portal _portal = Mockito.mock(Portal.class);
+	private final Portal _portal = MockHelperUtil.initMock(Portal.class);
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-web/src/test/java/com/liferay/adaptive/media/web/internal/servlet/AMServletTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/test/java/com/liferay/adaptive/media/web/internal/servlet/AMServletTest.java
@@ -17,6 +17,7 @@ package com.liferay.adaptive.media.web.internal.servlet;
 import com.liferay.adaptive.media.exception.AMException;
 import com.liferay.adaptive.media.handler.AMRequestHandler;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 
 import java.util.Optional;
@@ -42,11 +43,8 @@ public class AMServletTest {
 
 	@Test
 	public void testMiscellaneousError() throws Exception {
-		Mockito.when(
-			_request.getPathInfo()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_request, "getPathInfo", RandomTestUtil.randomString());
 
 		Mockito.when(
 			_amRequestHandlerLocator.locateForPattern(Mockito.anyString())
@@ -71,11 +69,8 @@ public class AMServletTest {
 
 	@Test
 	public void testNoMediaFound() throws Exception {
-		Mockito.when(
-			_request.getPathInfo()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_request, "getPathInfo", RandomTestUtil.randomString());
 
 		Mockito.when(
 			_amRequestHandlerLocator.locateForPattern(Mockito.anyString())
@@ -100,11 +95,8 @@ public class AMServletTest {
 
 	@Test
 	public void testNoMediaFoundWithException() throws Exception {
-		Mockito.when(
-			_request.getPathInfo()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_request, "getPathInfo", RandomTestUtil.randomString());
 
 		Mockito.when(
 			_amRequestHandlerLocator.locateForPattern(Mockito.anyString())
@@ -129,11 +121,8 @@ public class AMServletTest {
 
 	@Test
 	public void testNoPermissionError() throws Exception {
-		Mockito.when(
-			_request.getPathInfo()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_request, "getPathInfo", RandomTestUtil.randomString());
 
 		Mockito.when(
 			_amRequestHandlerLocator.locateForPattern(Mockito.anyString())
@@ -158,11 +147,8 @@ public class AMServletTest {
 
 	@Test
 	public void testNoRequestHandlerFound() throws Exception {
-		Mockito.when(
-			_request.getPathInfo()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_request, "getPathInfo", RandomTestUtil.randomString());
 
 		Mockito.when(
 			_amRequestHandlerLocator.locateForPattern(Mockito.anyString())
@@ -184,7 +170,7 @@ public class AMServletTest {
 	private final AMRequestHandlerLocator _amRequestHandlerLocator =
 		Mockito.mock(AMRequestHandlerLocator.class);
 	private final AMServlet _amServlet = new AMServlet();
-	private final HttpServletRequest _request = Mockito.mock(
+	private final HttpServletRequest _request = MockHelperUtil.initMock(
 		HttpServletRequest.class);
 	private final HttpServletResponse _response = Mockito.mock(
 		HttpServletResponse.class);

--- a/modules/apps/apio-architect/apio-architect-impl/src/test/java/com/liferay/apio/architect/impl/pagination/PageTypeTest.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/test/java/com/liferay/apio/architect/impl/pagination/PageTypeTest.java
@@ -19,34 +19,22 @@ import static org.hamcrest.Matchers.is;
 import static org.springframework.test.util.MatcherAssertionErrors.assertThat;
 
 import com.liferay.apio.architect.pagination.Page;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
 
 /**
  * @author Alejandro Hernández
  */
-@RunWith(MockitoJUnitRunner.class)
 public class PageTypeTest {
 
 	@Before
-	public void setUp() {
-		Mockito.when(
-			_page.getPageNumber()
-		).thenReturn(
-			3
-		);
+	public void setUp() throws Exception {
+		MockHelperUtil.setMethodAlwaysReturnExpected(_page, "getPageNumber", 3);
 
-		Mockito.when(
-			_page.getLastPageNumber()
-		).thenReturn(
-			5
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_page, "getLastPageNumber", 5);
 	}
 
 	@Test
@@ -78,12 +66,11 @@ public class PageTypeTest {
 	}
 
 	@Test
-	public void testCallingPageNumberOnNextWithLastPageReturnsLast() {
-		Mockito.when(
-			_page.getLastPageNumber()
-		).thenReturn(
-			3
-		);
+	public void testCallingPageNumberOnNextWithLastPageReturnsLast()
+		throws Exception {
+
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_page, "getLastPageNumber", 3);
 
 		Integer pageNumber = PageType.NEXT.getPageNumber(_page);
 
@@ -98,19 +85,16 @@ public class PageTypeTest {
 	}
 
 	@Test
-	public void testCallingPageNumberOnPreviousWithPageOneReturnsOne() {
-		Mockito.when(
-			_page.getPageNumber()
-		).thenReturn(
-			1
-		);
+	public void testCallingPageNumberOnPreviousWithPageOneReturnsOne()
+		throws Exception {
+
+		MockHelperUtil.setMethodAlwaysReturnExpected(_page, "getPageNumber", 1);
 
 		Integer pageNumber = PageType.PREVIOUS.getPageNumber(_page);
 
 		assertThat(pageNumber, is(1));
 	}
 
-	@Mock
-	private final Page _page = Mockito.mock(Page.class);
+	private final Page _page = MockHelperUtil.initMock(Page.class);
 
 }

--- a/modules/apps/apio-architect/apio-architect-impl/src/test/java/com/liferay/apio/architect/impl/provider/FieldsProviderTest.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/test/java/com/liferay/apio/architect/impl/provider/FieldsProviderTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.liferay.apio.architect.impl.response.control.Fields;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 
 import java.util.Collections;
 import java.util.Map;
@@ -27,15 +28,15 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.junit.Test;
 
-import org.mockito.Mockito;
-
 /**
  * @author Alejandro Hernández
  */
 public class FieldsProviderTest {
 
 	@Test
-	public void testFieldsProviderReturnsAlwaysTrueIfEmptyFields() {
+	public void testFieldsProviderReturnsAlwaysTrueIfEmptyFields()
+		throws Exception {
+
 		Predicate<String> predicate = _getPredicate("");
 
 		assertThat(predicate.test("alternateName"), is(true));
@@ -44,7 +45,9 @@ public class FieldsProviderTest {
 	}
 
 	@Test
-	public void testFieldsProviderReturnsAlwaysTrueIfInvalidParam() {
+	public void testFieldsProviderReturnsAlwaysTrueIfInvalidParam()
+		throws Exception {
+
 		Predicate<String> predicate = _getPredicate(
 			"description", "familyName", "givenName");
 
@@ -54,27 +57,26 @@ public class FieldsProviderTest {
 	}
 
 	@Test
-	public void testFieldsProviderReturnValidFields() {
+	public void testFieldsProviderReturnValidFields() throws Exception {
 		Predicate<String> predicate = _getPredicate("familyName,givenName");
 
 		assertThat(predicate.test("alternateName"), is(false));
 		assertThat(predicate.test("givenName"), is(true));
 	}
 
-	private Predicate<String> _getPredicate(String... personFields) {
+	private Predicate<String> _getPredicate(String... personFields)
+		throws Exception {
+
 		FieldsProvider fieldsProvider = new FieldsProvider();
 
-		HttpServletRequest httpServletRequest = Mockito.mock(
+		HttpServletRequest httpServletRequest = MockHelperUtil.initMock(
 			HttpServletRequest.class);
 
 		Map<String, String[]> parameterMap = Collections.singletonMap(
 			"fields[Person]", personFields);
 
-		Mockito.when(
-			httpServletRequest.getParameterMap()
-		).thenReturn(
-			parameterMap
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			httpServletRequest, "getParameterMap", parameterMap);
 
 		Fields fields = fieldsProvider.createContext(httpServletRequest);
 

--- a/modules/apps/apio-architect/apio-architect-impl/src/test/java/com/liferay/apio/architect/impl/url/URLCreatorTest.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/test/java/com/liferay/apio/architect/impl/url/URLCreatorTest.java
@@ -43,6 +43,7 @@ import com.liferay.apio.architect.pagination.Page;
 import com.liferay.apio.architect.pagination.PageItems;
 import com.liferay.apio.architect.pagination.Pagination;
 import com.liferay.apio.architect.uri.Path;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -51,8 +52,6 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import org.junit.Test;
-
-import org.mockito.Mockito;
 
 /**
  * @author Alejandro Hernández
@@ -98,20 +97,12 @@ public class URLCreatorTest {
 	}
 
 	@Test
-	public void testCreateCollectionPageURL() {
-		Pagination pagination = Mockito.mock(Pagination.class);
+	public void testCreateCollectionPageURL() throws Exception {
+		Pagination pagination = MockHelperUtil.setMethodAlwaysReturnExpected(
+			Pagination.class, "getItemsPerPage", 30);
 
-		Mockito.when(
-			pagination.getItemsPerPage()
-		).thenReturn(
-			30
-		);
-
-		Mockito.when(
-			pagination.getPageNumber()
-		).thenReturn(
-			1
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			Pagination.class, "getPageNumber", 1);
 
 		PageItems<String> pageItems = new PageItems<>(emptyList(), 0);
 

--- a/modules/apps/blogs/blogs-test/src/test/java/com/liferay/blogs/internal/util/PingbackMethodImplTest.java
+++ b/modules/apps/blogs/blogs-test/src/test/java/com/liferay/blogs/internal/util/PingbackMethodImplTest.java
@@ -762,7 +762,6 @@ public class PingbackMethodImplTest extends PowerMockito {
 	@Mock
 	private PortletLocalService _portletLocalService;
 
-	@Mock
 	private ServiceTrackerMap<String, PortletProvider> _serviceTrackerMap;
 
 	@Mock

--- a/modules/apps/configuration-admin/configuration-admin-web/src/test/java/com/liferay/configuration/admin/web/internal/util/AttributeDefinitionUtilTest.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/test/java/com/liferay/configuration/admin/web/internal/util/AttributeDefinitionUtilTest.java
@@ -15,6 +15,7 @@
 package com.liferay.configuration.admin.web.internal.util;
 
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 
 import java.util.Arrays;
@@ -26,10 +27,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.metatype.AttributeDefinition;
 
@@ -39,24 +36,16 @@ import org.osgi.service.metatype.AttributeDefinition;
 public class AttributeDefinitionUtilTest {
 
 	@Before
-	public void setUp() {
-		MockitoAnnotations.initMocks(this);
+	public void setUp() throws Exception {
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_attributeDefinition, "getID", _ID);
 
-		Mockito.doReturn(
-			_ID
-		).when(
-			_attributeDefinition
-		).getID();
-
-		Mockito.doReturn(
-			_properties
-		).when(
-			_configuration
-		).getProperties();
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_configuration, "getProperties", _properties);
 	}
 
 	@Test
-	public void testDefaultValueArray() {
+	public void testDefaultValueArray() throws Exception {
 		mockCardinality(Integer.MAX_VALUE);
 
 		mockDefaultValue("A", "B", "C");
@@ -65,25 +54,22 @@ public class AttributeDefinitionUtilTest {
 	}
 
 	@Test
-	public void testDefaultValueBlankString() {
+	public void testDefaultValueBlankString() throws Exception {
 		mockDefaultValue(StringPool.BLANK);
 
 		assertDefaultValue(StringPool.BLANK);
 	}
 
 	@Test
-	public void testDefaultValueEmpty() {
-		Mockito.doReturn(
-			new String[0]
-		).when(
-			_attributeDefinition
-		).getDefaultValue();
+	public void testDefaultValueEmpty() throws Exception {
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_attributeDefinition, "getDefaultValue", new String[0]);
 
 		assertDefaultValue(StringPool.BLANK);
 	}
 
 	@Test
-	public void testDefaultValueWithPipesArray() {
+	public void testDefaultValueWithPipesArray() throws Exception {
 		mockCardinality(42);
 
 		mockDefaultValue("A|B|C");
@@ -92,14 +78,14 @@ public class AttributeDefinitionUtilTest {
 	}
 
 	@Test
-	public void testDefaultValueWithPipesString() {
+	public void testDefaultValueWithPipesString() throws Exception {
 		mockDefaultValue("A|B|C");
 
 		assertDefaultValue("A|B|C");
 	}
 
 	@Test
-	public void testPropertyArray() {
+	public void testPropertyArray() throws Exception {
 		mockCardinality(2);
 
 		mockProperty(new Object[] {false, true});
@@ -120,7 +106,7 @@ public class AttributeDefinitionUtilTest {
 	}
 
 	@Test
-	public void testPropertyVector() {
+	public void testPropertyVector() throws Exception {
 		mockCardinality(-3);
 
 		mockProperty(new Vector<Integer>(Arrays.asList(1, 2, 3)));
@@ -141,20 +127,14 @@ public class AttributeDefinitionUtilTest {
 				_attributeDefinition, _configuration));
 	}
 
-	protected void mockCardinality(int value) {
-		Mockito.doReturn(
-			value
-		).when(
-			_attributeDefinition
-		).getCardinality();
+	protected void mockCardinality(int value) throws Exception {
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_attributeDefinition, "getCardinality", value);
 	}
 
-	protected void mockDefaultValue(String... value) {
-		Mockito.doReturn(
-			value
-		).when(
-			_attributeDefinition
-		).getDefaultValue();
+	protected void mockDefaultValue(String... value) throws Exception {
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_attributeDefinition, "getDefaultValue", value);
 	}
 
 	protected void mockProperty(Object value) {
@@ -163,12 +143,10 @@ public class AttributeDefinitionUtilTest {
 
 	private static final String _ID = RandomTestUtil.randomString();
 
-	@Mock
-	private AttributeDefinition _attributeDefinition;
-
-	@Mock
-	private Configuration _configuration;
-
+	private final AttributeDefinition _attributeDefinition =
+		MockHelperUtil.initMock(AttributeDefinition.class);
+	private final Configuration _configuration = MockHelperUtil.initMock(
+		Configuration.class);
 	private final Dictionary<String, Object> _properties = new Hashtable<>();
 
 }

--- a/modules/apps/document-library/document-library-repository-cmis-api/src/test/java/com/liferay/document/library/repository/cmis/search/BaseCmisSearchQueryBuilderTest.java
+++ b/modules/apps/document-library/document-library-repository-cmis-api/src/test/java/com/liferay/document/library/repository/cmis/search/BaseCmisSearchQueryBuilderTest.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchEngineHelper;
 import com.liferay.portal.kernel.service.RepositoryEntryLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.DateFormatFactory;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
@@ -61,7 +62,7 @@ public class BaseCmisSearchQueryBuilderTest {
 
 		_cmisSearchQueryBuilder = new BaseCmisSearchQueryBuilder(
 			createRepositoryEntryLocalService(),
-			Mockito.mock(UserLocalService.class));
+			MockHelperUtil.initMock(UserLocalService.class));
 	}
 
 	@Test
@@ -383,29 +384,21 @@ public class BaseCmisSearchQueryBuilderTest {
 		return dateFormatFactory;
 	}
 
-	protected RepositoryEntry createRepositoryEntry() {
-		RepositoryEntry repositoryEntry = Mockito.mock(RepositoryEntry.class);
-
-		Mockito.doReturn(
-			_MAPPED_ID
-		).when(
-			repositoryEntry
-		).getMappedId();
+	protected RepositoryEntry createRepositoryEntry() throws Exception {
+		RepositoryEntry repositoryEntry =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				RepositoryEntry.class, "getMappedId", _MAPPED_ID);
 
 		return repositoryEntry;
 	}
 
-	protected RepositoryEntryLocalService createRepositoryEntryLocalService() {
-		RepositoryEntryLocalService repositoryEntryLocalService = Mockito.mock(
-			RepositoryEntryLocalService.class);
+	protected RepositoryEntryLocalService createRepositoryEntryLocalService()
+		throws Exception {
 
-		Mockito.doReturn(
-			createRepositoryEntry()
-		).when(
-			repositoryEntryLocalService
-		).fetchRepositoryEntry(
-			Mockito.anyLong()
-		);
+		RepositoryEntryLocalService repositoryEntryLocalService =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				RepositoryEntryLocalService.class, "fetchRepositoryEntry",
+				createRepositoryEntry(), long.class);
 
 		return repositoryEntryLocalService;
 	}
@@ -415,7 +408,7 @@ public class BaseCmisSearchQueryBuilderTest {
 
 		return new RepositorySearchQueryBuilderImpl() {
 			{
-				setDLAppService(Mockito.mock(DLAppService.class));
+				setDLAppService(MockHelperUtil.initMock(DLAppService.class));
 
 				setRepositorySearchQueryTermBuilder(
 					createRepositorySearchQueryTermBuilder());

--- a/modules/apps/document-library/document-library-service/src/test/java/com/liferay/document/library/internal/search/SearchResultUtilDLFileEntryTest.java
+++ b/modules/apps/document-library/document-library-service/src/test/java/com/liferay/document/library/internal/search/SearchResultUtilDLFileEntryTest.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.search.result.SearchResultContributor;
 import com.liferay.portal.kernel.search.result.SearchResultTranslator;
 import com.liferay.portal.kernel.test.CaptureHandler;
 import com.liferay.portal.kernel.test.JDKLoggerTestUtil;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.search.internal.result.SearchResultManagerImpl;
@@ -406,8 +407,8 @@ public class SearchResultUtilDLFileEntryTest
 	@Mock
 	private DLAppLocalService _dlAppLocalService;
 
-	@Mock
-	private FileEntry _fileEntry;
+	private final FileEntry _fileEntry = MockHelperUtil.initMock(
+		FileEntry.class);
 
 	@Mock
 	private Indexer<Object> _indexer;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/test/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/DDMFormEvaluatorHelperTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/test/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/DDMFormEvaluatorHelperTest.java
@@ -1264,7 +1264,6 @@ public class DDMFormEvaluatorHelperTest {
 	@Mock
 	private User _user;
 
-	@Mock
 	private UserGroupRoleLocalService _userGroupRoleLocalService;
 
 	@Mock

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/test/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/functions/BelongsToRoleFunctionTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/test/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/functions/BelongsToRoleFunctionTest.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
 
@@ -129,11 +130,8 @@ public class BelongsToRoleFunctionTest {
 	}
 
 	protected void mockHasRegularRole() throws Exception {
-		Mockito.when(
-			_role.getType()
-		).thenReturn(
-			RoleConstants.TYPE_REGULAR
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_role, "getType", RoleConstants.TYPE_REGULAR);
 
 		Mockito.when(
 			_userLocalService.hasRoleUser(
@@ -145,11 +143,8 @@ public class BelongsToRoleFunctionTest {
 	}
 
 	protected void mockHasSiteRole() throws Exception {
-		Mockito.when(
-			_role.getType()
-		).thenReturn(
-			RoleConstants.TYPE_SITE
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_role, "getType", RoleConstants.TYPE_SITE);
 
 		Mockito.when(
 			_userGroupRoleLocalService.hasUserGroupRole(
@@ -181,28 +176,17 @@ public class BelongsToRoleFunctionTest {
 	}
 
 	protected void setRole() throws Exception {
-		Mockito.when(
-			_roleLocalService.fetchRole(
-				Matchers.anyLong(), Matchers.anyString())
-		).thenReturn(
-			_role
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_roleLocalService, "fetchRole", _role, long.class, String.class);
 	}
 
-	@Mock
-	private Company _company;
-
-	@Mock
-	private HttpServletRequest _request;
-
-	@Mock
-	private Role _role;
-
-	@Mock
-	private RoleLocalService _roleLocalService;
-
-	@Mock
-	private User _user;
+	private final Company _company = MockHelperUtil.initMock(Company.class);
+	private final HttpServletRequest _request = MockHelperUtil.initMock(
+		HttpServletRequest.class);
+	private final Role _role = MockHelperUtil.initMock(Role.class);
+	private final RoleLocalService _roleLocalService = MockHelperUtil.initMock(
+		RoleLocalService.class);
+	private final User _user = MockHelperUtil.initMock(User.class);
 
 	@Mock
 	private UserGroupRoleLocalService _userGroupRoleLocalService;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/BaseDDMFormFieldTypeSettingsTestCase.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/BaseDDMFormFieldTypeSettingsTestCase.java
@@ -95,10 +95,7 @@ public abstract class BaseDDMFormFieldTypeSettingsTestCase
 	@Mock
 	protected Language language;
 
-	@Mock
 	private ClassLoader _classLoader;
-
-	@Mock
 	private ResourceBundle _resourceBundle;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/document/library/internal/DocumentLibraryDDMFormFieldTemplateContextContributorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/document/library/internal/DocumentLibraryDDMFormFieldTemplateContextContributorTest.java
@@ -245,8 +245,6 @@ public class DocumentLibraryDDMFormFieldTemplateContextContributorTest
 
 	private final Html _html = new HtmlImpl();
 	private final JSONFactory _jsonFactory = new JSONFactoryImpl();
-
-	@Mock
 	private ResourceBundle _resourceBundle;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/select/internal/SelectDDMFormFieldTemplateContextContributorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/select/internal/SelectDDMFormFieldTemplateContextContributorTest.java
@@ -26,7 +26,6 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
-import com.liferay.portal.kernel.util.ResourceBundleLoader;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
 import java.util.ArrayList;
@@ -392,13 +391,7 @@ public class SelectDDMFormFieldTemplateContextContributorTest
 	private DDMFormFieldOptionsFactory _ddmFormFieldOptionsFactory;
 
 	private final JSONFactory _jsonFactory = new JSONFactoryImpl();
-
-	@Mock
 	private ResourceBundle _resourceBundle;
-
-	@Mock
-	private ResourceBundleLoader _resourceBundleLoader;
-
 	private final SelectDDMFormFieldTemplateContextContributor
 		_selectDDMFormFieldTemplateContextContributor =
 			new SelectDDMFormFieldTemplateContextContributor();

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/test/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormFieldTemplateContextFactoryTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/test/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormFieldTemplateContextFactoryTest.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageConstants;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.template.TemplateResource;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -69,7 +70,7 @@ public class DDMFormFieldTemplateContextFactoryTest {
 	}
 
 	@Test
-	public void testFieldValueChangedPropertyIsFalse() {
+	public void testFieldValueChangedPropertyIsFalse() throws Exception {
 		DDMForm ddmForm = DDMFormTestUtil.createDDMForm();
 
 		DDMFormField ddmFormField = DDMFormTestUtil.createTextDDMFormField(
@@ -115,7 +116,7 @@ public class DDMFormFieldTemplateContextFactoryTest {
 	}
 
 	@Test
-	public void testFieldValueChangedPropertyIsNull() {
+	public void testFieldValueChangedPropertyIsNull() throws Exception {
 		DDMForm ddmForm = DDMFormTestUtil.createDDMForm();
 
 		DDMFormField ddmFormField = DDMFormTestUtil.createTextDDMFormField(
@@ -159,7 +160,7 @@ public class DDMFormFieldTemplateContextFactoryTest {
 	}
 
 	@Test
-	public void testFieldValueChangedPropertyIsTrue() {
+	public void testFieldValueChangedPropertyIsTrue() throws Exception {
 		DDMForm ddmForm = DDMFormTestUtil.createDDMForm();
 
 		DDMFormField ddmFormField = DDMFormTestUtil.createTextDDMFormField(
@@ -205,7 +206,7 @@ public class DDMFormFieldTemplateContextFactoryTest {
 	}
 
 	@Test
-	public void testNotReadOnlyTextFieldAndReadOnlyForm() {
+	public void testNotReadOnlyTextFieldAndReadOnlyForm() throws Exception {
 
 		// Dynamic data mapping form
 
@@ -263,7 +264,7 @@ public class DDMFormFieldTemplateContextFactoryTest {
 	}
 
 	@Test
-	public void testReadOnlyTextFieldAndNotReadOnlyForm() {
+	public void testReadOnlyTextFieldAndNotReadOnlyForm() throws Exception {
 
 		// Dynamic data mapping form
 
@@ -321,7 +322,7 @@ public class DDMFormFieldTemplateContextFactoryTest {
 	}
 
 	@Test
-	public void testTextField() {
+	public void testTextField() throws Exception {
 
 		// Dynamic data mapping form
 
@@ -413,12 +414,14 @@ public class DDMFormFieldTemplateContextFactoryTest {
 	}
 
 	protected DDMFormFieldTemplateContextFactory
-		createDDMFormFieldTemplateContextFactory(
-			DDMForm ddmForm, DDMFormEvaluationResult ddmFormEvaluationResult,
-			List<DDMFormFieldValue> ddmFormFieldValues, boolean ddmFormReadOnly,
-			DDMFormFieldRenderer ddmFormFieldRenderer,
-			DDMFormFieldTemplateContextContributor
-				ddmFormFieldTemplateContextContributor) {
+			createDDMFormFieldTemplateContextFactory(
+				DDMForm ddmForm,
+				DDMFormEvaluationResult ddmFormEvaluationResult,
+				List<DDMFormFieldValue> ddmFormFieldValues,
+				boolean ddmFormReadOnly,
+				DDMFormFieldRenderer ddmFormFieldRenderer,
+				DDMFormFieldTemplateContextContributor
+					ddmFormFieldTemplateContextContributor) throws Exception {
 
 		DDMFormRenderingContext ddmFormRenderingContext =
 			new DDMFormRenderingContext();
@@ -495,27 +498,20 @@ public class DDMFormFieldTemplateContextFactoryTest {
 	}
 
 	protected DDMFormFieldTypeServicesTracker
-		mockDDMFormFieldTypeServicesTracker(
-			DDMFormFieldRenderer ddmFormFieldRenderer,
-			DDMFormFieldTemplateContextContributor
-				ddmFormFieldTemplateContextContributor) {
+			mockDDMFormFieldTypeServicesTracker(
+				DDMFormFieldRenderer ddmFormFieldRenderer,
+				DDMFormFieldTemplateContextContributor
+					ddmFormFieldTemplateContextContributor) throws Exception {
 
 		DDMFormFieldTypeServicesTracker ddmFormFieldTypeServicesTracker =
-			Mockito.mock(DDMFormFieldTypeServicesTracker.class);
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				DDMFormFieldTypeServicesTracker.class,
+				"getDDMFormFieldRenderer", ddmFormFieldRenderer, String.class);
 
-		Mockito.when(
-			ddmFormFieldTypeServicesTracker.getDDMFormFieldRenderer(
-				Matchers.anyString())
-		).thenReturn(
-			ddmFormFieldRenderer
-		);
-
-		Mockito.when(
-			ddmFormFieldTypeServicesTracker.
-				getDDMFormFieldTemplateContextContributor(Matchers.anyString())
-		).thenReturn(
-			ddmFormFieldTemplateContextContributor
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			ddmFormFieldTypeServicesTracker,
+			"getDDMFormFieldTemplateContextContributor",
+			ddmFormFieldTemplateContextContributor, String.class);
 
 		return ddmFormFieldTypeServicesTracker;
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-taglib/src/test/java/com/liferay/dynamic/data/mapping/form/taglib/servlet/taglib/util/DDMFormTaglibUtilTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-taglib/src/test/java/com/liferay/dynamic/data/mapping/form/taglib/servlet/taglib/util/DDMFormTaglibUtilTest.java
@@ -23,6 +23,7 @@ import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMStructureVersionLocalService;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 
 import java.lang.reflect.Field;
@@ -31,9 +32,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.mockito.Mock;
-import org.mockito.Mockito;
 
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -119,11 +117,9 @@ public class DDMFormTaglibUtilTest {
 		Field field = ReflectionUtil.getDeclaredField(
 			DDMFormTaglibUtil.class, "_ddmStructureLocalService");
 
-		Mockito.when(
-			_ddmStructureLocalService.fetchDDMStructure(Mockito.anyLong())
-		).thenReturn(
-			_ddmStructure
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_ddmStructureLocalService, "fetchDDMStructure", _ddmStructure,
+			long.class);
 
 		field.set(_ddmFormTaglibUtil, _ddmStructureLocalService);
 	}
@@ -135,12 +131,9 @@ public class DDMFormTaglibUtilTest {
 		Field field = ReflectionUtil.getDeclaredField(
 			DDMFormTaglibUtil.class, "_ddmStructureVersionLocalService");
 
-		Mockito.when(
-			_ddmStructureVersionLocalService.fetchDDMStructureVersion(
-				Mockito.anyLong())
-		).thenReturn(
-			_ddmStructureVersion
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_ddmStructureVersionLocalService, "fetchDDMStructureVersion",
+			_ddmStructureVersion, long.class);
 
 		field.set(_ddmFormTaglibUtil, _ddmStructureVersionLocalService);
 	}
@@ -148,13 +141,11 @@ public class DDMFormTaglibUtilTest {
 	private final DDMFormTaglibUtil _ddmFormTaglibUtil =
 		new DDMFormTaglibUtil();
 	private DDMStructure _ddmStructure;
-
-	@Mock
-	private DDMStructureLocalService _ddmStructureLocalService;
-
+	private final DDMStructureLocalService _ddmStructureLocalService =
+		MockHelperUtil.initMock(DDMStructureLocalService.class);
 	private DDMStructureVersion _ddmStructureVersion;
-
-	@Mock
-	private DDMStructureVersionLocalService _ddmStructureVersionLocalService;
+	private final DDMStructureVersionLocalService
+		_ddmStructureVersionLocalService = MockHelperUtil.initMock(
+			DDMStructureVersionLocalService.class);
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContextTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContextTest.java
@@ -69,7 +69,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.mockito.Matchers;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import org.powermock.api.mockito.PowerMockito;
@@ -396,8 +395,6 @@ public class DDMFormAdminDisplayContextTest extends PowerMockito {
 
 	private DDMFormAdminDisplayContext _ddmFormAdminDisplayContext;
 	private RenderRequest _renderRequest;
-
-	@Mock
 	private ServiceTrackerMap<String, ResourceBundleLoader> _serviceTrackerMap;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCCommandHelperTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCCommandHelperTest.java
@@ -284,7 +284,6 @@ public class AddFormInstanceRecordMVCCommandHelperTest extends PowerMockito {
 	@Mock
 	private Portal _portal;
 
-	@Mock
 	private HttpServletRequest _request;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/test/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImplTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/test/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImplTest.java
@@ -32,6 +32,7 @@ import com.liferay.dynamic.data.mapping.test.util.DDMFormValuesTestUtil;
 import com.liferay.dynamic.data.mapping.util.DDMIndexer;
 import com.liferay.portal.json.JSONFactoryImpl;
 import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
@@ -53,8 +54,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.mockito.Mockito;
 
 import org.powermock.core.classloader.annotations.PrepareOnlyThisForTest;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
@@ -244,7 +243,8 @@ public class DDMIndexerImplTest {
 		return new DDMFormJSONSerializer() {
 			{
 				setDDMFormFieldTypeServicesTracker(
-					Mockito.mock(DDMFormFieldTypeServicesTracker.class));
+					MockHelperUtil.initMock(
+						DDMFormFieldTypeServicesTracker.class));
 
 				setJSONFactory(new JSONFactoryImpl());
 			}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/test/java/com/liferay/dynamic/data/mapping/util/DDMImplTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/test/java/com/liferay/dynamic/data/mapping/util/DDMImplTest.java
@@ -41,6 +41,7 @@ import com.liferay.dynamic.data.mapping.storage.Field;
 import com.liferay.dynamic.data.mapping.storage.Fields;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.util.PropsValues;
@@ -54,8 +55,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.mockito.Mockito;
 
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
@@ -728,14 +727,10 @@ public class DDMImplTest extends BaseDDMTestCase {
 	}
 
 	protected void setUpDDM() throws Exception {
-		DDMFormSerializerTracker ddmFormSerializerTracker = Mockito.mock(
-			DDMFormSerializerTracker.class);
-
-		Mockito.when(
-			ddmFormSerializerTracker.getDDMFormSerializer(Mockito.anyString())
-		).thenReturn(
-			ddmFormJSONSerializer
-		);
+		DDMFormSerializerTracker ddmFormSerializerTracker =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				DDMFormSerializerTracker.class, "getDDMFormSerializer",
+				ddmFormJSONSerializer, String.class);
 
 		java.lang.reflect.Field field = ReflectionUtil.getDeclaredField(
 			DDMImpl.class, "_ddmFormSerializerTracker");
@@ -743,14 +738,10 @@ public class DDMImplTest extends BaseDDMTestCase {
 		field.set(_ddm, ddmFormSerializerTracker);
 
 		DDMFormValuesDeserializerTracker ddmFormValuesDeserializerTracker =
-			Mockito.mock(DDMFormValuesDeserializerTracker.class);
-
-		Mockito.when(
-			ddmFormValuesDeserializerTracker.getDDMFormValuesDeserializer(
-				Mockito.anyString())
-		).thenReturn(
-			_ddmFormValuesDeserializer
-		);
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				DDMFormValuesDeserializerTracker.class,
+				"getDDMFormValuesDeserializer", _ddmFormValuesDeserializer,
+				String.class);
 
 		field = ReflectionUtil.getDeclaredField(
 			DDMImpl.class, "_ddmFormValuesDeserializerTracker");
@@ -758,14 +749,10 @@ public class DDMImplTest extends BaseDDMTestCase {
 		field.set(_ddm, ddmFormValuesDeserializerTracker);
 
 		DDMFormValuesSerializerTracker ddmFormValuesSerializerTracker =
-			Mockito.mock(DDMFormValuesSerializerTracker.class);
-
-		Mockito.when(
-			ddmFormValuesSerializerTracker.getDDMFormValuesSerializer(
-				Mockito.anyString())
-		).thenReturn(
-			_ddmFormValuesSerializer
-		);
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				DDMFormValuesSerializerTracker.class,
+				"getDDMFormValuesSerializer", _ddmFormValuesSerializer,
+				String.class);
 
 		field = ReflectionUtil.getDeclaredField(
 			DDMImpl.class, "_ddmFormValuesSerializerTracker");

--- a/modules/apps/journal/journal-test/src/test/java/com/liferay/journal/search/SearchResultUtilJournalArticleTest.java
+++ b/modules/apps/journal/journal-test/src/test/java/com/liferay/journal/search/SearchResultUtilJournalArticleTest.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.search.SummaryFactory;
 import com.liferay.portal.kernel.search.result.SearchResultTranslator;
 import com.liferay.portal.kernel.test.CaptureHandler;
 import com.liferay.portal.kernel.test.JDKLoggerTestUtil;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.search.internal.result.SearchResultManagerImpl;
 import com.liferay.portal.search.internal.result.SearchResultTranslatorImpl;
@@ -73,11 +74,8 @@ public class SearchResultUtilJournalArticleTest
 			(PortletRequest)Matchers.any(), (PortletResponse)Matchers.any()
 		);
 
-		Mockito.when(
-			_indexerRegistry.getIndexer(Mockito.anyString())
-		).thenReturn(
-			_indexer
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_indexerRegistry, "getIndexer", _indexer, String.class);
 
 		Document document = createDocument();
 
@@ -172,7 +170,7 @@ public class SearchResultUtilJournalArticleTest
 	@Mock
 	private Indexer<Object> _indexer;
 
-	@Mock
-	private IndexerRegistry _indexerRegistry;
+	private final IndexerRegistry _indexerRegistry = MockHelperUtil.initMock(
+		IndexerRegistry.class);
 
 }

--- a/modules/apps/knowledge-base/knowledge-base-service/src/test/java/com/liferay/knowledge/base/internal/importer/KBArchiveFactoryTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/test/java/com/liferay/knowledge/base/internal/importer/KBArchiveFactoryTest.java
@@ -231,8 +231,7 @@ public class KBArchiveFactoryTest {
 
 	private final ConfigurationProvider _configurationProvider = Mockito.mock(
 		ConfigurationProvider.class);
-	private final GroupServiceSettingsLocator _groupServiceSettingsLocator =
-		Mockito.mock(GroupServiceSettingsLocator.class);
+	private GroupServiceSettingsLocator _groupServiceSettingsLocator;
 	private final KBArchiveFactory _kbArchiveFactory = new KBArchiveFactory();
 	private final KBGroupServiceConfiguration _kbGroupServiceConfiguration =
 		Mockito.mock(KBGroupServiceConfiguration.class);

--- a/modules/apps/message-boards/message-boards-comment/src/test/java/com/liferay/message/boards/comment/internal/MBCommentManagerImplTest.java
+++ b/modules/apps/message-boards/message-boards-comment/src/test/java/com/liferay/message/boards/comment/internal/MBCommentManagerImplTest.java
@@ -22,6 +22,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.comment.DuplicateCommentException;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Function;
 import com.liferay.portal.kernel.util.Portal;
@@ -80,11 +81,8 @@ public class MBCommentManagerImplTest extends Mockito {
 
 	@Test
 	public void testAddCommentWithUserNameAndSubject() throws Exception {
-		when(
-			_mbMessage.getMessageId()
-		).thenReturn(
-			_MBMESSAGE_ID
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_mbMessage, "getMessageId", _MBMESSAGE_ID);
 
 		Assert.assertEquals(
 			_MBMESSAGE_ID,
@@ -207,12 +205,9 @@ public class MBCommentManagerImplTest extends Mockito {
 			_mbCommentManagerImpl.getCommentsCount(_CLASS_NAME, classPK));
 	}
 
-	protected void setUpExistingComment(String body) {
-		when(
-			_mbMessage.getBody()
-		).thenReturn(
-			body
-		);
+	protected void setUpExistingComment(String body) throws Exception {
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_mbMessage, "getBody", body);
 
 		List<MBMessage> messages = Collections.singletonList(_mbMessage);
 
@@ -227,11 +222,8 @@ public class MBCommentManagerImplTest extends Mockito {
 	protected void setUpMBCommentManagerImpl() throws Exception {
 		_mbCommentManagerImpl.setMBMessageLocalService(_mbMessageLocalService);
 
-		when(
-			_mbMessageDisplay.getThread()
-		).thenReturn(
-			_mbThread
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_mbMessageDisplay, "getThread", _mbThread);
 
 		when(
 			_mbMessageLocalService.addDiscussionMessage(
@@ -251,17 +243,11 @@ public class MBCommentManagerImplTest extends Mockito {
 			_mbMessageDisplay
 		);
 
-		when(
-			_mbThread.getRootMessageId()
-		).thenReturn(
-			_ROOT_MESSAGE_ID
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_mbThread, "getRootMessageId", _ROOT_MESSAGE_ID);
 
-		when(
-			_mbThread.getThreadId()
-		).thenReturn(
-			_THREAD_ID
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_mbThread, "getThreadId", _THREAD_ID);
 	}
 
 	protected void setUpPortalUtil() {
@@ -300,18 +286,15 @@ public class MBCommentManagerImplTest extends Mockito {
 
 	private final MBCommentManagerImpl _mbCommentManagerImpl =
 		new MBCommentManagerImpl();
-
-	@Mock
-	private MBMessage _mbMessage;
-
-	@Mock
-	private MBMessageDisplay _mbMessageDisplay;
+	private final MBMessage _mbMessage = MockHelperUtil.initMock(
+		MBMessage.class);
+	private final MBMessageDisplay _mbMessageDisplay = MockHelperUtil.initMock(
+		MBMessageDisplay.class);
 
 	@Mock
 	private MBMessageLocalService _mbMessageLocalService;
 
-	@Mock
-	private MBThread _mbThread;
+	private final MBThread _mbThread = MockHelperUtil.initMock(MBThread.class);
 
 	@Mock
 	private Portal _portal;

--- a/modules/apps/message-boards/message-boards-comment/src/test/java/com/liferay/message/boards/comment/internal/search/SearchResultUtilMBMessageTest.java
+++ b/modules/apps/message-boards/message-boards-comment/src/test/java/com/liferay/message/boards/comment/internal/search/SearchResultUtilMBMessageTest.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.search.SearchResultManager;
 import com.liferay.portal.kernel.search.SummaryFactory;
 import com.liferay.portal.kernel.search.result.SearchResultContributor;
 import com.liferay.portal.kernel.search.result.SearchResultTranslator;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.search.internal.result.SearchResultManagerImpl;
 import com.liferay.portal.search.internal.result.SearchResultTranslatorImpl;
 import com.liferay.portal.search.internal.result.SummaryFactoryImpl;
@@ -41,7 +42,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.mockito.Mock;
-import org.mockito.Mockito;
 
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -59,23 +59,14 @@ public class SearchResultUtilMBMessageTest
 	public void setUp() throws Exception {
 		super.setUp();
 
-		when(
-			_commentManager.fetchComment(Mockito.anyLong())
-		).thenReturn(
-			_comment
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_commentManager, "fetchComment", _comment, long.class);
 
-		when(
-			_comment.getCommentId()
-		).thenReturn(
-			SearchTestUtil.ENTRY_CLASS_PK
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_comment, "getCommentId", SearchTestUtil.ENTRY_CLASS_PK);
 
-		when(
-			_mbMessage.getMessageId()
-		).thenReturn(
-			SearchTestUtil.ENTRY_CLASS_PK
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_mbMessage, "getMessageId", SearchTestUtil.ENTRY_CLASS_PK);
 
 		when(
 			_mbMessageLocalService.getMessage(SearchTestUtil.ENTRY_CLASS_PK)
@@ -214,16 +205,12 @@ public class SearchResultUtilMBMessageTest
 	private static final String _MB_MESSAGE_CLASS_NAME =
 		MBMessage.class.getName();
 
-	@Mock
-	private Comment _comment;
-
-	@Mock
-	private CommentManager _commentManager;
-
+	private final Comment _comment = MockHelperUtil.initMock(Comment.class);
+	private final CommentManager _commentManager = MockHelperUtil.initMock(
+		CommentManager.class);
 	private IndexerRegistry _indexerRegistry;
-
-	@Mock
-	private MBMessage _mbMessage;
+	private final MBMessage _mbMessage = MockHelperUtil.initMock(
+		MBMessage.class);
 
 	@Mock
 	private MBMessageLocalService _mbMessageLocalService;

--- a/modules/apps/message-boards/message-boards-comment/src/test/java/com/liferay/message/boards/comment/internal/search/SearchResultUtilMBMessageTest.java
+++ b/modules/apps/message-boards/message-boards-comment/src/test/java/com/liferay/message/boards/comment/internal/search/SearchResultUtilMBMessageTest.java
@@ -220,7 +220,6 @@ public class SearchResultUtilMBMessageTest
 	@Mock
 	private CommentManager _commentManager;
 
-	@Mock
 	private IndexerRegistry _indexerRegistry;
 
 	@Mock

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/test/java/com/liferay/oauth2/provider/scope/internal/liferay/ScopeLocatorImplTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/test/java/com/liferay/oauth2/provider/scope/internal/liferay/ScopeLocatorImplTest.java
@@ -30,6 +30,7 @@ import com.liferay.oauth2.provider.scope.spi.scope.mapper.ScopeMapper;
 import com.liferay.oauth2.provider.scope.spi.scope.matcher.ScopeMatcherFactory;
 import com.liferay.osgi.service.tracker.collections.ServiceReferenceServiceTuple;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 
 import java.lang.reflect.Field;
 
@@ -448,8 +449,8 @@ public class ScopeLocatorImplTest extends PowerMockito {
 
 			configurator.configure(
 				(companyId, applicationName, service) -> {
-					ServiceReference<?> serviceReference = Mockito.mock(
-						ServiceReference.class);
+					ServiceReference<?> serviceReference =
+						MockHelperUtil.initMock(ServiceReference.class);
 
 					when(
 						scopeFinderByNameServiceTrackerMap.getService(

--- a/modules/apps/portal-background-task/portal-background-task-service/src/test/java/com/liferay/portal/background/task/internal/BaseBackgroundTaskTestCase.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/test/java/com/liferay/portal/background/task/internal/BaseBackgroundTaskTestCase.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -40,8 +41,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 
-import org.mockito.Mockito;
-
 /**
  * @author Michael C. Han
  */
@@ -52,41 +51,32 @@ public abstract class BaseBackgroundTaskTestCase {
 		backgroundTaskThreadLocalManagerImpl =
 			new BackgroundTaskThreadLocalManagerImpl();
 
-		CompanyLocalService companyLocalService = Mockito.mock(
-			CompanyLocalService.class);
+		Company company = MockHelperUtil.initMock(Company.class);
 
-		Mockito.when(
-			companyLocalService.fetchCompany(Mockito.anyLong())
-		).thenReturn(
-			Mockito.mock(Company.class)
-		);
+		CompanyLocalService companyLocalService =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				CompanyLocalService.class, "fetchCompany", company, long.class);
 
 		backgroundTaskThreadLocalManagerImpl.companyLocalService =
 			companyLocalService;
 
-		PermissionCheckerFactory permissionCheckerFactory = Mockito.mock(
-			PermissionCheckerFactory.class);
+		PermissionCheckerFactory permissionCheckerFactory =
+			MockHelperUtil.initMock(PermissionCheckerFactory.class);
 
-		PermissionChecker permissionChecker = Mockito.mock(
+		PermissionChecker permissionChecker = MockHelperUtil.initMock(
 			PermissionChecker.class);
 
-		Mockito.when(
-			permissionCheckerFactory.create(Mockito.any(User.class))
-		).thenReturn(
-			permissionChecker
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			permissionCheckerFactory, "create", permissionChecker, User.class);
 
 		backgroundTaskThreadLocalManagerImpl.setPermissionCheckerFactory(
 			permissionCheckerFactory);
 
-		UserLocalService userLocalService = Mockito.mock(
-			UserLocalService.class);
+		User user = MockHelperUtil.initMock(User.class);
 
-		Mockito.when(
-			userLocalService.fetchUser(Mockito.anyLong())
-		).thenReturn(
-			Mockito.mock(User.class)
-		);
+		UserLocalService userLocalService =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				UserLocalService.class, "fetchUser", user, long.class);
 
 		backgroundTaskThreadLocalManagerImpl.setUserLocalService(
 			userLocalService);

--- a/modules/apps/portal-background-task/portal-background-task-service/src/test/java/com/liferay/portal/background/task/internal/ThreadLocalAwareBackgroundTaskExecutorTest.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/test/java/com/liferay/portal/background/task/internal/ThreadLocalAwareBackgroundTaskExecutorTest.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskResult;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 
 import java.io.Serializable;
 
@@ -37,14 +38,9 @@ public class ThreadLocalAwareBackgroundTaskExecutorTest
 
 	@Test
 	public void testStaleBackgroundTaskIsSkipped() throws Exception {
-		CompanyLocalService companyLocalService = Mockito.mock(
-			CompanyLocalService.class);
-
-		Mockito.when(
-			companyLocalService.fetchCompany(Mockito.anyLong())
-		).thenReturn(
-			null
-		);
+		CompanyLocalService companyLocalService =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				CompanyLocalService.class, "fetchCompany", null, long.class);
 
 		backgroundTaskThreadLocalManagerImpl.companyLocalService =
 			companyLocalService;
@@ -58,16 +54,14 @@ public class ThreadLocalAwareBackgroundTaskExecutorTest
 					backgroundTaskExecutor,
 					backgroundTaskThreadLocalManagerImpl);
 
-		BackgroundTask backgroundTask = Mockito.mock(BackgroundTask.class);
-
-		Mockito.when(
-			backgroundTask.getTaskContextMap()
-		).thenReturn(
-			Collections.singletonMap(
-				BackgroundTaskThreadLocalManagerImpl.KEY_THREAD_LOCAL_VALUES,
-				(Serializable)new HashMap<>(
-					Collections.singletonMap("companyId", 1)))
-		);
+		BackgroundTask backgroundTask =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				BackgroundTask.class, "getTaskContextMap",
+				Collections.singletonMap(
+					BackgroundTaskThreadLocalManagerImpl.
+						KEY_THREAD_LOCAL_VALUES,
+					(Serializable)new HashMap<>(
+						Collections.singletonMap("companyId", 1))));
 
 		BackgroundTaskResult backgroundTaskResult =
 			threadLocalAwareBackgroundTaskExecutor.execute(backgroundTask);

--- a/modules/apps/portal-scripting-javascript/portal-scripting-javascript/src/test/java/com/liferay/portal/scripting/javascript/internal/JavaScriptExecutorTest.java
+++ b/modules/apps/portal-scripting-javascript/portal-scripting-javascript/src/test/java/com/liferay/portal/scripting/javascript/internal/JavaScriptExecutorTest.java
@@ -14,13 +14,9 @@
 
 package com.liferay.portal.scripting.javascript.internal;
 
-import com.liferay.portal.kernel.cache.PortalCache;
-import com.liferay.portal.kernel.cache.SingleVMPool;
 import com.liferay.portal.kernel.scripting.ScriptingException;
 import com.liferay.portal.kernel.scripting.ScriptingExecutor;
 import com.liferay.portal.scripting.ScriptingExecutorTestCase;
-
-import java.io.Serializable;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -29,18 +25,12 @@ import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import org.mockito.Mockito;
-
-import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
  * @author     Bruno Basto
  * @deprecated As of Judson (7.1.x), with no direct replacement
  */
 @Deprecated
-@RunWith(PowerMockRunner.class)
 public class JavaScriptExecutorTest extends ScriptingExecutorTestCase {
 
 	@Override
@@ -51,22 +41,6 @@ public class JavaScriptExecutorTest extends ScriptingExecutorTestCase {
 	@Override
 	public ScriptingExecutor getScriptingExecutor() {
 		JavaScriptExecutor javaScriptExecutor = new JavaScriptExecutor();
-
-		PortalCache portalCache = Mockito.mock(PortalCache.class);
-
-		Mockito.when(
-			portalCache.get(Mockito.any(Serializable.class))
-		).thenReturn(
-			null
-		);
-
-		SingleVMPool singleVMPool = Mockito.mock(SingleVMPool.class);
-
-		Mockito.when(
-			singleVMPool.getPortalCache(Mockito.anyString())
-		).thenReturn(
-			portalCache
-		);
 
 		return javaScriptExecutor;
 	}

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/cluster/ElasticsearchClusterTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/cluster/ElasticsearchClusterTest.java
@@ -16,6 +16,7 @@ package com.liferay.portal.search.elasticsearch6.internal.cluster;
 
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.search.elasticsearch6.internal.index.IndexNameBuilder;
 
 import java.util.ArrayList;
@@ -27,10 +28,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-
 /**
  * @author Artur Aquino
  */
@@ -39,13 +36,11 @@ public class ElasticsearchClusterTest {
 
 	@Before
 	public void setUp() {
-		MockitoAnnotations.initMocks(this);
-
 		_replicasClusterContext = createReplicasClusterContext();
 	}
 
 	@Test
-	public void testReplicaIndexNamesIncludeSystemCompanyId() {
+	public void testReplicaIndexNamesIncludeSystemCompanyId() throws Exception {
 		long[] companyIds = {42, 142857};
 
 		setUpCompanyLocalService(getCompanies(companyIds));
@@ -76,7 +71,7 @@ public class ElasticsearchClusterTest {
 		return elasticsearchCluster.new ReplicasClusterContextImpl();
 	}
 
-	protected List<Company> getCompanies(long[] companyIds) {
+	protected List<Company> getCompanies(long[] companyIds) throws Exception {
 		List<Company> companies = new ArrayList<>(companyIds.length);
 
 		for (long companyId : companyIds) {
@@ -86,14 +81,9 @@ public class ElasticsearchClusterTest {
 		return companies;
 	}
 
-	protected Company getCompany(long companyId) {
-		Company company = Mockito.mock(Company.class);
-
-		Mockito.when(
-			company.getCompanyId()
-		).thenReturn(
-			companyId
-		);
+	protected Company getCompany(long companyId) throws Exception {
+		Company company = MockHelperUtil.setMethodAlwaysReturnExpected(
+			Company.class, "getCompanyId", companyId);
 
 		return company;
 	}
@@ -102,17 +92,15 @@ public class ElasticsearchClusterTest {
 		return "cid-" + companyId;
 	}
 
-	protected void setUpCompanyLocalService(List<Company> companies) {
-		Mockito.when(
-			_companyLocalService.getCompanies()
-		).thenReturn(
-			companies
-		);
+	protected void setUpCompanyLocalService(List<Company> companies)
+		throws Exception {
+
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_companyLocalService, "getCompanies", companies);
 	}
 
-	@Mock
-	private CompanyLocalService _companyLocalService;
-
+	private final CompanyLocalService _companyLocalService =
+		MockHelperUtil.initMock(CompanyLocalService.class);
 	private ReplicasClusterContext _replicasClusterContext;
 
 }

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/cluster/ReplicasClusterListenerTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/cluster/ReplicasClusterListenerTest.java
@@ -17,6 +17,7 @@ package com.liferay.portal.search.elasticsearch6.internal.cluster;
 import com.liferay.portal.kernel.cluster.ClusterEvent;
 import com.liferay.portal.kernel.test.CaptureHandler;
 import com.liferay.portal.kernel.test.JDKLoggerTestUtil;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 
 import java.util.List;
@@ -39,29 +40,20 @@ import org.mockito.MockitoAnnotations;
 public class ReplicasClusterListenerTest {
 
 	@Before
-	public void setUp() {
+	public void setUp() throws Exception {
 		MockitoAnnotations.initMocks(this);
 
 		setEmbeddedCluster(true);
 		setMasterExecutor(true);
 
-		Mockito.when(
-			_replicasClusterContext.getClusterSize()
-		).thenReturn(
-			_REPLICAS + 1
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_replicasClusterContext, "getClusterSize", _REPLICAS + 1);
 
-		Mockito.when(
-			_replicasClusterContext.getReplicasManager()
-		).thenReturn(
-			_replicasManager
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_replicasClusterContext, "getReplicasManager", _replicasManager);
 
-		Mockito.when(
-			_replicasClusterContext.getTargetIndexNames()
-		).thenReturn(
-			_INDICES
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_replicasClusterContext, "getTargetIndexNames", _INDICES);
 
 		_replicasClusterListener = new ReplicasClusterListener(
 			_replicasClusterContext);
@@ -74,12 +66,9 @@ public class ReplicasClusterListenerTest {
 	}
 
 	@Test
-	public void testLiferayClusterReportsEmpty() {
-		Mockito.when(
-			_replicasClusterContext.getClusterSize()
-		).thenReturn(
-			0
-		);
+	public void testLiferayClusterReportsEmpty() throws Exception {
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_replicasClusterContext, "getClusterSize", 0);
 
 		processClusterEvent();
 
@@ -105,7 +94,7 @@ public class ReplicasClusterListenerTest {
 	}
 
 	@Test
-	public void testNonmasterLiferayNodeDoesNothing() {
+	public void testNonmasterLiferayNodeDoesNothing() throws Exception {
 		setMasterExecutor(false);
 
 		processClusterEvent();
@@ -114,7 +103,7 @@ public class ReplicasClusterListenerTest {
 	}
 
 	@Test
-	public void testRemoteElasticsearchClusterIsLeftAlone() {
+	public void testRemoteElasticsearchClusterIsLeftAlone() throws Exception {
 		setEmbeddedCluster(false);
 
 		processClusterEvent();
@@ -180,20 +169,14 @@ public class ReplicasClusterListenerTest {
 		_replicasClusterListener.processClusterEvent(ClusterEvent.join());
 	}
 
-	protected void setEmbeddedCluster(boolean value) {
-		Mockito.when(
-			_replicasClusterContext.isEmbeddedOperationMode()
-		).thenReturn(
-			value
-		);
+	protected void setEmbeddedCluster(boolean value) throws Exception {
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_replicasClusterContext, "isEmbeddedOperationMode", value);
 	}
 
-	protected void setMasterExecutor(boolean value) {
-		Mockito.when(
-			_replicasClusterContext.isMaster()
-		).thenReturn(
-			value
-		);
+	protected void setMasterExecutor(boolean value) throws Exception {
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_replicasClusterContext, "isMaster", value);
 	}
 
 	private static final String[] _INDICES =
@@ -201,9 +184,8 @@ public class ReplicasClusterListenerTest {
 
 	private static final int _REPLICAS = RandomTestUtil.randomInt() - 1;
 
-	@Mock
-	private ReplicasClusterContext _replicasClusterContext;
-
+	private final ReplicasClusterContext _replicasClusterContext =
+		MockHelperUtil.initMock(ReplicasClusterContext.class);
 	private ReplicasClusterListener _replicasClusterListener;
 
 	@Mock

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/cluster/ReplicasManagerImplTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/cluster/ReplicasManagerImplTest.java
@@ -17,6 +17,7 @@ package com.liferay.portal.search.elasticsearch6.internal.cluster;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.search.elasticsearch6.internal.connection.ElasticsearchFixture;
 import com.liferay.portal.search.elasticsearch6.internal.connection.IndexCreator;
@@ -32,10 +33,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-
 /**
  * @author Artur Aquino
  */
@@ -44,8 +41,6 @@ public class ReplicasManagerImplTest {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
-
 		_replicasClusterContext = createReplicasClusterContext();
 	}
 
@@ -125,25 +120,17 @@ public class ReplicasManagerImplTest {
 		return new IndexName(testName.getMethodName() + "-" + companyId);
 	}
 
-	protected void setUpCompanyLocalService(long companyId) {
-		Company company = Mockito.mock(Company.class);
+	protected void setUpCompanyLocalService(long companyId) throws Exception {
+		Company company = MockHelperUtil.setMethodAlwaysReturnExpected(
+			Company.class, "getCompanyId", companyId);
 
-		Mockito.when(
-			company.getCompanyId()
-		).thenReturn(
-			companyId
-		);
-
-		Mockito.when(
-			_companyLocalService.getCompanies()
-		).thenReturn(
-			Collections.singletonList(company)
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_companyLocalService, "getCompanies",
+			Collections.singletonList(company));
 	}
 
-	@Mock
-	private CompanyLocalService _companyLocalService;
-
+	private final CompanyLocalService _companyLocalService =
+		MockHelperUtil.initMock(CompanyLocalService.class);
 	private ReplicasClusterContext _replicasClusterContext;
 	private final TestCluster _testCluster = new TestCluster(2, this);
 

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/connection/EmbeddedElasticsearchConnectionHttpTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/connection/EmbeddedElasticsearchConnectionHttpTest.java
@@ -41,8 +41,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.mockito.MockitoAnnotations;
-
 /**
  * @author André de Oliveira
  */
@@ -50,8 +48,6 @@ public class EmbeddedElasticsearchConnectionHttpTest {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
-
 		_clusterName = RandomTestUtil.randomString();
 
 		Map<String, Object> properties = new HashMap<String, Object>() {

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/connection/EmbeddedElasticsearchPluginManagerTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/connection/EmbeddedElasticsearchPluginManagerTest.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.search.elasticsearch6.internal.connection;
 
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 
 import java.io.IOException;
@@ -200,19 +201,12 @@ public class EmbeddedElasticsearchPluginManagerTest {
 			_pluginManager
 		).getInstalledPluginsPaths();
 
-		Mockito.doReturn(
-			_pluginManager
-		).when(
-			_pluginManagerFactory
-		).createPluginManager();
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_pluginManagerFactory, "createPluginManager", _pluginManager);
 
-		Mockito.doReturn(
-			_pluginManager
-		).when(
-			_pluginManagerFactory
-		).createPluginManager(
-			Mockito.<PluginZip>any()
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_pluginManagerFactory, "createPluginManager", _pluginManager,
+			PluginZip.class);
 	}
 
 	protected void setUpPluginZipFactory() throws Exception {
@@ -232,8 +226,8 @@ public class EmbeddedElasticsearchPluginManagerTest {
 	@Mock
 	private PluginManager _pluginManager;
 
-	@Mock
-	private PluginManagerFactory _pluginManagerFactory;
+	private final PluginManagerFactory _pluginManagerFactory =
+		MockHelperUtil.initMock(PluginManagerFactory.class);
 
 	@Mock
 	private PluginZip _pluginZip;

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/connection/IndexCreator.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/connection/IndexCreator.java
@@ -14,13 +14,13 @@
 
 package com.liferay.portal.search.elasticsearch6.internal.connection;
 
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
+
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequestBuilder;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.IndicesAdminClient;
 import org.elasticsearch.common.settings.Settings;
-
-import org.mockito.Mockito;
 
 /**
  * @author André de Oliveira
@@ -50,7 +50,8 @@ public class IndexCreator {
 		IndexCreationHelper indexCreationHelper = _indexCreationHelper;
 
 		if (indexCreationHelper == null) {
-			indexCreationHelper = Mockito.mock(IndexCreationHelper.class);
+			indexCreationHelper = MockHelperUtil.initMock(
+				IndexCreationHelper.class);
 		}
 
 		indexCreationHelper.contribute(createIndexRequestBuilder);

--- a/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/connection/RemoteElasticsearchConnectionTest.java
+++ b/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/test/java/com/liferay/portal/search/elasticsearch6/internal/connection/RemoteElasticsearchConnectionTest.java
@@ -32,9 +32,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-
 /**
  * @author André de Oliveira
  */
@@ -42,8 +39,6 @@ public class RemoteElasticsearchConnectionTest {
 
 	@Before
 	public void setUp() {
-		MockitoAnnotations.initMocks(this);
-
 		_remoteElasticsearchConnection = new RemoteElasticsearchConnection();
 
 		_remoteElasticsearchConnection.props = _props;
@@ -138,9 +133,7 @@ public class RemoteElasticsearchConnectionTest {
 		Assert.assertEquals(port, inetSocketAddress.getPort());
 	}
 
-	@Mock
 	private Props _props;
-
 	private RemoteElasticsearchConnection _remoteElasticsearchConnection;
 
 }

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/expando/BaseExpandoTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/expando/BaseExpandoTestCase.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
 import com.liferay.portal.kernel.search.query.FieldQueryFactory;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.search.analysis.FieldQueryBuilderFactory;
@@ -157,28 +158,25 @@ public abstract class BaseExpandoTestCase extends BaseIndexingTestCase {
 	}
 
 	protected ExpandoBridge createExpandoBridge(
-		String attributeName, int indexType) {
+			String attributeName, int indexType)
+		throws Exception {
 
-		ExpandoBridge expandoBridge = Mockito.mock(ExpandoBridge.class);
+		ExpandoBridge expandoBridge =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				ExpandoBridge.class, "getAttributeNames",
+				Collections.enumeration(
+					Collections.singletonList(attributeName)));
 
-		Mockito.doReturn(
-			Collections.enumeration(Collections.singletonList(attributeName))
-		).when(
-			expandoBridge
-		).getAttributeNames();
-
-		Mockito.doReturn(
-			createUnicodeProperties(indexType)
-		).when(
-			expandoBridge
-		).getAttributeProperties(
-			Mockito.anyString()
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			expandoBridge, "getAttributeProperties",
+			createUnicodeProperties(indexType), String.class);
 
 		return expandoBridge;
 	}
 
-	protected ExpandoBridgeFactory createExpandoBridgeFactory() {
+	protected ExpandoBridgeFactory createExpandoBridgeFactory()
+		throws Exception {
+
 		ExpandoBridgeFactory expandoBridgeFactory = Mockito.mock(
 			ExpandoBridgeFactory.class);
 
@@ -228,25 +226,23 @@ public abstract class BaseExpandoTestCase extends BaseIndexingTestCase {
 		return expandoBridgeIndexer;
 	}
 
-	protected ExpandoColumn createExpandoColumn(int indexType) {
-		ExpandoColumn expandoColumn = Mockito.mock(ExpandoColumn.class);
+	protected ExpandoColumn createExpandoColumn(int indexType)
+		throws Exception {
 
-		Mockito.doReturn(
-			createUnicodeProperties(indexType)
-		).when(
-			expandoColumn
-		).getTypeSettingsProperties();
+		ExpandoColumn expandoColumn =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				ExpandoColumn.class, "getTypeSettingsProperties",
+				createUnicodeProperties(indexType));
 
-		Mockito.doReturn(
-			ExpandoColumnConstants.STRING
-		).when(
-			expandoColumn
-		).getType();
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			expandoColumn, "getType", ExpandoColumnConstants.STRING);
 
 		return expandoColumn;
 	}
 
-	protected ExpandoColumnLocalService createExpandoColumnLocalService() {
+	protected ExpandoColumnLocalService createExpandoColumnLocalService()
+		throws Exception {
+
 		ExpandoColumnLocalService expandoColumnLocalService = Mockito.mock(
 			ExpandoColumnLocalService.class);
 
@@ -271,7 +267,7 @@ public abstract class BaseExpandoTestCase extends BaseIndexingTestCase {
 	}
 
 	protected ExpandoQueryContributorHelper
-		createExpandoQueryContributorHelper() {
+		createExpandoQueryContributorHelper() throws Exception {
 
 		return new ExpandoQueryContributorHelper(
 			createExpandoBridgeFactory(), createExpandoBridgeIndexer(),

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/facet/display/context/CustomFacetDisplayContextTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/custom/facet/display/context/CustomFacetDisplayContextTest.java
@@ -17,6 +17,7 @@ package com.liferay.portal.search.web.internal.custom.facet.display.context;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.search.facet.collector.FacetCollector;
 import com.liferay.portal.kernel.search.facet.collector.TermCollector;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 
 import java.util.Collections;
@@ -26,24 +27,15 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-
 /**
  * @author Wade Cao
  */
 public class CustomFacetDisplayContextTest {
 
 	@Before
-	public void setUp() {
-		MockitoAnnotations.initMocks(this);
-
-		Mockito.doReturn(
-			_facetCollector
-		).when(
-			_facet
-		).getFacetCollector();
+	public void setUp() throws Exception {
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_facet, "getFacetCollector", _facetCollector);
 	}
 
 	@Test
@@ -194,36 +186,29 @@ public class CustomFacetDisplayContextTest {
 		return customFacetDisplayBuilder.build();
 	}
 
-	protected TermCollector createTermCollector(String fieldName, int count) {
-		TermCollector termCollector = Mockito.mock(TermCollector.class);
+	protected TermCollector createTermCollector(String fieldName, int count)
+		throws Exception {
 
-		Mockito.doReturn(
-			count
-		).when(
-			termCollector
-		).getFrequency();
+		TermCollector termCollector =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				TermCollector.class, "getFrequency", count);
 
-		Mockito.doReturn(
-			fieldName
-		).when(
-			termCollector
-		).getTerm();
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			termCollector, "getTerm", fieldName);
 
 		return termCollector;
 	}
 
-	protected void setUpOneTermCollector(String fieldName, int count) {
-		Mockito.doReturn(
-			Collections.singletonList(createTermCollector(fieldName, count))
-		).when(
-			_facetCollector
-		).getTermCollectors();
+	protected void setUpOneTermCollector(String fieldName, int count)
+		throws Exception {
+
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_facetCollector, "getTermCollectors",
+			Collections.singletonList(createTermCollector(fieldName, count)));
 	}
 
-	@Mock
-	private Facet _facet;
-
-	@Mock
-	private FacetCollector _facetCollector;
+	private final Facet _facet = MockHelperUtil.initMock(Facet.class);
+	private final FacetCollector _facetCollector = MockHelperUtil.initMock(
+		FacetCollector.class);
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/facet/display/context/AssetCategoriesSearchFacetDisplayContextTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/facet/display/context/AssetCategoriesSearchFacetDisplayContextTest.java
@@ -20,6 +20,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.search.facet.collector.FacetCollector;
 import com.liferay.portal.kernel.search.facet.collector.TermCollector;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.search.web.internal.facet.display.builder.AssetCategoriesSearchFacetDisplayBuilder;
@@ -43,14 +44,11 @@ import org.mockito.MockitoAnnotations;
 public class AssetCategoriesSearchFacetDisplayContextTest {
 
 	@Before
-	public void setUp() {
+	public void setUp() throws Exception {
 		MockitoAnnotations.initMocks(this);
 
-		Mockito.doReturn(
-			_facetCollector
-		).when(
-			_facet
-		).getFacetCollector();
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_facet, "getFacetCollector", _facetCollector);
 	}
 
 	@Test
@@ -293,22 +291,16 @@ public class AssetCategoriesSearchFacetDisplayContextTest {
 			assetCategoriesSearchFacetDisplayContext.isRenderNothing());
 	}
 
-	protected AssetCategory createAssetCategory(long assetCategoryId) {
-		AssetCategory assetCategory = Mockito.mock(AssetCategory.class);
+	protected AssetCategory createAssetCategory(long assetCategoryId)
+		throws Exception {
 
-		Mockito.doReturn(
-			assetCategoryId
-		).when(
-			assetCategory
-		).getCategoryId();
+		AssetCategory assetCategory =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				AssetCategory.class, "getCategoryId", assetCategoryId);
 
-		Mockito.doReturn(
-			String.valueOf(assetCategoryId)
-		).when(
-			assetCategory
-		).getTitle(
-			(Locale)Mockito.any()
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			assetCategory, "getTitle", String.valueOf(assetCategoryId),
+			Locale.class);
 
 		Mockito.doReturn(
 			assetCategory
@@ -350,26 +342,20 @@ public class AssetCategoriesSearchFacetDisplayContextTest {
 	}
 
 	protected TermCollector createTermCollector(
-		long assetCategoryId, int frequency) {
+			long assetCategoryId, int frequency)
+		throws Exception {
 
-		TermCollector termCollector = Mockito.mock(TermCollector.class);
+		TermCollector termCollector =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				TermCollector.class, "getFrequency", frequency);
 
-		Mockito.doReturn(
-			frequency
-		).when(
-			termCollector
-		).getFrequency();
-
-		Mockito.doReturn(
-			String.valueOf(assetCategoryId)
-		).when(
-			termCollector
-		).getTerm();
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			termCollector, "getTerm", String.valueOf(assetCategoryId));
 
 		return termCollector;
 	}
 
-	protected void setUpAssetCategory(long assetCategoryId) {
+	protected void setUpAssetCategory(long assetCategoryId) throws Exception {
 		AssetCategory assetCategory = createAssetCategory(assetCategoryId);
 
 		Mockito.doReturn(
@@ -381,7 +367,9 @@ public class AssetCategoriesSearchFacetDisplayContextTest {
 		);
 	}
 
-	protected void setUpAssetCategoryUnauthorized(long assetCategoryId) {
+	protected void setUpAssetCategoryUnauthorized(long assetCategoryId)
+		throws Exception {
+
 		AssetCategory assetCategory = createAssetCategory(assetCategoryId);
 
 		Mockito.doReturn(
@@ -393,13 +381,13 @@ public class AssetCategoriesSearchFacetDisplayContextTest {
 		);
 	}
 
-	protected void setUpOneTermCollector(long assetCategoryId, int frequency) {
-		Mockito.doReturn(
+	protected void setUpOneTermCollector(long assetCategoryId, int frequency)
+		throws Exception {
+
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_facetCollector, "getTermCollectors",
 			Collections.singletonList(
-				createTermCollector(assetCategoryId, frequency))
-		).when(
-			_facetCollector
-		).getTermCollectors();
+				createTermCollector(assetCategoryId, frequency)));
 	}
 
 	@Mock
@@ -408,10 +396,8 @@ public class AssetCategoriesSearchFacetDisplayContextTest {
 	@Mock
 	private AssetCategoryPermissionChecker _assetCategoryPermissionChecker;
 
-	@Mock
-	private Facet _facet;
-
-	@Mock
-	private FacetCollector _facetCollector;
+	private final Facet _facet = MockHelperUtil.initMock(Facet.class);
+	private final FacetCollector _facetCollector = MockHelperUtil.initMock(
+		FacetCollector.class);
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/facet/display/context/AssetTagsSearchFacetDisplayContextTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/facet/display/context/AssetTagsSearchFacetDisplayContextTest.java
@@ -18,6 +18,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.search.facet.collector.FacetCollector;
 import com.liferay.portal.kernel.search.facet.collector.TermCollector;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.search.web.internal.facet.display.builder.AssetTagsSearchFacetDisplayBuilder;
 
@@ -28,24 +29,15 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-
 /**
  * @author André de Oliveira
  */
 public class AssetTagsSearchFacetDisplayContextTest {
 
 	@Before
-	public void setUp() {
-		MockitoAnnotations.initMocks(this);
-
-		Mockito.doReturn(
-			_facetCollector
-		).when(
-			_facet
-		).getFacetCollector();
+	public void setUp() throws Exception {
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_facet, "getFacetCollector", _facetCollector);
 	}
 
 	@Test
@@ -214,37 +206,30 @@ public class AssetTagsSearchFacetDisplayContextTest {
 		return assetTagsSearchFacetDisplayContext;
 	}
 
-	protected TermCollector createTermCollector(String term, int frequency) {
-		TermCollector termCollector = Mockito.mock(TermCollector.class);
+	protected TermCollector createTermCollector(String term, int frequency)
+		throws Exception {
 
-		Mockito.doReturn(
-			frequency
-		).when(
-			termCollector
-		).getFrequency();
+		TermCollector termCollector =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				TermCollector.class, "getFrequency", frequency);
 
-		Mockito.doReturn(
-			term
-		).when(
-			termCollector
-		).getTerm();
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			termCollector, "getTerm", term);
 
 		return termCollector;
 	}
 
-	protected void setUpOneTermCollector(String facetParam, int frequency) {
-		Mockito.doReturn(
+	protected void setUpOneTermCollector(String facetParam, int frequency)
+		throws Exception {
+
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_facetCollector, "getTermCollectors",
 			Collections.singletonList(
-				createTermCollector(facetParam, frequency))
-		).when(
-			_facetCollector
-		).getTermCollectors();
+				createTermCollector(facetParam, frequency)));
 	}
 
-	@Mock
-	private Facet _facet;
-
-	@Mock
-	private FacetCollector _facetCollector;
+	private final Facet _facet = MockHelperUtil.initMock(Facet.class);
+	private final FacetCollector _facetCollector = MockHelperUtil.initMock(
+		FacetCollector.class);
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/facet/display/context/FolderSearchFacetDisplayContextTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/facet/display/context/FolderSearchFacetDisplayContextTest.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.search.facet.collector.DefaultTermCollector;
 import com.liferay.portal.kernel.search.facet.collector.FacetCollector;
 import com.liferay.portal.kernel.search.facet.collector.TermCollector;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.search.web.internal.facet.display.builder.FolderSearchFacetDisplayBuilder;
 
@@ -40,14 +41,11 @@ import org.mockito.MockitoAnnotations;
 public class FolderSearchFacetDisplayContextTest {
 
 	@Before
-	public void setUp() {
+	public void setUp() throws Exception {
 		MockitoAnnotations.initMocks(this);
 
-		Mockito.doReturn(
-			_facetCollector
-		).when(
-			_facet
-		).getFacetCollector();
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_facet, "getFacetCollector", _facetCollector);
 	}
 
 	@Test
@@ -77,11 +75,8 @@ public class FolderSearchFacetDisplayContextTest {
 	public void testEmptySearchResultsWithEmptyTermCollectors()
 		throws Exception {
 
-		Mockito.when(
-			_facetCollector.getTermCollectors()
-		).thenReturn(
-			Collections.emptyList()
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_facetCollector, "getTermCollectors", Collections.emptyList());
 
 		FolderSearchFacetDisplayContext folderSearchFacetDisplayContext =
 			createDisplayContext(null);
@@ -134,11 +129,9 @@ public class FolderSearchFacetDisplayContextTest {
 	public void testEmptySearchResultsWithUnmatchedTermCollector()
 		throws Exception {
 
-		Mockito.when(
-			_facetCollector.getTermCollectors()
-		).thenReturn(
-			Arrays.asList(new DefaultTermCollector("0", 200))
-		);
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_facetCollector, "getTermCollectors",
+			Arrays.asList(new DefaultTermCollector("0", 200)));
 
 		FolderSearchFacetDisplayContext folderSearchFacetDisplayContext =
 			createDisplayContext(null);
@@ -268,37 +261,30 @@ public class FolderSearchFacetDisplayContextTest {
 		return folderSearchFacetDisplayContext;
 	}
 
-	protected TermCollector createTermCollector(long folderId, int count) {
-		TermCollector termCollector = Mockito.mock(TermCollector.class);
+	protected TermCollector createTermCollector(long folderId, int count)
+		throws Exception {
 
-		Mockito.doReturn(
-			count
-		).when(
-			termCollector
-		).getFrequency();
+		TermCollector termCollector =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				TermCollector.class, "getFrequency", count);
 
-		Mockito.doReturn(
-			String.valueOf(folderId)
-		).when(
-			termCollector
-		).getTerm();
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			termCollector, "getTerm", String.valueOf(folderId));
 
 		return termCollector;
 	}
 
-	protected void setUpOneTermCollector(long folderId, int count) {
-		Mockito.doReturn(
-			Collections.singletonList(createTermCollector(folderId, count))
-		).when(
-			_facetCollector
-		).getTermCollectors();
+	protected void setUpOneTermCollector(long folderId, int count)
+		throws Exception {
+
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_facetCollector, "getTermCollectors",
+			Collections.singletonList(createTermCollector(folderId, count)));
 	}
 
-	@Mock
-	private Facet _facet;
-
-	@Mock
-	private FacetCollector _facetCollector;
+	private final Facet _facet = MockHelperUtil.initMock(Facet.class);
+	private final FacetCollector _facetCollector = MockHelperUtil.initMock(
+		FacetCollector.class);
 
 	@Mock
 	private FolderTitleLookup _folderTitleLookup;

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/facet/display/context/ScopeSearchFacetDisplayContextTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/facet/display/context/ScopeSearchFacetDisplayContextTest.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.search.facet.collector.FacetCollector;
 import com.liferay.portal.kernel.search.facet.collector.TermCollector;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.search.web.internal.facet.display.builder.ScopeSearchFacetDisplayBuilder;
 
@@ -40,14 +41,11 @@ import org.mockito.MockitoAnnotations;
 public class ScopeSearchFacetDisplayContextTest {
 
 	@Before
-	public void setUp() {
+	public void setUp() throws Exception {
 		MockitoAnnotations.initMocks(this);
 
-		Mockito.doReturn(
-			_facetCollector
-		).when(
-			_facet
-		).getFacetCollector();
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_facet, "getFacetCollector", _facetCollector);
 	}
 
 	@Test
@@ -217,56 +215,39 @@ public class ScopeSearchFacetDisplayContextTest {
 	}
 
 	protected Group createGroup(long groupId, String name) throws Exception {
-		Group group = Mockito.mock(Group.class);
+		Group group = MockHelperUtil.setMethodAlwaysReturnExpected(
+			Group.class, "getDescriptiveName", name, Locale.class);
 
-		Mockito.doReturn(
-			name
-		).when(
-			group
-		).getDescriptiveName(
-			Mockito.<Locale>any()
-		);
-
-		Mockito.doReturn(
-			groupId
-		).when(
-			group
-		).getGroupId();
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			group, "getGroupId", groupId);
 
 		return group;
 	}
 
-	protected TermCollector createTermCollector(long groupId, int count) {
-		TermCollector termCollector = Mockito.mock(TermCollector.class);
+	protected TermCollector createTermCollector(long groupId, int count)
+		throws Exception {
 
-		Mockito.doReturn(
-			count
-		).when(
-			termCollector
-		).getFrequency();
+		TermCollector termCollector =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				TermCollector.class, "getFrequency", count);
 
-		Mockito.doReturn(
-			String.valueOf(groupId)
-		).when(
-			termCollector
-		).getTerm();
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			termCollector, "getTerm", String.valueOf(groupId));
 
 		return termCollector;
 	}
 
-	protected void setUpOneTermCollector(long groupId, int count) {
-		Mockito.doReturn(
-			Collections.singletonList(createTermCollector(groupId, count))
-		).when(
-			_facetCollector
-		).getTermCollectors();
+	protected void setUpOneTermCollector(long groupId, int count)
+		throws Exception {
+
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_facetCollector, "getTermCollectors",
+			Collections.singletonList(createTermCollector(groupId, count)));
 	}
 
-	@Mock
-	private Facet _facet;
-
-	@Mock
-	private FacetCollector _facetCollector;
+	private final Facet _facet = MockHelperUtil.initMock(Facet.class);
+	private final FacetCollector _facetCollector = MockHelperUtil.initMock(
+		FacetCollector.class);
 
 	@Mock
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/facet/display/context/UserSearchFacetDisplayContextTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/facet/display/context/UserSearchFacetDisplayContextTest.java
@@ -14,10 +14,10 @@
 
 package com.liferay.portal.search.web.internal.facet.display.context;
 
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.search.facet.collector.FacetCollector;
 import com.liferay.portal.kernel.search.facet.collector.TermCollector;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.search.web.internal.facet.display.builder.UserSearchFacetDisplayBuilder;
 
@@ -28,24 +28,15 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-
 /**
  * @author Lino Alves
  */
 public class UserSearchFacetDisplayContextTest {
 
 	@Before
-	public void setUp() {
-		MockitoAnnotations.initMocks(this);
-
-		Mockito.doReturn(
-			_facetCollector
-		).when(
-			_facet
-		).getFacetCollector();
+	public void setUp() throws Exception {
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_facet, "getFacetCollector", _facetCollector);
 	}
 
 	@Test
@@ -195,48 +186,29 @@ public class UserSearchFacetDisplayContextTest {
 		return userSearchFacetDisplayBuilder.build();
 	}
 
-	protected TermCollector createTermCollector(String userName, int count) {
-		TermCollector termCollector = Mockito.mock(TermCollector.class);
+	protected TermCollector createTermCollector(String userName, int count)
+		throws Exception {
 
-		Mockito.doReturn(
-			count
-		).when(
-			termCollector
-		).getFrequency();
+		TermCollector termCollector =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				TermCollector.class, "getFrequency", count);
 
-		Mockito.doReturn(
-			userName
-		).when(
-			termCollector
-		).getTerm();
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			termCollector, "getTerm", userName);
 
 		return termCollector;
 	}
 
-	protected User createUser(String userName) throws Exception {
-		User user = Mockito.mock(User.class);
+	protected void setUpOneTermCollector(String userName, int count)
+		throws Exception {
 
-		Mockito.doReturn(
-			userName
-		).when(
-			user
-		).getFullName();
-
-		return user;
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_facetCollector, "getTermCollectors",
+			Collections.singletonList(createTermCollector(userName, count)));
 	}
 
-	protected void setUpOneTermCollector(String userName, int count) {
-		Mockito.doReturn(
-			Collections.singletonList(createTermCollector(userName, count))
-		).when(
-			_facetCollector
-		).getTermCollectors();
-	}
-
-	@Mock
-	private Facet _facet;
-
-	@Mock
-	private FacetCollector _facetCollector;
+	private final Facet _facet = MockHelperUtil.initMock(Facet.class);
+	private final FacetCollector _facetCollector = MockHelperUtil.initMock(
+		FacetCollector.class);
 
 }

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/modified/facet/builder/ModifiedFacetBuilderTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/modified/facet/builder/ModifiedFacetBuilderTest.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.facet.config.FacetConfiguration;
 import com.liferay.portal.kernel.search.facet.util.RangeParserUtil;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.DateFormatFactory;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -40,15 +41,13 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.mockito.Mockito;
-
 /**
  * @author Adam Brandizzi
  */
 public class ModifiedFacetBuilderTest {
 
 	@Before
-	public void setUp() {
+	public void setUp() throws Exception {
 		calendarFactory = createCalendarFactory();
 		dateFormatFactory = new DateFormatFactoryImpl();
 		filterBuilders = new FilterBuildersImpl();
@@ -68,12 +67,10 @@ public class ModifiedFacetBuilderTest {
 	}
 
 	@Test
-	public void testBuiltInNamedRange() {
-		Mockito.doReturn(
-			new GregorianCalendar(2018, Calendar.MARCH, 1, 15, 19, 23)
-		).when(
-			calendarFactory
-		).getCalendar();
+	public void testBuiltInNamedRange() throws Exception {
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			calendarFactory, "getCalendar",
+			new GregorianCalendar(2018, Calendar.MARCH, 1, 15, 19, 23));
 
 		ModifiedFacetBuilder modifiedFacetBuilder =
 			createModifiedFacetBuilder();
@@ -163,14 +160,10 @@ public class ModifiedFacetBuilderTest {
 		}
 	}
 
-	protected CalendarFactory createCalendarFactory() {
-		CalendarFactory calendarFactory = Mockito.mock(CalendarFactory.class);
-
-		Mockito.doReturn(
-			Calendar.getInstance()
-		).when(
-			calendarFactory
-		).getCalendar();
+	protected CalendarFactory createCalendarFactory() throws Exception {
+		CalendarFactory calendarFactory =
+			MockHelperUtil.setMethodAlwaysReturnExpected(
+				CalendarFactory.class, "getCalendar", Calendar.getInstance());
 
 		return calendarFactory;
 	}

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/modified/facet/display/context/ModifiedFacetDisplayBuilderTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/modified/facet/display/context/ModifiedFacetDisplayBuilderTest.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.search.facet.collector.FacetCollector;
 import com.liferay.portal.kernel.search.facet.collector.TermCollector;
 import com.liferay.portal.kernel.search.facet.config.FacetConfiguration;
+import com.liferay.portal.kernel.test.util.MockHelperUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.DateFormatFactory;
@@ -68,21 +69,15 @@ public class ModifiedFacetDisplayBuilderTest {
 		setUpHtmlUtil();
 		setUpPortalUtil();
 
-		Mockito.doReturn(
-			_facetCollector
-		).when(
-			_facet
-		).getFacetCollector();
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_facet, "getFacetCollector", _facetCollector);
 
-		Mockito.doReturn(
-			getFacetConfiguration()
-		).when(
-			_facet
-		).getFacetConfiguration();
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_facet, "getFacetConfiguration", getFacetConfiguration());
 	}
 
 	@Test
-	public void testCustomRangeHasFrequency() {
+	public void testCustomRangeHasFrequency() throws Exception {
 		String from = "2018-01-01";
 		String to = "2018-01-31";
 
@@ -111,7 +106,7 @@ public class ModifiedFacetDisplayBuilderTest {
 	}
 
 	@Test
-	public void testCustomRangeHasTermCollectorFrequency() {
+	public void testCustomRangeHasTermCollectorFrequency() throws Exception {
 		int frequency = RandomTestUtil.randomInt();
 		TermCollector termCollector = mockTermCollector();
 
@@ -135,7 +130,7 @@ public class ModifiedFacetDisplayBuilderTest {
 	}
 
 	@Test
-	public void testIsNothingSelected() {
+	public void testIsNothingSelected() throws Exception {
 		ModifiedFacetDisplayBuilder modifiedFacetDisplayBuilder =
 			createDisplayBuilder();
 
@@ -146,7 +141,9 @@ public class ModifiedFacetDisplayBuilderTest {
 	}
 
 	@Test
-	public void testIsNothingSelectedWithFromAndToAttributes() {
+	public void testIsNothingSelectedWithFromAndToAttributes()
+		throws Exception {
+
 		ModifiedFacetDisplayBuilder modifiedFacetDisplayBuilder =
 			createDisplayBuilder();
 
@@ -160,7 +157,7 @@ public class ModifiedFacetDisplayBuilderTest {
 	}
 
 	@Test
-	public void testIsNothingSelectedWithSelectedRange() {
+	public void testIsNothingSelectedWithSelectedRange() throws Exception {
 		ModifiedFacetDisplayBuilder modifiedFacetDisplayBuilder =
 			createDisplayBuilder();
 
@@ -173,7 +170,7 @@ public class ModifiedFacetDisplayBuilderTest {
 	}
 
 	@Test
-	public void testIsRenderNothingFalseWithFromAndTo() {
+	public void testIsRenderNothingFalseWithFromAndTo() throws Exception {
 		ModifiedFacetDisplayBuilder modifiedFacetDisplayBuilder =
 			createDisplayBuilder();
 
@@ -188,7 +185,7 @@ public class ModifiedFacetDisplayBuilderTest {
 	}
 
 	@Test
-	public void testIsRenderNothingFalseWithHits() {
+	public void testIsRenderNothingFalseWithHits() throws Exception {
 		ModifiedFacetDisplayBuilder modifiedFacetDisplayBuilder =
 			createDisplayBuilder();
 
@@ -201,7 +198,7 @@ public class ModifiedFacetDisplayBuilderTest {
 	}
 
 	@Test
-	public void testIsRenderNothingFalseWithSelectedRange() {
+	public void testIsRenderNothingFalseWithSelectedRange() throws Exception {
 		ModifiedFacetDisplayBuilder modifiedFacetDisplayBuilder =
 			createDisplayBuilder();
 
@@ -215,7 +212,7 @@ public class ModifiedFacetDisplayBuilderTest {
 	}
 
 	@Test
-	public void testIsRenderNothingTrueWithNoHits() {
+	public void testIsRenderNothingTrueWithNoHits() throws Exception {
 		ModifiedFacetDisplayBuilder modifiedFacetDisplayBuilder =
 			createDisplayBuilder();
 
@@ -228,7 +225,7 @@ public class ModifiedFacetDisplayBuilderTest {
 	}
 
 	@Test
-	public void testMissingFromAndToParameters() {
+	public void testMissingFromAndToParameters() throws Exception {
 		ModifiedFacetDisplayBuilder modifiedFacetDisplayBuilder =
 			createDisplayBuilder();
 
@@ -243,7 +240,7 @@ public class ModifiedFacetDisplayBuilderTest {
 	}
 
 	@Test
-	public void testModifiedFacetTermDisplayContexts() {
+	public void testModifiedFacetTermDisplayContexts() throws Exception {
 		ModifiedFacetDisplayBuilder modifiedFacetDisplayBuilder =
 			createDisplayBuilder();
 
@@ -329,7 +326,9 @@ public class ModifiedFacetDisplayBuilderTest {
 		return dataJSONObject;
 	}
 
-	protected ModifiedFacetDisplayBuilder createDisplayBuilder() {
+	protected ModifiedFacetDisplayBuilder createDisplayBuilder()
+		throws Exception {
+
 		ModifiedFacetDisplayBuilder modifiedFacetDisplayBuilder =
 			new ModifiedFacetDisplayBuilder(
 				_calendarFactory, _dateFormatFactory, _http);
@@ -372,12 +371,12 @@ public class ModifiedFacetDisplayBuilderTest {
 		return facetConfiguration;
 	}
 
-	protected void mockFacetConfiguration(String... labelsAndRanges) {
-		Mockito.doReturn(
-			getFacetConfiguration(createDataJSONObject(labelsAndRanges))
-		).when(
-			_facet
-		).getFacetConfiguration();
+	protected void mockFacetConfiguration(String... labelsAndRanges)
+		throws Exception {
+
+		MockHelperUtil.setMethodAlwaysReturnExpected(
+			_facet, "getFacetConfiguration",
+			getFacetConfiguration(createDataJSONObject(labelsAndRanges)));
 	}
 
 	protected TermCollector mockTermCollector() {
@@ -446,9 +445,7 @@ public class ModifiedFacetDisplayBuilderTest {
 	private CalendarFactory _calendarFactory;
 	private DateFormatFactory _dateFormatFactory;
 	private DateRangeFactory _dateRangeFactory;
-
-	@Mock
-	private Facet _facet;
+	private final Facet _facet = MockHelperUtil.initMock(Facet.class);
 
 	@Mock
 	private FacetCollector _facetCollector;

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/result/display/builder/SearchResultContentDisplayBuilderTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/result/display/builder/SearchResultContentDisplayBuilderTest.java
@@ -305,7 +305,6 @@ public class SearchResultContentDisplayBuilderTest {
 	@Mock
 	private PortletURL _editPortletURL;
 
-	@Mock
 	private PermissionChecker _permissionChecker;
 
 	@Mock
@@ -314,7 +313,6 @@ public class SearchResultContentDisplayBuilderTest {
 	@Mock
 	private PortletURL _renderPortletURL;
 
-	@Mock
 	private RenderRequest _renderRequest;
 
 	@Mock

--- a/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/result/display/builder/SearchResultSummaryDisplayBuilderTest.java
+++ b/modules/apps/portal-search/portal-search-web/src/test/java/com/liferay/portal/search/web/internal/result/display/builder/SearchResultSummaryDisplayBuilderTest.java
@@ -550,8 +550,6 @@ public class SearchResultSummaryDisplayBuilderTest {
 	protected IndexerRegistry indexerRegistry;
 
 	protected Locale locale = Locale.US;
-
-	@Mock
 	protected PermissionChecker permissionChecker;
 
 	@Mock

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/searcher/FacetedSearcherImplTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/searcher/FacetedSearcherImplTest.java
@@ -136,9 +136,7 @@ public class FacetedSearcherImplTest {
 			preFilterContributorHelper, searchEngineHelper);
 	}
 
-	@Mock
 	protected ExpandoQueryContributorHelper expandoQueryContributorHelper;
-
 	protected FacetedSearcher facetedSearcher;
 
 	@Mock

--- a/modules/apps/portal/portal-spring-extender-impl/src/test/java/com/liferay/portal/spring/extender/internal/classloader/BundleResolverClassLoaderTest.java
+++ b/modules/apps/portal/portal-spring-extender-impl/src/test/java/com/liferay/portal/spring/extender/internal/classloader/BundleResolverClassLoaderTest.java
@@ -137,10 +137,7 @@ public class BundleResolverClassLoaderTest extends PowerMockito {
 	@Mock
 	private Bundle _bundle2;
 
-	@Mock
 	private Enumeration<URL> _enumeration;
-
-	@Mock
 	private URL _url;
 
 }

--- a/modules/apps/wiki/wiki-editor-configuration/src/test/java/com/liferay/wiki/editor/configuration/internal/WikiAttachmentImageCreoleEditorConfigContributorTest.java
+++ b/modules/apps/wiki/wiki-editor-configuration/src/test/java/com/liferay/wiki/editor/configuration/internal/WikiAttachmentImageCreoleEditorConfigContributorTest.java
@@ -27,7 +27,6 @@ import com.liferay.portal.language.LanguageImpl;
 import com.liferay.registry.BasicRegistryImpl;
 import com.liferay.registry.RegistryUtil;
 import com.liferay.wiki.constants.WikiPortletKeys;
-import com.liferay.wiki.service.WikiPageLocalService;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -295,8 +294,5 @@ public class WikiAttachmentImageCreoleEditorConfigContributorTest
 
 	@Mock
 	private ThemeDisplay _themeDisplay;
-
-	@Mock
-	private WikiPageLocalService _wikiPageLocalService;
 
 }

--- a/modules/apps/wiki/wiki-editor-configuration/src/test/java/com/liferay/wiki/editor/configuration/internal/WikiAttachmentImageHTMLEditorConfigContributorTest.java
+++ b/modules/apps/wiki/wiki-editor-configuration/src/test/java/com/liferay/wiki/editor/configuration/internal/WikiAttachmentImageHTMLEditorConfigContributorTest.java
@@ -27,7 +27,6 @@ import com.liferay.portal.language.LanguageImpl;
 import com.liferay.registry.BasicRegistryImpl;
 import com.liferay.registry.RegistryUtil;
 import com.liferay.wiki.constants.WikiPortletKeys;
-import com.liferay.wiki.service.WikiPageLocalService;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -293,8 +292,5 @@ public class WikiAttachmentImageHTMLEditorConfigContributorTest
 
 	@Mock
 	private ThemeDisplay _themeDisplay;
-
-	@Mock
-	private WikiPageLocalService _wikiPageLocalService;
 
 }

--- a/modules/apps/wiki/wiki-editor-configuration/src/test/java/com/liferay/wiki/editor/configuration/internal/WikiLinksCKEditorCreoleEditorConfigContributorTest.java
+++ b/modules/apps/wiki/wiki-editor-configuration/src/test/java/com/liferay/wiki/editor/configuration/internal/WikiLinksCKEditorCreoleEditorConfigContributorTest.java
@@ -223,10 +223,7 @@ public class WikiLinksCKEditorCreoleEditorConfigContributorTest
 	private ItemSelector _itemSelector;
 
 	private RequestBackedPortletURLFactory _requestBackedPortletURLFactory;
-
-	@Mock
 	private ThemeDisplay _themeDisplay;
-
 	private WikiLinksCKEditorCreoleEditorConfigContributor
 		_wikiLinksCKEditorCreoleEditorConfigContributor;
 

--- a/modules/apps/wiki/wiki-editor-configuration/src/test/java/com/liferay/wiki/editor/configuration/internal/WikiLinksCKEditorEditorConfigContributorTest.java
+++ b/modules/apps/wiki/wiki-editor-configuration/src/test/java/com/liferay/wiki/editor/configuration/internal/WikiLinksCKEditorEditorConfigContributorTest.java
@@ -219,10 +219,7 @@ public class WikiLinksCKEditorEditorConfigContributorTest extends PowerMockito {
 	private ItemSelector _itemSelector;
 
 	private RequestBackedPortletURLFactory _requestBackedPortletURLFactory;
-
-	@Mock
 	private ThemeDisplay _themeDisplay;
-
 	private WikiLinksCKEditorConfigContributor
 		_wikiLinksCKEditorEditorConfigContributor;
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/servlet/ServletResponseUtilRangeTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/servlet/ServletResponseUtilRangeTest.java
@@ -331,7 +331,6 @@ public class ServletResponseUtilRangeTest extends PowerMockito {
 	@Mock
 	private HttpServletRequest _request;
 
-	@Mock
 	private HttpServletResponse _response;
 
 }

--- a/portal-test/src/com/liferay/portal/kernel/test/util/MockHelperUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/MockHelperUtil.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.test.util;
+
+import com.liferay.portal.kernel.util.ProxyUtil;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Lance Ji
+ */
+public class MockHelperUtil {
+
+	public static <T> T initMock(Class<T> clazz) {
+		return (T)ProxyUtil.newProxyInstance(
+			clazz.getClassLoader(), new Class<?>[] {clazz},
+			new MockInvocationHandler(clazz));
+	}
+
+	public static <T> T setMethodAlwaysReturnExpected(
+			Class<T> clazz, String methodName, Object expectedResult,
+			Class<?>... parameterTypes)
+		throws Exception {
+
+		T mock = initMock(clazz);
+
+		setMethodAlwaysReturnExpected(
+			mock, methodName, expectedResult, parameterTypes);
+
+		return mock;
+	}
+
+	public static <T, R> void setMethodAlwaysReturnExpected(
+			T targetMock, String methodName, R expectedResult,
+			Class<?>... parameterTypes)
+		throws Exception {
+
+		InvocationHandler invocationHandler = ProxyUtil.getInvocationHandler(
+			targetMock);
+
+		if (invocationHandler instanceof MockInvocationHandler) {
+			MockInvocationHandler mockInvocationHandler =
+				(MockInvocationHandler)invocationHandler;
+
+			mockInvocationHandler._registerMethodReturnExpected(
+				methodName, expectedResult, parameterTypes);
+		}
+		else {
+			throw new UnsupportedOperationException("Not a valid mock");
+		}
+	}
+
+	private static class MethodInvocationHandler implements InvocationHandler {
+
+		@Override
+		public Object invoke(Object proxy, Method method, Object[] args)
+			throws Throwable {
+
+			return _expectedResult;
+		}
+
+		private MethodInvocationHandler(Object expectedResult) {
+			_expectedResult = expectedResult;
+		}
+
+		private void _setExpectedResult(Object expectedResult) {
+			_expectedResult = expectedResult;
+		}
+
+		private Object _expectedResult;
+
+	}
+
+	private static class MockInvocationHandler implements InvocationHandler {
+
+		@Override
+		public Object invoke(Object proxy, Method method, Object[] args)
+			throws Throwable {
+
+			InvocationHandler invocationHandler = _invocationHandlers.get(
+				method);
+
+			if (invocationHandler == null) {
+				Class<?> returnType = method.getReturnType();
+
+				if (_defaultInvokeValue.get(returnType) != null) {
+					return _defaultInvokeValue.get(returnType);
+				}
+
+				return null;
+			}
+
+			return invocationHandler.invoke(proxy, method, args);
+		}
+
+		private MockInvocationHandler(Class<?> clazz) {
+			_clazz = clazz;
+			_invocationHandlers = new HashMap<>();
+		}
+
+		private void _registerMethodReturnExpected(
+				String methodName, Object expectedResult,
+				Class<?>... parameterTypes)
+			throws Exception {
+
+			Method method = _clazz.getMethod(methodName, parameterTypes);
+
+			MethodInvocationHandler methodInvocationHandler =
+				_invocationHandlers.get(method);
+
+			if (methodInvocationHandler == null) {
+				methodInvocationHandler = new MethodInvocationHandler(
+					expectedResult);
+
+				_invocationHandlers.put(method, methodInvocationHandler);
+			}
+
+			methodInvocationHandler._setExpectedResult(expectedResult);
+		}
+
+		private static final Map<Class<?>, Object> _defaultInvokeValue =
+			new HashMap<Class<?>, Object>() {
+				{
+					put(int.class, 0);
+					put(Integer.class, 0);
+					put(long.class, 0L);
+					put(Long.class, 0L);
+					put(Boolean.class, false);
+					put(boolean.class, false);
+					put(String.class, "");
+					put(List.class, Collections.emptyList());
+					put(Set.class, Collections.emptySet());
+					put(Map.class, Collections.emptyMap());
+				}
+			};
+
+		private final Class<?> _clazz;
+		private final Map<Method, MethodInvocationHandler> _invocationHandlers;
+
+	}
+
+}


### PR DESCRIPTION
Hi Tina,

This pull is to show the initial setup the API to replace Mockito and PowerMockito.

For the default InvocationHandler we talked on Friday, I have changed the behavior to return a preset value instead of invoking the original method. I'll talk to you in the morning.

The first commit is from LPS-85008, it's just there so I won't make duplicated changes to same tests.

There is a lot of tests influenced with the API. This pull contains the first part of it. I need to talk to you about the process of replacing old mock with API.

Thanks.
Lance