### PR TITLE
LPS-87064 JSP template in theme

### DIFF
--- a/portal-impl/src/com/liferay/portal/deploy/hot/ThemeHotDeployListener.java
+++ b/portal-impl/src/com/liferay/portal/deploy/hot/ThemeHotDeployListener.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.template.TemplateResourceLoaderUtil;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.ThemeHelper;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.HashMap;
@@ -114,6 +115,22 @@ public class ThemeHotDeployListener extends BaseHotDeployListener {
 					StringBundler.concat(
 						String.valueOf(themes.size()), " themes for ",
 						servletContextName, " are available for use"));
+			}
+		}
+
+		if (_log.isWarnEnabled()) {
+			for (Theme theme : themes) {
+				String templateExtension = theme.getTemplateExtension();
+
+				if (templateExtension.equals(
+						ThemeHelper.TEMPLATE_EXTENSION_JSP)) {
+
+					_log.warn(
+						StringBundler.concat(
+							"JSP template is no longer supported for theme. ",
+							"Please Update theme ", theme.getName(),
+							" to use FreeMarker for forward compatibility."));
+				}
 			}
 		}
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/ThemeHelper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/ThemeHelper.java
@@ -34,6 +34,10 @@ public class ThemeHelper {
 
 	public static final String TEMPLATE_EXTENSION_FTL = "ftl";
 
+	/**
+	 * @deprecated As of Judson (7.1.x), with no direct replacement
+	 */
+	@Deprecated
 	public static final String TEMPLATE_EXTENSION_JSP = "jsp";
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/util/ThemeHelper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/ThemeHelper.java
@@ -21,8 +21,6 @@ import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.template.TemplateConstants;
 import com.liferay.portal.kernel.template.TemplateResourceLoaderUtil;
 
-import java.net.URL;
-
 import java.util.Objects;
 
 import javax.servlet.ServletContext;
@@ -157,25 +155,8 @@ public class ThemeHelper {
 			return TemplateResourceLoaderUtil.hasTemplateResource(
 				TemplateConstants.LANG_TYPE_FTL, resourcePath);
 		}
-		else {
-			URL url = null;
 
-			if (theme.isWARFile()) {
-				ServletContext themeServletContext = servletContext.getContext(
-					theme.getContextPath());
-
-				url = themeServletContext.getResource(resourcePath);
-			}
-			else {
-				url = servletContext.getResource(resourcePath);
-			}
-
-			if (url == null) {
-				return false;
-			}
-
-			return true;
-		}
+		return false;
 	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/util/ThemeHelper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/ThemeHelper.java
@@ -146,12 +146,12 @@ public class ThemeHelper {
 			return false;
 		}
 
-		String resourcePath = getResourcePath(
-			servletContext, theme, portletId, path);
-
 		String extension = theme.getTemplateExtension();
 
 		if (extension.equals(TEMPLATE_EXTENSION_FTL)) {
+			String resourcePath = getResourcePath(
+				servletContext, theme, portletId, path);
+
 			return TemplateResourceLoaderUtil.hasTemplateResource(
 				TemplateConstants.LANG_TYPE_FTL, resourcePath);
 		}

--- a/readme/BREAKING_CHANGES.markdown
+++ b/readme/BREAKING_CHANGES.markdown
@@ -1045,3 +1045,33 @@ the permissions.
 This change removes old logic that is no longer used in Liferay Portal.
 
 ---------------------------------------
+
+### Removed Support for JSP templates in Themes
+- **Date:** 2018-Nov-14
+- **JIRA Ticket:** LPS-87064
+
+#### What changed?
+
+- Themes can no longer use JSP for templates.
+- Some related supporting logic have been removed from the public APIs
+`com.liferay.portal.kernel.util.ThemeHelper` and
+`com.liferay.taglib.util.ThemeUtil`.
+
+#### Who is affected?
+
+This affects anyone who has themes using JSP templates or is using the removed
+methods.
+
+#### How should I update my code?
+
+If you have a theme using JSP templates, consider migrating it to FreeMarker.
+
+#### Why was this change made?
+
+JSP is not a real template engine. JSP templates in themes are rarely used and
+the recommendation is to use FreeMarker.
+
+The removal of JSP templates allows for an increased focus on existing and new
+template engines.
+
+---------------------------------------

--- a/util-taglib/src/com/liferay/taglib/util/ThemeUtil.java
+++ b/util-taglib/src/com/liferay/taglib/util/ThemeUtil.java
@@ -99,6 +99,10 @@ public class ThemeUtil {
 			ThemeHelper.TEMPLATE_EXTENSION_FTL);
 	}
 
+	/**
+	 * @deprecated As of Judson (7.1.x), with no direct replacement
+	 */
+	@Deprecated
 	public static void includeJSP(
 			ServletContext servletContext, HttpServletRequest request,
 			HttpServletResponse response, String path, Theme theme)
@@ -286,6 +290,10 @@ public class ThemeUtil {
 		return writer.toString();
 	}
 
+	/**
+	 * @deprecated As of Judson (7.1.x), with no direct replacement
+	 */
+	@Deprecated
 	protected static void doIncludeJSP(
 			ServletContext servletContext, HttpServletRequest request,
 			HttpServletResponse response, String path, Theme theme)

--- a/util-taglib/src/com/liferay/taglib/util/ThemeUtil.java
+++ b/util-taglib/src/com/liferay/taglib/util/ThemeUtil.java
@@ -14,7 +14,6 @@
 
 package com.liferay.taglib.util;
 
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.io.unsync.UnsyncStringWriter;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -80,11 +79,6 @@ public class ThemeUtil {
 
 		if (extension.equals(ThemeHelper.TEMPLATE_EXTENSION_FTL)) {
 			includeFTL(servletContext, request, response, path, theme, true);
-		}
-		else {
-			path = theme.getTemplatesPath() + StringPool.SLASH + path;
-
-			includeJSP(servletContext, request, response, path, theme);
 		}
 	}
 
@@ -162,9 +156,6 @@ public class ThemeUtil {
 				return doIncludeFTL(
 					servletContext, request, response, path, theme, false,
 					write);
-			}
-			else if (extension.equals(ThemeHelper.TEMPLATE_EXTENSION_JSP)) {
-				doIncludeJSP(servletContext, request, response, path, theme);
 			}
 
 			return null;


### PR DESCRIPTION
@tinatian 1) Added a warning at deploy time; 2) I can confirm theme.jsp.override.enabled is about using any template to override jsp, see https://issues.liferay.com/browse/LPS-14595 and https://issues.liferay.com/browse/LPS-19902