### PR TITLE
LPS-89659 SchedulerEventMessageListenerWrapper bug

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/scheduler/messaging/SchedulerEventMessageListenerWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/scheduler/messaging/SchedulerEventMessageListenerWrapper.java
@@ -89,6 +89,8 @@ public class SchedulerEventMessageListenerWrapper
 								" milliseconds before retry",
 						ie);
 				}
+
+				return;
 			}
 		}
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/scheduler/messaging/SchedulerEventMessageListenerWrapperTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/scheduler/messaging/SchedulerEventMessageListenerWrapperTest.java
@@ -100,10 +100,10 @@ public class SchedulerEventMessageListenerWrapperTest {
 		futureTask2.get();
 
 		Assert.assertSame(
-			"Message is not processed", _testMessage1,
+			"Message is not processed", _testMessage1.getPayload(),
 			_testMessage1.getResponse());
 		Assert.assertSame(
-			"Message is not processed", _testMessage2,
+			"Message is not processed", _testMessage2.getPayload(),
 			_testMessage2.getResponse());
 	}
 
@@ -152,7 +152,7 @@ public class SchedulerEventMessageListenerWrapperTest {
 		futureTask1.get();
 
 		Assert.assertSame(
-			"Message is not processed", _testMessage1,
+			"Message is not processed", _testMessage1.getPayload(),
 			_testMessage1.getResponse());
 	}
 
@@ -204,7 +204,7 @@ public class SchedulerEventMessageListenerWrapperTest {
 		}
 
 		Assert.assertSame(
-			"Message is not processed", _testMessage1,
+			"Message is not processed", _testMessage1.getPayload(),
 			_testMessage1.getResponse());
 		Assert.assertNull(_testMessage2.getResponse());
 		Assert.assertNull(exception);
@@ -247,7 +247,7 @@ public class SchedulerEventMessageListenerWrapperTest {
 
 				_blockCountDownLatch.await();
 
-				message.setResponse(message);
+				message.setResponse(message.getPayload());
 			}
 			catch (InterruptedException ie) {
 			}


### PR DESCRIPTION
@tinatian If a thread which is trying to lock is interrupted, it will still execute _processMessage() and then unlock. Hai found this when trying to add code coverage.