### PR TITLE
LPS-64822

### DIFF
--- a/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/configuration/XSLEngineConfiguration.java
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/configuration/XSLEngineConfiguration.java
@@ -29,6 +29,12 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 public interface XSLEngineConfiguration {
 
 	@Meta.AD(
+		deflt = "true", name = "prevent-local-connections-enabled",
+		required = false
+	)
+	public boolean preventLocalConnections();
+
+	@Meta.AD(
 		deflt = "true", name = "secure-processing-enabled", required = false
 	)
 	public boolean secureProcessingEnabled();

--- a/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/configuration/XSLEngineConfiguration.java
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/configuration/XSLEngineConfiguration.java
@@ -29,8 +29,7 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 public interface XSLEngineConfiguration {
 
 	@Meta.AD(
-		deflt = "true", name = "prevent-local-connections-enabled",
-		required = false
+		deflt = "true", name = "prevent-local-connections", required = false
 	)
 	public boolean preventLocalConnections();
 

--- a/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLSecureURIResolver.java
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLSecureURIResolver.java
@@ -14,8 +14,6 @@
 
 package com.liferay.portal.template.xsl.internal;
 
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.InetAddressUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.xsl.XSLURIResolver;
@@ -56,7 +54,7 @@ public class XSLSecureURIResolver implements XSLURIResolver {
 			if (InetAddressUtil.isLocalInetAddress(
 					InetAddress.getByName(url.getHost()))) {
 
-				_log.error(
+				throw new TransformerException(
 					StringBundler.concat(
 						"Denied access to resource: ", href,
 						". Access to local network is disabled by the secure ",
@@ -72,9 +70,6 @@ public class XSLSecureURIResolver implements XSLURIResolver {
 			throw new TransformerException("Error resolving URL reference", e);
 		}
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		XSLSecureURIResolver.class);
 
 	private final XSLURIResolver _xsluriResolver;
 

--- a/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLSecureURIResolver.java
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLSecureURIResolver.java
@@ -39,7 +39,11 @@ public class XSLSecureURIResolver implements XSLURIResolver {
 
 	@Override
 	public String getLanguageId() {
-		return _xsluriResolver.getLanguageId();
+		if (_xsluriResolver != null) {
+			return _xsluriResolver.getLanguageId();
+		}
+
+		return null;
 	}
 
 	@Override
@@ -57,11 +61,12 @@ public class XSLSecureURIResolver implements XSLURIResolver {
 						"Denied access to resource: ", href,
 						". Access to local network is disabled by the secure ",
 						"processing feature."));
-
-				return null;
+			}
+			else if (_xsluriResolver != null) {
+				return _xsluriResolver.resolve(href, base);
 			}
 
-			return _xsluriResolver.resolve(href, base);
+			return null;
 		}
 		catch (MalformedURLException | UnknownHostException e) {
 			throw new TransformerException("Error resolving URL reference", e);

--- a/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLSecureURIResolver.java
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLSecureURIResolver.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.template.xsl.internal;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.InetAddressUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.xsl.XSLURIResolver;
+
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.UnknownHostException;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerException;
+
+/**
+ * @author Marta Medio
+ */
+public class XSLSecureURIResolver implements XSLURIResolver {
+
+	public XSLSecureURIResolver(XSLURIResolver xsluriResolver) {
+		_xsluriResolver = xsluriResolver;
+	}
+
+	@Override
+	public String getLanguageId() {
+		return _xsluriResolver.getLanguageId();
+	}
+
+	@Override
+	public Source resolve(String href, String base)
+		throws TransformerException {
+
+		try {
+			URL url = new URL(href);
+
+			if (InetAddressUtil.isLocalInetAddress(
+					InetAddress.getByName(url.getHost()))) {
+
+				_log.error(
+					StringBundler.concat(
+						"Denied access to resource: ", href,
+						". Access to local network is disabled by the secure ",
+						"processing feature."));
+
+				return null;
+			}
+
+			return _xsluriResolver.resolve(href, base);
+		}
+		catch (MalformedURLException | UnknownHostException e) {
+			throw new TransformerException("Error resolving URL reference", e);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		XSLSecureURIResolver.class);
+
+	private final XSLURIResolver _xsluriResolver;
+
+}

--- a/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLTemplate.java
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLTemplate.java
@@ -69,6 +69,9 @@ public class XSLTemplate implements Template {
 		_errorTemplateResource = errorTemplateResource;
 		_templateContextHelper = templateContextHelper;
 
+		_preventLocalConnections =
+			xslEngineConfiguration.preventLocalConnections();
+
 		_transformerFactory = TransformerFactory.newInstance();
 
 		try {
@@ -113,6 +116,10 @@ public class XSLTemplate implements Template {
 		XSLErrorListener xslErrorListener = new XSLErrorListener(locale);
 
 		_transformerFactory.setErrorListener(xslErrorListener);
+
+		if (_preventLocalConnections) {
+			xslURIResolver = new XSLSecureURIResolver(xslURIResolver);
+		}
 
 		_transformerFactory.setURIResolver(xslURIResolver);
 
@@ -290,6 +297,7 @@ public class XSLTemplate implements Template {
 
 	private final Map<String, Object> _context;
 	private TemplateResource _errorTemplateResource;
+	private final boolean _preventLocalConnections;
 	private final TemplateContextHelper _templateContextHelper;
 	private final TransformerFactory _transformerFactory;
 	private StreamSource _xmlStreamSource;

--- a/modules/apps/portal-template/portal-template-xsl/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/resources/content/Language.properties
@@ -1,2 +1,3 @@
+prevent-local-connections-enabled=Prevent Local Connections
 secure-processing-enabled=Secure Processing Enabled
 xsl-engine-configuration-name=XSL Engine

--- a/modules/apps/portal-template/portal-template-xsl/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/resources/content/Language.properties
@@ -1,3 +1,3 @@
-prevent-local-connections-enabled=Prevent Local Connections
+prevent-local-connections=Prevent Local Connections
 secure-processing-enabled=Secure Processing Enabled
 xsl-engine-configuration-name=XSL Engine


### PR DESCRIPTION
Hi Tina,

can you please review and send to Brian/further? This is originally a security fix but I found out XSL template errors don't work at all.

After the code was moved to modules it doesn't use portal's xalan.jar and defaults to JDK's impl one. That's old and insecure 2.7.0 in Oracle's JDK8.

XSLTemplate when initializing and rendering use FactoryFinder/ServiceLoader and (wrong)? TCCL of journal-service `AggregateClassLoader` (in case of journal templates). I would expect the journal-service CL to delegate to the portal's WebappClassLoader but it fails to load the `META-INF/services/javax.xml.transform.TransformerFactory` resource from xalan.jar there => it uses system CL. Maybe there's a bug in our AggregateClassLoader. Setting directly portal CL into TCCL helped but I'm not sure this is right.

On top, the `com.sun.*` implementation doesn't have full-featured xsltc and Xalan java calls don't work in templates - cannot resolve the right LanguageUtil method (https://github.com/liferay/liferay-portal/blob/d9fef8cce3e03b99265693e8a192829d9408bd8d/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/dependencies/error.xsl#L22). Sometimes uses HttpServletRequest one and sometimes Locale one + is unable to cast.

Also when XSL error happens we are printing out wrong template - error.xsl - instead of the one that caused the issue.

Thank you.