### PR TITLE
LPS-89354 XSL templates engine use wrong Xalan 2.7.0 from JDK, errors cannot be rendered

### DIFF
--- a/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/configuration/XSLEngineConfiguration.java
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/configuration/XSLEngineConfiguration.java
@@ -29,6 +29,12 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 public interface XSLEngineConfiguration {
 
 	@Meta.AD(
+		deflt = "true", name = "prevent-local-connections-enabled",
+		required = false
+	)
+	public boolean preventLocalConnections();
+
+	@Meta.AD(
 		deflt = "true", name = "secure-processing-enabled", required = false
 	)
 	public boolean secureProcessingEnabled();

--- a/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/configuration/XSLEngineConfiguration.java
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/configuration/XSLEngineConfiguration.java
@@ -29,8 +29,7 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 public interface XSLEngineConfiguration {
 
 	@Meta.AD(
-		deflt = "true", name = "prevent-local-connections-enabled",
-		required = false
+		deflt = "true", name = "prevent-local-connections", required = false
 	)
 	public boolean preventLocalConnections();
 

--- a/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/configuration/XSLEngineConfiguration.java
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/configuration/XSLEngineConfiguration.java
@@ -28,6 +28,9 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 )
 public interface XSLEngineConfiguration {
 
+	@Meta.AD(deflt = "false", name = "display-xsl-errors", required = false)
+	public boolean displayXSLErrors();
+
 	@Meta.AD(
 		deflt = "true", name = "prevent-local-connections", required = false
 	)

--- a/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLErrorListener.java
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLErrorListener.java
@@ -111,6 +111,10 @@ public class XSLErrorListener implements ErrorListener {
 			}
 		}
 
+		if (rootCause == null) {
+			rootCause = exception;
+		}
+
 		_message = rootCause.getMessage();
 
 		if (locator != null) {

--- a/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLSecureURIResolver.java
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLSecureURIResolver.java
@@ -14,8 +14,6 @@
 
 package com.liferay.portal.template.xsl.internal;
 
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.InetAddressUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.xsl.XSLURIResolver;
@@ -56,7 +54,7 @@ public class XSLSecureURIResolver implements XSLURIResolver {
 			if (InetAddressUtil.isLocalInetAddress(
 					InetAddress.getByName(url.getHost()))) {
 
-				_log.error(
+				throw new TransformerException(
 					StringBundler.concat(
 						"Denied access to resource: ", href,
 						". Access to local network is disabled by the secure ",
@@ -72,9 +70,6 @@ public class XSLSecureURIResolver implements XSLURIResolver {
 			throw new TransformerException("Error resolving URL reference", e);
 		}
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		XSLSecureURIResolver.class);
 
 	private final XSLURIResolver _xsluriResolver;
 

--- a/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLSecureURIResolver.java
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLSecureURIResolver.java
@@ -39,7 +39,11 @@ public class XSLSecureURIResolver implements XSLURIResolver {
 
 	@Override
 	public String getLanguageId() {
-		return _xsluriResolver.getLanguageId();
+		if (_xsluriResolver != null) {
+			return _xsluriResolver.getLanguageId();
+		}
+
+		return null;
 	}
 
 	@Override
@@ -57,11 +61,12 @@ public class XSLSecureURIResolver implements XSLURIResolver {
 						"Denied access to resource: ", href,
 						". Access to local network is disabled by the secure ",
 						"processing feature."));
-
-				return null;
+			}
+			else if (_xsluriResolver != null) {
+				return _xsluriResolver.resolve(href, base);
 			}
 
-			return _xsluriResolver.resolve(href, base);
+			return null;
 		}
 		catch (MalformedURLException | UnknownHostException e) {
 			throw new TransformerException("Error resolving URL reference", e);

--- a/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLSecureURIResolver.java
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLSecureURIResolver.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.template.xsl.internal;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.InetAddressUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.xsl.XSLURIResolver;
+
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.UnknownHostException;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerException;
+
+/**
+ * @author Marta Medio
+ */
+public class XSLSecureURIResolver implements XSLURIResolver {
+
+	public XSLSecureURIResolver(XSLURIResolver xsluriResolver) {
+		_xsluriResolver = xsluriResolver;
+	}
+
+	@Override
+	public String getLanguageId() {
+		return _xsluriResolver.getLanguageId();
+	}
+
+	@Override
+	public Source resolve(String href, String base)
+		throws TransformerException {
+
+		try {
+			URL url = new URL(href);
+
+			if (InetAddressUtil.isLocalInetAddress(
+					InetAddress.getByName(url.getHost()))) {
+
+				_log.error(
+					StringBundler.concat(
+						"Denied access to resource: ", href,
+						". Access to local network is disabled by the secure ",
+						"processing feature."));
+
+				return null;
+			}
+
+			return _xsluriResolver.resolve(href, base);
+		}
+		catch (MalformedURLException | UnknownHostException e) {
+			throw new TransformerException("Error resolving URL reference", e);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		XSLSecureURIResolver.class);
+
+	private final XSLURIResolver _xsluriResolver;
+
+}

--- a/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLTemplate.java
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLTemplate.java
@@ -69,6 +69,9 @@ public class XSLTemplate implements Template {
 		_errorTemplateResource = errorTemplateResource;
 		_templateContextHelper = templateContextHelper;
 
+		_preventLocalConnections =
+			xslEngineConfiguration.preventLocalConnections();
+
 		_transformerFactory = TransformerFactory.newInstance();
 
 		try {
@@ -113,6 +116,10 @@ public class XSLTemplate implements Template {
 		XSLErrorListener xslErrorListener = new XSLErrorListener(locale);
 
 		_transformerFactory.setErrorListener(xslErrorListener);
+
+		if (_preventLocalConnections) {
+			xslURIResolver = new XSLSecureURIResolver(xslURIResolver);
+		}
 
 		_transformerFactory.setURIResolver(xslURIResolver);
 
@@ -290,6 +297,7 @@ public class XSLTemplate implements Template {
 
 	private final Map<String, Object> _context;
 	private TemplateResource _errorTemplateResource;
+	private final boolean _preventLocalConnections;
 	private final TemplateContextHelper _templateContextHelper;
 	private final TransformerFactory _transformerFactory;
 	private StreamSource _xmlStreamSource;

--- a/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLTemplate.java
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLTemplate.java
@@ -15,6 +15,8 @@
 package com.liferay.portal.template.xsl.internal;
 
 import com.liferay.portal.kernel.io.unsync.UnsyncStringWriter;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.template.StringTemplateResource;
 import com.liferay.portal.kernel.template.Template;
 import com.liferay.portal.kernel.template.TemplateConstants;
@@ -72,6 +74,7 @@ public class XSLTemplate implements Template {
 		_preventLocalConnections =
 			xslEngineConfiguration.preventLocalConnections();
 
+		_errorTransformerFactory = TransformerFactory.newInstance();
 		_transformerFactory = TransformerFactory.newInstance();
 
 		try {
@@ -80,6 +83,9 @@ public class XSLTemplate implements Template {
 				xslEngineConfiguration.secureProcessingEnabled());
 		}
 		catch (TransformerConfigurationException tce) {
+			_log.error(
+				"Unable to configure secure processing: " + tce.getMessage(),
+				tce);
 		}
 
 		_context = new HashMap<>();
@@ -115,6 +121,7 @@ public class XSLTemplate implements Template {
 
 		XSLErrorListener xslErrorListener = new XSLErrorListener(locale);
 
+		_errorTransformerFactory.setErrorListener(xslErrorListener);
 		_transformerFactory.setErrorListener(xslErrorListener);
 
 		if (_preventLocalConnections) {
@@ -130,7 +137,8 @@ public class XSLTemplate implements Template {
 
 		if (_errorTemplateResource == null) {
 			try {
-				transformer = _getTransformer(_xslTemplateResource);
+				transformer = _getTransformer(
+					_xslTemplateResource, _transformerFactory);
 
 				transformer.transform(
 					_xmlStreamSource, new StreamResult(writer));
@@ -147,7 +155,8 @@ public class XSLTemplate implements Template {
 
 		UnsyncStringWriter unsyncStringWriter = new UnsyncStringWriter();
 
-		transformer = _getTransformer(_xslTemplateResource);
+		transformer = _getTransformer(
+			_xslTemplateResource, _transformerFactory);
 
 		transformer.setParameter(TemplateConstants.WRITER, unsyncStringWriter);
 
@@ -203,7 +212,7 @@ public class XSLTemplate implements Template {
 		}
 		catch (Exception e1) {
 			Transformer errorTransformer = _getTransformer(
-				_errorTemplateResource);
+				_errorTemplateResource, _errorTransformerFactory);
 
 			errorTransformer.setParameter(TemplateConstants.WRITER, writer);
 
@@ -271,14 +280,16 @@ public class XSLTemplate implements Template {
 		return _context.values();
 	}
 
-	private Transformer _getTransformer(TemplateResource templateResource)
+	private Transformer _getTransformer(
+			TemplateResource templateResource,
+			TransformerFactory transformerFactory)
 		throws TemplateException {
 
 		try {
 			StreamSource scriptSource = new StreamSource(
 				templateResource.getReader());
 
-			Transformer transformer = _transformerFactory.newTransformer(
+			Transformer transformer = transformerFactory.newTransformer(
 				scriptSource);
 
 			for (Map.Entry<String, Object> entry : _context.entrySet()) {
@@ -295,8 +306,11 @@ public class XSLTemplate implements Template {
 		}
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(XSLTemplate.class);
+
 	private final Map<String, Object> _context;
 	private TemplateResource _errorTemplateResource;
+	private final TransformerFactory _errorTransformerFactory;
 	private final boolean _preventLocalConnections;
 	private final TemplateContextHelper _templateContextHelper;
 	private final TransformerFactory _transformerFactory;

--- a/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLTemplate.java
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLTemplate.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.template.TemplateConstants;
 import com.liferay.portal.kernel.template.TemplateException;
 import com.liferay.portal.kernel.template.TemplateResource;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.template.TemplateContextHelper;
 import com.liferay.portal.template.xsl.configuration.XSLEngineConfiguration;
@@ -74,8 +75,19 @@ public class XSLTemplate implements Template {
 		_preventLocalConnections =
 			xslEngineConfiguration.preventLocalConnections();
 
-		_errorTransformerFactory = TransformerFactory.newInstance();
-		_transformerFactory = TransformerFactory.newInstance();
+		Thread thread = Thread.currentThread();
+
+		ClassLoader contextClassLoader = thread.getContextClassLoader();
+
+		thread.setContextClassLoader(PortalClassLoaderUtil.getClassLoader());
+
+		try {
+			_errorTransformerFactory = TransformerFactory.newInstance();
+			_transformerFactory = TransformerFactory.newInstance();
+		}
+		finally {
+			thread.setContextClassLoader(contextClassLoader);
+		}
 
 		try {
 			_transformerFactory.setFeature(
@@ -207,6 +219,12 @@ public class XSLTemplate implements Template {
 
 	@Override
 	public void processTemplate(Writer writer) throws TemplateException {
+		Thread thread = Thread.currentThread();
+
+		ClassLoader contextClassLoader = thread.getContextClassLoader();
+
+		thread.setContextClassLoader(PortalClassLoaderUtil.getClassLoader());
+
 		try {
 			doProcessTemplate(writer);
 		}
@@ -248,6 +266,9 @@ public class XSLTemplate implements Template {
 						_errorTemplateResource.getTemplateId(),
 					e2);
 			}
+		}
+		finally {
+			thread.setContextClassLoader(contextClassLoader);
 		}
 	}
 

--- a/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLTemplate.java
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLTemplate.java
@@ -313,6 +313,8 @@ public class XSLTemplate implements Template {
 			Transformer transformer = transformerFactory.newTransformer(
 				scriptSource);
 
+			transformer.setErrorListener(transformerFactory.getErrorListener());
+
 			for (Map.Entry<String, Object> entry : _context.entrySet()) {
 				transformer.setParameter(entry.getKey(), entry.getValue());
 			}

--- a/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLTemplate.java
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLTemplate.java
@@ -142,7 +142,7 @@ public class XSLTemplate implements Template {
 
 		_transformerFactory.setURIResolver(xslURIResolver);
 
-		_xmlStreamSource = new StreamSource(
+		StreamSource xmlStreamSource = new StreamSource(
 			_xslTemplateResource.getXMLReader());
 
 		Transformer transformer = null;
@@ -153,7 +153,7 @@ public class XSLTemplate implements Template {
 					_xslTemplateResource, _transformerFactory);
 
 				transformer.transform(
-					_xmlStreamSource, new StreamResult(writer));
+					xmlStreamSource, new StreamResult(writer));
 
 				return;
 			}
@@ -173,7 +173,7 @@ public class XSLTemplate implements Template {
 		transformer.setParameter(TemplateConstants.WRITER, unsyncStringWriter);
 
 		transformer.transform(
-			_xmlStreamSource, new StreamResult(unsyncStringWriter));
+			xmlStreamSource, new StreamResult(unsyncStringWriter));
 
 		StringBundler sb = unsyncStringWriter.getStringBundler();
 
@@ -338,7 +338,6 @@ public class XSLTemplate implements Template {
 	private final boolean _preventLocalConnections;
 	private final TemplateContextHelper _templateContextHelper;
 	private final TransformerFactory _transformerFactory;
-	private StreamSource _xmlStreamSource;
 	private final XSLTemplateResource _xslTemplateResource;
 
 }

--- a/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLTemplate.java
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLTemplate.java
@@ -14,10 +14,10 @@
 
 package com.liferay.portal.template.xsl.internal;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.io.unsync.UnsyncStringWriter;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.template.StringTemplateResource;
 import com.liferay.portal.kernel.template.Template;
 import com.liferay.portal.kernel.template.TemplateConstants;
 import com.liferay.portal.kernel.template.TemplateException;
@@ -30,6 +30,8 @@ import com.liferay.portal.template.xsl.configuration.XSLEngineConfiguration;
 import com.liferay.portal.xsl.XSLTemplateResource;
 import com.liferay.portal.xsl.XSLURIResolver;
 
+import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.Writer;
 
 import java.util.Collection;
@@ -37,6 +39,8 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -72,6 +76,7 @@ public class XSLTemplate implements Template {
 		_errorTemplateResource = errorTemplateResource;
 		_templateContextHelper = templateContextHelper;
 
+		_displayXSLErrors = xslEngineConfiguration.displayXSLErrors();
 		_preventLocalConnections =
 			xslEngineConfiguration.preventLocalConnections();
 
@@ -229,6 +234,22 @@ public class XSLTemplate implements Template {
 			doProcessTemplate(writer);
 		}
 		catch (Exception e1) {
+			if (!_displayXSLErrors) {
+				String message = StringBundler.concat(
+					"Unable to process XSL template ",
+					_xslTemplateResource.getTemplateId(), ": ",
+					e1.getMessage());
+
+				if (_log.isDebugEnabled()) {
+					_log.debug(message, e1);
+				}
+				else {
+					_log.error(message);
+				}
+
+				return;
+			}
+
 			Transformer errorTransformer = _getTransformer(
 				_errorTemplateResource, _errorTransformerFactory);
 
@@ -240,12 +261,17 @@ public class XSLTemplate implements Template {
 			errorTransformer.setParameter(
 				"exception", xslErrorListener.getMessageAndLocation());
 
-			if (_errorTemplateResource instanceof StringTemplateResource) {
-				StringTemplateResource stringTemplateResource =
-					(StringTemplateResource)_errorTemplateResource;
+			try (BufferedReader br = new BufferedReader(
+					_xslTemplateResource.getReader())) {
 
-				errorTransformer.setParameter(
-					"script", stringTemplateResource.getContent());
+				Stream<String> stream = br.lines();
+
+				String script = stream.collect(
+					Collectors.joining(StringPool.NEW_LINE));
+
+				errorTransformer.setParameter("script", script);
+			}
+			catch (IOException ioe) {
 			}
 
 			if (xslErrorListener.getLocation() != null) {
@@ -333,6 +359,7 @@ public class XSLTemplate implements Template {
 	private static final Log _log = LogFactoryUtil.getLog(XSLTemplate.class);
 
 	private final Map<String, Object> _context;
+	private final boolean _displayXSLErrors;
 	private TemplateResource _errorTemplateResource;
 	private final TransformerFactory _errorTransformerFactory;
 	private final boolean _preventLocalConnections;

--- a/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLTemplate.java
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/java/com/liferay/portal/template/xsl/internal/XSLTemplate.java
@@ -258,7 +258,8 @@ public class XSLTemplate implements Template {
 
 			try {
 				errorTransformer.transform(
-					_xmlStreamSource, new StreamResult(writer));
+					new StreamSource(_xslTemplateResource.getXMLReader()),
+					new StreamResult(writer));
 			}
 			catch (Exception e2) {
 				throw new TemplateException(

--- a/modules/apps/portal-template/portal-template-xsl/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/resources/content/Language.properties
@@ -1,2 +1,3 @@
+prevent-local-connections-enabled=Prevent Local Connections
 secure-processing-enabled=Secure Processing Enabled
 xsl-engine-configuration-name=XSL Engine

--- a/modules/apps/portal-template/portal-template-xsl/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/resources/content/Language.properties
@@ -1,3 +1,3 @@
-prevent-local-connections-enabled=Prevent Local Connections
+prevent-local-connections=Prevent Local Connections
 secure-processing-enabled=Secure Processing Enabled
 xsl-engine-configuration-name=XSL Engine

--- a/modules/apps/portal-template/portal-template-xsl/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-template/portal-template-xsl/src/main/resources/content/Language.properties
@@ -1,3 +1,4 @@
+display-xsl-errors=Display XSL Errors
 prevent-local-connections=Prevent Local Connections
 secure-processing-enabled=Secure Processing Enabled
 xsl-engine-configuration-name=XSL Engine


### PR DESCRIPTION
Hi Tina,

I sent the other fix (fist 4 commits) to Brian: https://github.com/brianchandotcom/liferay-portal/pull/66967 I included them here to prevent rebase errors.

Re: https://github.com/tinatian/liferay-portal/pull/1180#issuecomment-455728211 - I didn't create a test for this but described steps to reproduce it in the ticket https://issues.liferay.com/browse/LPS-89354 

Feel free to throw away my commits and fix it as you think it should be, the general way you described.

Thank you.