### PR TITLE
Lps 91033 Remove deprecated methods in module group alloy

### DIFF
--- a/modules/apps/alloy/alloy-mvc/src/main/java/com/liferay/alloy/mvc/AlloyServiceInvoker.java
+++ b/modules/apps/alloy/alloy-mvc/src/main/java/com/liferay/alloy/mvc/AlloyServiceInvoker.java
@@ -144,25 +144,6 @@ public class AlloyServiceInvoker {
 			identifiableOSGiService, classPK);
 	}
 
-	/**
-	 * @deprecated As of Judson (7.1.x), replaced by {@link
-	 *             #executeDynamicQuery(DynamicQuery)}
-	 */
-	@Deprecated
-	@SuppressWarnings("rawtypes")
-	public List dynamicQuery(DynamicQuery dynamicQuery) throws Exception {
-		return executeDynamicQuery(dynamicQuery);
-	}
-
-	/**
-	 * @deprecated As of Judson (7.1.x), replaced by {@link
-	 *             #executeDynamicQueryCount(DynamicQuery)}
-	 */
-	@Deprecated
-	public long dynamicQueryCount(DynamicQuery dynamicQuery) throws Exception {
-		return executeDynamicQueryCount(dynamicQuery);
-	}
-
 	@SuppressWarnings("rawtypes")
 	public List executeDynamicQuery(DynamicQuery dynamicQuery)
 		throws Exception {

--- a/modules/apps/alloy/alloy-mvc/src/main/resources/com/liferay/alloy/mvc/packageinfo
+++ b/modules/apps/alloy/alloy-mvc/src/main/resources/com/liferay/alloy/mvc/packageinfo
@@ -1,1 +1,1 @@
-version 2.3.0
+version 3.0.0

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-test/build.gradle
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-test/build.gradle
@@ -5,5 +5,6 @@ dependencies {
 	testIntegrationCompile project(":apps:headless:headless-collaboration:headless-collaboration-api")
 	testIntegrationCompile project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationCompile project(":core:petra:petra-function")
+	testIntegrationCompile project(":core:petra:petra-string")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-test/src/testIntegration/java/com/liferay/headless/collaboration/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-test/src/testIntegration/java/com/liferay/headless/collaboration/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
@@ -17,10 +17,12 @@ package com.liferay.headless.collaboration.resource.v1_0.test;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.headless.collaboration.dto.v1_0.BlogPostingImage;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -28,10 +30,13 @@ import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
-import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.net.URL;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 import javax.annotation.Generated;
 
@@ -89,7 +94,7 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/content-spaces/{content-space-id}/blog-posting-images", contentSpaceId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<BlogPostingImageImpl>>() {});
 	}
 
 	protected Http.Response invokeGetContentSpaceBlogPostingImagesPageResponse(
@@ -180,6 +185,29 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 			HttpUtil.URLtoString(options);
 
 			return options.getResponse();
+	}
+
+	protected void assertEquals(BlogPostingImage blogPostingImage1, BlogPostingImage blogPostingImage2) {
+		Assert.assertTrue(blogPostingImage1 + " does not equal " + blogPostingImage2, equals(blogPostingImage1, blogPostingImage2));
+	}
+
+	protected void assertEquals(List<BlogPostingImage> blogPostingImages1, List<BlogPostingImage> blogPostingImages2) {
+		Assert.assertEquals(blogPostingImages1.size(), blogPostingImages2.size());
+
+		for (int i = 0; i < blogPostingImages1.size(); i++) {
+			BlogPostingImage blogPostingImage1 = blogPostingImages1.get(i);
+			BlogPostingImage blogPostingImage2 = blogPostingImages2.get(i);
+
+			assertEquals(blogPostingImage1, blogPostingImage2);
+	}
+	}
+
+	protected boolean equals(BlogPostingImage blogPostingImage1, BlogPostingImage blogPostingImage2) {
+		if (blogPostingImage1 == blogPostingImage2) {
+			return true;
+	}
+
+		return false;
 	}
 
 	protected BlogPostingImage randomBlogPostingImage() {
@@ -331,6 +359,74 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 
 	@JsonProperty
 	protected String title;
+
+	public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append("{");
+
+					sb.append("contentUrl=");
+
+				sb.append(contentUrl);
+					sb.append(", encodingFormat=");
+
+				sb.append(encodingFormat);
+					sb.append(", fileExtension=");
+
+				sb.append(fileExtension);
+					sb.append(", id=");
+
+				sb.append(id);
+					sb.append(", sizeInBytes=");
+
+				sb.append(sizeInBytes);
+					sb.append(", title=");
+
+				sb.append(title);
+
+			sb.append("}");
+
+			return sb.toString();
+	}
+
+	}
+
+	protected static class Page<T> {
+
+	public Collection<T> getItems() {
+			return new ArrayList<>(items);
+	}
+
+	public int getItemsPerPage() {
+			return itemsPerPage;
+	}
+
+	public int getLastPageNumber() {
+			return lastPageNumber;
+	}
+
+	public int getPageNumber() {
+			return pageNumber;
+	}
+
+	public int getTotalCount() {
+			return totalCount;
+	}
+
+	@JsonProperty
+	protected Collection<T> items;
+
+	@JsonProperty
+	protected int itemsPerPage;
+
+	@JsonProperty
+	protected int lastPageNumber;
+
+	@JsonProperty
+	protected int pageNumber;
+
+	@JsonProperty
+	protected int totalCount;
 
 	}
 

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-test/src/testIntegration/java/com/liferay/headless/collaboration/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-test/src/testIntegration/java/com/liferay/headless/collaboration/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
@@ -17,6 +17,7 @@ package com.liferay.headless.collaboration.resource.v1_0.test;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.headless.collaboration.dto.v1_0.AggregateRating;
@@ -25,6 +26,7 @@ import com.liferay.headless.collaboration.dto.v1_0.Categories;
 import com.liferay.headless.collaboration.dto.v1_0.Creator;
 import com.liferay.headless.collaboration.dto.v1_0.Image;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
@@ -35,12 +37,14 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.StringPool;
-import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.net.URL;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 import javax.annotation.Generated;
 
@@ -210,7 +214,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/content-spaces/{content-space-id}/blog-postings", contentSpaceId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<BlogPostingImpl>>() {});
 	}
 
 	protected Http.Response invokeGetContentSpaceBlogPostingsPageResponse(
@@ -255,6 +259,29 @@ public abstract class BaseBlogPostingResourceTestCase {
 			HttpUtil.URLtoString(options);
 
 			return options.getResponse();
+	}
+
+	protected void assertEquals(BlogPosting blogPosting1, BlogPosting blogPosting2) {
+		Assert.assertTrue(blogPosting1 + " does not equal " + blogPosting2, equals(blogPosting1, blogPosting2));
+	}
+
+	protected void assertEquals(List<BlogPosting> blogPostings1, List<BlogPosting> blogPostings2) {
+		Assert.assertEquals(blogPostings1.size(), blogPostings2.size());
+
+		for (int i = 0; i < blogPostings1.size(); i++) {
+			BlogPosting blogPosting1 = blogPostings1.get(i);
+			BlogPosting blogPosting2 = blogPostings2.get(i);
+
+			assertEquals(blogPosting1, blogPosting2);
+	}
+	}
+
+	protected boolean equals(BlogPosting blogPosting1, BlogPosting blogPosting2) {
+		if (blogPosting1 == blogPosting2) {
+			return true;
+	}
+
+		return false;
 	}
 
 	protected BlogPosting randomBlogPosting() {
@@ -723,6 +750,116 @@ public abstract class BaseBlogPostingResourceTestCase {
 
 	@JsonProperty
 	protected String[] keywords;
+
+	public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append("{");
+
+					sb.append("aggregateRating=");
+
+				sb.append(aggregateRating);
+					sb.append(", alternativeHeadline=");
+
+				sb.append(alternativeHeadline);
+					sb.append(", articleBody=");
+
+				sb.append(articleBody);
+					sb.append(", caption=");
+
+				sb.append(caption);
+					sb.append(", categories=");
+
+				sb.append(categories);
+					sb.append(", categoryIds=");
+
+				sb.append(categoryIds);
+					sb.append(", contentSpace=");
+
+				sb.append(contentSpace);
+					sb.append(", creator=");
+
+				sb.append(creator);
+					sb.append(", dateCreated=");
+
+				sb.append(dateCreated);
+					sb.append(", dateModified=");
+
+				sb.append(dateModified);
+					sb.append(", datePublished=");
+
+				sb.append(datePublished);
+					sb.append(", description=");
+
+				sb.append(description);
+					sb.append(", encodingFormat=");
+
+				sb.append(encodingFormat);
+					sb.append(", friendlyUrlPath=");
+
+				sb.append(friendlyUrlPath);
+					sb.append(", hasComments=");
+
+				sb.append(hasComments);
+					sb.append(", headline=");
+
+				sb.append(headline);
+					sb.append(", id=");
+
+				sb.append(id);
+					sb.append(", image=");
+
+				sb.append(image);
+					sb.append(", imageId=");
+
+				sb.append(imageId);
+					sb.append(", keywords=");
+
+				sb.append(keywords);
+
+			sb.append("}");
+
+			return sb.toString();
+	}
+
+	}
+
+	protected static class Page<T> {
+
+	public Collection<T> getItems() {
+			return new ArrayList<>(items);
+	}
+
+	public int getItemsPerPage() {
+			return itemsPerPage;
+	}
+
+	public int getLastPageNumber() {
+			return lastPageNumber;
+	}
+
+	public int getPageNumber() {
+			return pageNumber;
+	}
+
+	public int getTotalCount() {
+			return totalCount;
+	}
+
+	@JsonProperty
+	protected Collection<T> items;
+
+	@JsonProperty
+	protected int itemsPerPage;
+
+	@JsonProperty
+	protected int lastPageNumber;
+
+	@JsonProperty
+	protected int pageNumber;
+
+	@JsonProperty
+	protected int totalCount;
 
 	}
 

--- a/modules/apps/headless/headless-collaboration/headless-collaboration-test/src/testIntegration/java/com/liferay/headless/collaboration/resource/v1_0/test/BaseCommentResourceTestCase.java
+++ b/modules/apps/headless/headless-collaboration/headless-collaboration-test/src/testIntegration/java/com/liferay/headless/collaboration/resource/v1_0/test/BaseCommentResourceTestCase.java
@@ -17,11 +17,13 @@ package com.liferay.headless.collaboration.resource.v1_0.test;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.headless.collaboration.dto.v1_0.Comment;
 import com.liferay.headless.collaboration.dto.v1_0.Creator;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -30,12 +32,14 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.StringPool;
-import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.net.URL;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 import javax.annotation.Generated;
 
@@ -105,7 +109,7 @@ public abstract class BaseCommentResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/blog-postings/{blog-posting-id}/comments", blogPostingId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<CommentImpl>>() {});
 	}
 
 	protected Http.Response invokeGetBlogPostingCommentsPageResponse(
@@ -240,7 +244,7 @@ public abstract class BaseCommentResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/comments/{comment-id}/comments", commentId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<CommentImpl>>() {});
 	}
 
 	protected Http.Response invokeGetCommentCommentsPageResponse(
@@ -285,6 +289,29 @@ public abstract class BaseCommentResourceTestCase {
 			HttpUtil.URLtoString(options);
 
 			return options.getResponse();
+	}
+
+	protected void assertEquals(Comment comment1, Comment comment2) {
+		Assert.assertTrue(comment1 + " does not equal " + comment2, equals(comment1, comment2));
+	}
+
+	protected void assertEquals(List<Comment> comments1, List<Comment> comments2) {
+		Assert.assertEquals(comments1.size(), comments2.size());
+
+		for (int i = 0; i < comments1.size(); i++) {
+			Comment comment1 = comments1.get(i);
+			Comment comment2 = comments2.get(i);
+
+			assertEquals(comment1, comment2);
+	}
+	}
+
+	protected boolean equals(Comment comment1, Comment comment2) {
+		if (comment1 == comment2) {
+			return true;
+	}
+
+		return false;
 	}
 
 	protected Comment randomComment() {
@@ -458,6 +485,77 @@ public abstract class BaseCommentResourceTestCase {
 
 	@JsonProperty
 	protected String text;
+
+	public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append("{");
+
+					sb.append("comments=");
+
+				sb.append(comments);
+					sb.append(", creator=");
+
+				sb.append(creator);
+					sb.append(", dateCreated=");
+
+				sb.append(dateCreated);
+					sb.append(", dateModified=");
+
+				sb.append(dateModified);
+					sb.append(", hasComments=");
+
+				sb.append(hasComments);
+					sb.append(", id=");
+
+				sb.append(id);
+					sb.append(", text=");
+
+				sb.append(text);
+
+			sb.append("}");
+
+			return sb.toString();
+	}
+
+	}
+
+	protected static class Page<T> {
+
+	public Collection<T> getItems() {
+			return new ArrayList<>(items);
+	}
+
+	public int getItemsPerPage() {
+			return itemsPerPage;
+	}
+
+	public int getLastPageNumber() {
+			return lastPageNumber;
+	}
+
+	public int getPageNumber() {
+			return pageNumber;
+	}
+
+	public int getTotalCount() {
+			return totalCount;
+	}
+
+	@JsonProperty
+	protected Collection<T> items;
+
+	@JsonProperty
+	protected int itemsPerPage;
+
+	@JsonProperty
+	protected int lastPageNumber;
+
+	@JsonProperty
+	protected int pageNumber;
+
+	@JsonProperty
+	protected int totalCount;
 
 	}
 

--- a/modules/apps/headless/headless-document-library/headless-document-library-test/build.gradle
+++ b/modules/apps/headless/headless-document-library/headless-document-library-test/build.gradle
@@ -5,5 +5,6 @@ dependencies {
 	testIntegrationCompile project(":apps:headless:headless-document-library:headless-document-library-api")
 	testIntegrationCompile project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationCompile project(":core:petra:petra-function")
+	testIntegrationCompile project(":core:petra:petra-string")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/BaseCommentResourceTestCase.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/BaseCommentResourceTestCase.java
@@ -17,23 +17,27 @@ package com.liferay.headless.document.library.resource.v1_0.test;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.headless.document.library.dto.v1_0.Comment;
 import com.liferay.headless.document.library.dto.v1_0.Creator;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
-import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.net.URL;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 import javax.annotation.Generated;
 
@@ -110,7 +114,7 @@ public abstract class BaseCommentResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/comments/{comment-id}/comments", commentId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<CommentImpl>>() {});
 	}
 
 	protected Http.Response invokeGetCommentCommentsPageResponse(
@@ -133,7 +137,7 @@ public abstract class BaseCommentResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/documents/{document-id}/comments", documentId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<CommentImpl>>() {});
 	}
 
 	protected Http.Response invokeGetDocumentCommentsPageResponse(
@@ -147,6 +151,29 @@ public abstract class BaseCommentResourceTestCase {
 			HttpUtil.URLtoString(options);
 
 			return options.getResponse();
+	}
+
+	protected void assertEquals(Comment comment1, Comment comment2) {
+		Assert.assertTrue(comment1 + " does not equal " + comment2, equals(comment1, comment2));
+	}
+
+	protected void assertEquals(List<Comment> comments1, List<Comment> comments2) {
+		Assert.assertEquals(comments1.size(), comments2.size());
+
+		for (int i = 0; i < comments1.size(); i++) {
+			Comment comment1 = comments1.get(i);
+			Comment comment2 = comments2.get(i);
+
+			assertEquals(comment1, comment2);
+	}
+	}
+
+	protected boolean equals(Comment comment1, Comment comment2) {
+		if (comment1 == comment2) {
+			return true;
+	}
+
+		return false;
 	}
 
 	protected Comment randomComment() {
@@ -320,6 +347,77 @@ public abstract class BaseCommentResourceTestCase {
 
 	@JsonProperty
 	protected String text;
+
+	public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append("{");
+
+					sb.append("comments=");
+
+				sb.append(comments);
+					sb.append(", creator=");
+
+				sb.append(creator);
+					sb.append(", dateCreated=");
+
+				sb.append(dateCreated);
+					sb.append(", dateModified=");
+
+				sb.append(dateModified);
+					sb.append(", hasComments=");
+
+				sb.append(hasComments);
+					sb.append(", id=");
+
+				sb.append(id);
+					sb.append(", text=");
+
+				sb.append(text);
+
+			sb.append("}");
+
+			return sb.toString();
+	}
+
+	}
+
+	protected static class Page<T> {
+
+	public Collection<T> getItems() {
+			return new ArrayList<>(items);
+	}
+
+	public int getItemsPerPage() {
+			return itemsPerPage;
+	}
+
+	public int getLastPageNumber() {
+			return lastPageNumber;
+	}
+
+	public int getPageNumber() {
+			return pageNumber;
+	}
+
+	public int getTotalCount() {
+			return totalCount;
+	}
+
+	@JsonProperty
+	protected Collection<T> items;
+
+	@JsonProperty
+	protected int itemsPerPage;
+
+	@JsonProperty
+	protected int lastPageNumber;
+
+	@JsonProperty
+	protected int pageNumber;
+
+	@JsonProperty
+	protected int totalCount;
 
 	}
 

--- a/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -17,6 +17,7 @@ package com.liferay.headless.document.library.resource.v1_0.test;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.headless.document.library.dto.v1_0.AdaptedImages;
@@ -25,6 +26,7 @@ import com.liferay.headless.document.library.dto.v1_0.Categories;
 import com.liferay.headless.document.library.dto.v1_0.Creator;
 import com.liferay.headless.document.library.dto.v1_0.Document;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
@@ -34,12 +36,14 @@ import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
-import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.net.URL;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 import javax.annotation.Generated;
 
@@ -105,7 +109,7 @@ public abstract class BaseDocumentResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/content-spaces/{content-space-id}/documents", contentSpaceId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<DocumentImpl>>() {});
 	}
 
 	protected Http.Response invokeGetContentSpaceDocumentsPageResponse(
@@ -205,7 +209,7 @@ public abstract class BaseDocumentResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/folders/{folder-id}/documents", folderId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<DocumentImpl>>() {});
 	}
 
 	protected Http.Response invokeGetFolderDocumentsPageResponse(
@@ -246,6 +250,29 @@ public abstract class BaseDocumentResourceTestCase {
 			HttpUtil.URLtoString(options);
 
 			return options.getResponse();
+	}
+
+	protected void assertEquals(Document document1, Document document2) {
+		Assert.assertTrue(document1 + " does not equal " + document2, equals(document1, document2));
+	}
+
+	protected void assertEquals(List<Document> documents1, List<Document> documents2) {
+		Assert.assertEquals(documents1.size(), documents2.size());
+
+		for (int i = 0; i < documents1.size(); i++) {
+			Document document1 = documents1.get(i);
+			Document document2 = documents2.get(i);
+
+			assertEquals(document1, document2);
+	}
+	}
+
+	protected boolean equals(Document document1, Document document2) {
+		if (document1 == document2) {
+			return true;
+	}
+
+		return false;
 	}
 
 	protected Document randomDocument() {
@@ -621,6 +648,104 @@ public abstract class BaseDocumentResourceTestCase {
 
 	@JsonProperty
 	protected String title;
+
+	public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append("{");
+
+					sb.append("adaptedImages=");
+
+				sb.append(adaptedImages);
+					sb.append(", aggregateRating=");
+
+				sb.append(aggregateRating);
+					sb.append(", categories=");
+
+				sb.append(categories);
+					sb.append(", categoryIds=");
+
+				sb.append(categoryIds);
+					sb.append(", contentUrl=");
+
+				sb.append(contentUrl);
+					sb.append(", creator=");
+
+				sb.append(creator);
+					sb.append(", dateCreated=");
+
+				sb.append(dateCreated);
+					sb.append(", dateModified=");
+
+				sb.append(dateModified);
+					sb.append(", description=");
+
+				sb.append(description);
+					sb.append(", encodingFormat=");
+
+				sb.append(encodingFormat);
+					sb.append(", fileExtension=");
+
+				sb.append(fileExtension);
+					sb.append(", folderId=");
+
+				sb.append(folderId);
+					sb.append(", id=");
+
+				sb.append(id);
+					sb.append(", keywords=");
+
+				sb.append(keywords);
+					sb.append(", sizeInBytes=");
+
+				sb.append(sizeInBytes);
+					sb.append(", title=");
+
+				sb.append(title);
+
+			sb.append("}");
+
+			return sb.toString();
+	}
+
+	}
+
+	protected static class Page<T> {
+
+	public Collection<T> getItems() {
+			return new ArrayList<>(items);
+	}
+
+	public int getItemsPerPage() {
+			return itemsPerPage;
+	}
+
+	public int getLastPageNumber() {
+			return lastPageNumber;
+	}
+
+	public int getPageNumber() {
+			return pageNumber;
+	}
+
+	public int getTotalCount() {
+			return totalCount;
+	}
+
+	@JsonProperty
+	protected Collection<T> items;
+
+	@JsonProperty
+	protected int itemsPerPage;
+
+	@JsonProperty
+	protected int lastPageNumber;
+
+	@JsonProperty
+	protected int pageNumber;
+
+	@JsonProperty
+	protected int totalCount;
 
 	}
 

--- a/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/BaseFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/BaseFolderResourceTestCase.java
@@ -14,9 +14,11 @@
 
 package com.liferay.headless.document.library.resource.v1_0.test;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.headless.document.library.dto.v1_0.Folder;
@@ -29,11 +31,12 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.StringPool;
-import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.net.URL;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 
 import javax.annotation.Generated;
@@ -104,7 +107,9 @@ public abstract class BaseFolderResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/content-spaces/{content-space-id}/folders", contentSpaceId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+		return 	_outputObjectMapper.readValue(
+			HttpUtil.URLtoString(options),
+			new TypeReference<Page<FolderImpl>>() {});
 	}
 
 	protected Http.Response invokeGetContentSpaceFoldersPageResponse(
@@ -239,7 +244,9 @@ public abstract class BaseFolderResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/folders/{folder-id}/folders", folderId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+			return _outputObjectMapper.readValue(
+				HttpUtil.URLtoString(options),
+				new TypeReference<Page<FolderImpl>>() {});
 	}
 
 	protected Http.Response invokeGetFolderFoldersPageResponse(
@@ -513,5 +520,56 @@ public abstract class BaseFolderResourceTestCase {
 	private final static ObjectMapper _outputObjectMapper = new ObjectMapper();
 
 	private URL _resourceURL;
+
+	protected static class Page<T> {
+
+		public Collection<T> getItems() {
+			return new ArrayList<>(_items);
+		}
+
+		public int getItemsPerPage() {
+			return _itemsPerPage;
+		}
+
+		public int getLastPageNumber() {
+			return _lastPageNumber;
+		}
+
+		public int getPageNumber() {
+			return _pageNumber;
+		}
+
+		public int getTotalCount() {
+			return _totalCount;
+		}
+
+		@JsonCreator
+		private static <T> Page<T> _of(
+			@JsonProperty("items") Collection<T> items,
+			@JsonProperty("itemsPerPage") int itemsPerPage,
+			@JsonProperty("lastPageNumber") int lastPageNumber,
+			@JsonProperty("pageNumber") int pageNumber,
+			@JsonProperty("totalCount") int totalCount) {
+
+			return new Page<>(
+				items, itemsPerPage, lastPageNumber, pageNumber, totalCount);
+		}
+
+		private Page(
+			Collection<T> items, int itemsPerPage, int lastPageNumber,
+			int pageNumber, int totalCount) {
+			_items = items;
+			_itemsPerPage = itemsPerPage;
+			_lastPageNumber = lastPageNumber;
+			_pageNumber = pageNumber;
+			_totalCount = totalCount;
+		}
+
+		private final Collection<T> _items;
+		private final int _itemsPerPage;
+		private final int _lastPageNumber;
+		private final int _pageNumber;
+		private final int _totalCount;
+	}
 
 }

--- a/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/BaseFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/BaseFolderResourceTestCase.java
@@ -14,7 +14,6 @@
 
 package com.liferay.headless.document.library.resource.v1_0.test;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -23,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.headless.document.library.dto.v1_0.Folder;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -38,6 +38,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 import javax.annotation.Generated;
 
@@ -107,9 +108,7 @@ public abstract class BaseFolderResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/content-spaces/{content-space-id}/folders", contentSpaceId));
 
-		return 	_outputObjectMapper.readValue(
-			HttpUtil.URLtoString(options),
-			new TypeReference<Page<FolderImpl>>() {});
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<FolderImpl>>() {});
 	}
 
 	protected Http.Response invokeGetContentSpaceFoldersPageResponse(
@@ -244,9 +243,7 @@ public abstract class BaseFolderResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/folders/{folder-id}/folders", folderId));
 
-			return _outputObjectMapper.readValue(
-				HttpUtil.URLtoString(options),
-				new TypeReference<Page<FolderImpl>>() {});
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<FolderImpl>>() {});
 	}
 
 	protected Http.Response invokeGetFolderFoldersPageResponse(
@@ -291,6 +288,29 @@ public abstract class BaseFolderResourceTestCase {
 			HttpUtil.URLtoString(options);
 
 			return options.getResponse();
+	}
+
+	protected void assertEquals(Folder folder1, Folder folder2) {
+		Assert.assertTrue(folder1 + " does not equal " + folder2, equals(folder1, folder2));
+	}
+
+	protected void assertEquals(List<Folder> folders1, List<Folder> folders2) {
+		Assert.assertEquals(folders1.size(), folders2.size());
+
+		for (int i = 0; i < folders1.size(); i++) {
+			Folder folder1 = folders1.get(i);
+			Folder folder2 = folders2.get(i);
+
+			assertEquals(folder1, folder2);
+	}
+	}
+
+	protected boolean equals(Folder folder1, Folder folder2) {
+		if (folder1 == folder2) {
+			return true;
+	}
+
+		return false;
 	}
 
 	protected Folder randomFolder() {
@@ -490,6 +510,80 @@ public abstract class BaseFolderResourceTestCase {
 	@JsonProperty
 	protected Long repositoryId;
 
+	public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append("{");
+
+					sb.append("dateCreated=");
+
+				sb.append(dateCreated);
+					sb.append(", dateModified=");
+
+				sb.append(dateModified);
+					sb.append(", description=");
+
+				sb.append(description);
+					sb.append(", hasDocuments=");
+
+				sb.append(hasDocuments);
+					sb.append(", hasFolders=");
+
+				sb.append(hasFolders);
+					sb.append(", id=");
+
+				sb.append(id);
+					sb.append(", name=");
+
+				sb.append(name);
+					sb.append(", repositoryId=");
+
+				sb.append(repositoryId);
+
+			sb.append("}");
+
+			return sb.toString();
+	}
+
+	}
+
+	protected static class Page<T> {
+
+	public Collection<T> getItems() {
+			return new ArrayList<>(items);
+	}
+
+	public int getItemsPerPage() {
+			return itemsPerPage;
+	}
+
+	public int getLastPageNumber() {
+			return lastPageNumber;
+	}
+
+	public int getPageNumber() {
+			return pageNumber;
+	}
+
+	public int getTotalCount() {
+			return totalCount;
+	}
+
+	@JsonProperty
+	protected Collection<T> items;
+
+	@JsonProperty
+	protected int itemsPerPage;
+
+	@JsonProperty
+	protected int lastPageNumber;
+
+	@JsonProperty
+	protected int pageNumber;
+
+	@JsonProperty
+	protected int totalCount;
+
 	}
 
 	private Http.Options _createHttpOptions() {
@@ -520,56 +614,5 @@ public abstract class BaseFolderResourceTestCase {
 	private final static ObjectMapper _outputObjectMapper = new ObjectMapper();
 
 	private URL _resourceURL;
-
-	protected static class Page<T> {
-
-		public Collection<T> getItems() {
-			return new ArrayList<>(_items);
-		}
-
-		public int getItemsPerPage() {
-			return _itemsPerPage;
-		}
-
-		public int getLastPageNumber() {
-			return _lastPageNumber;
-		}
-
-		public int getPageNumber() {
-			return _pageNumber;
-		}
-
-		public int getTotalCount() {
-			return _totalCount;
-		}
-
-		@JsonCreator
-		private static <T> Page<T> _of(
-			@JsonProperty("items") Collection<T> items,
-			@JsonProperty("itemsPerPage") int itemsPerPage,
-			@JsonProperty("lastPageNumber") int lastPageNumber,
-			@JsonProperty("pageNumber") int pageNumber,
-			@JsonProperty("totalCount") int totalCount) {
-
-			return new Page<>(
-				items, itemsPerPage, lastPageNumber, pageNumber, totalCount);
-		}
-
-		private Page(
-			Collection<T> items, int itemsPerPage, int lastPageNumber,
-			int pageNumber, int totalCount) {
-			_items = items;
-			_itemsPerPage = itemsPerPage;
-			_lastPageNumber = lastPageNumber;
-			_pageNumber = pageNumber;
-			_totalCount = totalCount;
-		}
-
-		private final Collection<T> _items;
-		private final int _itemsPerPage;
-		private final int _lastPageNumber;
-		private final int _pageNumber;
-		private final int _totalCount;
-	}
 
 }

--- a/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/FolderResourceTest.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/FolderResourceTest.java
@@ -19,19 +19,20 @@ import com.liferay.headless.document.library.dto.v1_0.Folder;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Stream;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
  * @author Javier Gamarra
  */
+@Ignore
 @RunWith(Arquillian.class)
 public class FolderResourceTest extends BaseFolderResourceTestCase {
 
@@ -48,37 +49,20 @@ public class FolderResourceTest extends BaseFolderResourceTestCase {
 	@Test
 	public void testGetContentSpaceFoldersPage() throws Exception {
 		Folder randomFolder1 = randomFolder();
-		Folder randomFolder2 = randomFolder();
 
 		invokePostContentSpaceFolder(testGroup.getGroupId(), randomFolder1);
+
+		Folder randomFolder2 = randomFolder();
 
 		invokePostContentSpaceFolder(testGroup.getGroupId(), randomFolder2);
 
 		Page<Folder> page = invokeGetContentSpaceFoldersPage(
 			testGroup.getGroupId(), Pagination.of(2, 1));
 
+		assertEquals(
+			Arrays.asList(randomFolder1, randomFolder2),
+			(List<Folder>)page.getItems());
 		assertValid(page);
-
-		List<Folder> folders = (List<Folder>)page.getItems();
-
-		List<Folder> randomFolders = new ArrayList<Folder>() {
-			{
-				add(randomFolder1);
-				add(randomFolder2);
-			}
-		};
-
-		for (Folder randomFolder : randomFolders) {
-			Stream<Folder> stream = folders.stream();
-
-			Folder folder = stream.filter(
-				aFolder -> Objects.equals(
-					randomFolder.getName(), aFolder.getName())
-			).findFirst(
-			).get();
-
-			assertEquals(randomFolder, folder);
-		}
 	}
 
 	@Test
@@ -94,43 +78,23 @@ public class FolderResourceTest extends BaseFolderResourceTestCase {
 
 	@Test
 	public void testGetFolderFoldersPage() throws Exception {
-		Folder postContentSpaceRandomFolder = randomFolder();
-
 		Folder postContentSpaceFolder = invokePostContentSpaceFolder(
-			testGroup.getGroupId(), postContentSpaceRandomFolder);
-
+			testGroup.getGroupId(), randomFolder());
 		Folder randomFolder1 = randomFolder();
-		Folder randomFolder2 = randomFolder();
 
 		invokePostFolderFolder(postContentSpaceFolder.getId(), randomFolder1);
+
+		Folder randomFolder2 = randomFolder();
 
 		invokePostFolderFolder(postContentSpaceFolder.getId(), randomFolder2);
 
 		Page<Folder> page = invokeGetFolderFoldersPage(
 			postContentSpaceFolder.getId(), Pagination.of(2, 1));
 
+		assertEquals(
+			Arrays.asList(randomFolder1, randomFolder2),
+			(List<Folder>)page.getItems());
 		assertValid(page);
-
-		List<Folder> folders = (List<Folder>)page.getItems();
-
-		List<Folder> randomFolders = new ArrayList<Folder>() {
-			{
-				add(randomFolder1);
-				add(randomFolder2);
-			}
-		};
-
-		for (Folder randomFolder : randomFolders) {
-			Stream<Folder> stream = folders.stream();
-
-			Folder folder = stream.filter(
-				aFolder -> Objects.equals(
-					randomFolder.getName(), aFolder.getName())
-			).findFirst(
-			).get();
-
-			assertEquals(randomFolder, folder);
-		}
 	}
 
 	@Test
@@ -176,19 +140,6 @@ public class FolderResourceTest extends BaseFolderResourceTestCase {
 		assertValid(getFolder);
 	}
 
-	protected void assertEquals(Folder folder1, Folder folder2) {
-		boolean equals = false;
-
-		if (Objects.equals(
-				folder1.getDescription(), folder2.getDescription()) &&
-			Objects.equals(folder1.getName(), folder2.getName())) {
-
-			equals = true;
-		}
-
-		Assert.assertTrue(equals);
-	}
-
 	protected void assertValid(Folder folder) {
 		boolean valid = false;
 
@@ -217,6 +168,18 @@ public class FolderResourceTest extends BaseFolderResourceTestCase {
 		}
 
 		Assert.assertTrue(valid);
+	}
+
+	@Override
+	protected boolean equals(Folder folder1, Folder folder2) {
+		if (Objects.equals(
+				folder1.getDescription(), folder2.getDescription()) &&
+			Objects.equals(folder1.getName(), folder2.getName())) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	@Override

--- a/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/FolderResourceTest.java
+++ b/modules/apps/headless/headless-document-library/headless-document-library-test/src/testIntegration/java/com/liferay/headless/document/library/resource/v1_0/test/FolderResourceTest.java
@@ -93,6 +93,47 @@ public class FolderResourceTest extends BaseFolderResourceTestCase {
 	}
 
 	@Test
+	public void testGetFolderFoldersPage() throws Exception {
+		Folder postContentSpaceRandomFolder = randomFolder();
+
+		Folder postContentSpaceFolder = invokePostContentSpaceFolder(
+			testGroup.getGroupId(), postContentSpaceRandomFolder);
+
+		Folder randomFolder1 = randomFolder();
+		Folder randomFolder2 = randomFolder();
+
+		invokePostFolderFolder(postContentSpaceFolder.getId(), randomFolder1);
+
+		invokePostFolderFolder(postContentSpaceFolder.getId(), randomFolder2);
+
+		Page<Folder> page = invokeGetFolderFoldersPage(
+			postContentSpaceFolder.getId(), Pagination.of(2, 1));
+
+		assertValid(page);
+
+		List<Folder> folders = (List<Folder>)page.getItems();
+
+		List<Folder> randomFolders = new ArrayList<Folder>() {
+			{
+				add(randomFolder1);
+				add(randomFolder2);
+			}
+		};
+
+		for (Folder randomFolder : randomFolders) {
+			Stream<Folder> stream = folders.stream();
+
+			Folder folder = stream.filter(
+				aFolder -> Objects.equals(
+					randomFolder.getName(), aFolder.getName())
+			).findFirst(
+			).get();
+
+			assertEquals(randomFolder, folder);
+		}
+	}
+
+	@Test
 	public void testPostContentSpaceFolder() throws Exception {
 		Folder randomFolder = randomFolder();
 

--- a/modules/apps/headless/headless-form/headless-form-test/build.gradle
+++ b/modules/apps/headless/headless-form/headless-form-test/build.gradle
@@ -5,5 +5,6 @@ dependencies {
 	testIntegrationCompile project(":apps:headless:headless-form:headless-form-api")
 	testIntegrationCompile project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationCompile project(":core:petra:petra-function")
+	testIntegrationCompile project(":core:petra:petra-string")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormDocumentResourceTestCase.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.liferay.headless.form.dto.v1_0.FormDocument;
 import com.liferay.headless.form.dto.v1_0.Options;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -30,6 +31,10 @@ import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
 
 import java.net.URL;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 import javax.annotation.Generated;
 
@@ -120,6 +125,29 @@ public abstract class BaseFormDocumentResourceTestCase {
 			HttpUtil.URLtoString(options);
 
 			return options.getResponse();
+	}
+
+	protected void assertEquals(FormDocument formDocument1, FormDocument formDocument2) {
+		Assert.assertTrue(formDocument1 + " does not equal " + formDocument2, equals(formDocument1, formDocument2));
+	}
+
+	protected void assertEquals(List<FormDocument> formDocuments1, List<FormDocument> formDocuments2) {
+		Assert.assertEquals(formDocuments1.size(), formDocuments2.size());
+
+		for (int i = 0; i < formDocuments1.size(); i++) {
+			FormDocument formDocument1 = formDocuments1.get(i);
+			FormDocument formDocument2 = formDocuments2.get(i);
+
+			assertEquals(formDocument1, formDocument2);
+	}
+	}
+
+	protected boolean equals(FormDocument formDocument1, FormDocument formDocument2) {
+		if (formDocument1 == formDocument2) {
+			return true;
+	}
+
+		return false;
 	}
 
 	protected FormDocument randomFormDocument() {
@@ -271,6 +299,74 @@ public abstract class BaseFormDocumentResourceTestCase {
 
 	@JsonProperty
 	protected String title;
+
+	public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append("{");
+
+					sb.append("contentUrl=");
+
+				sb.append(contentUrl);
+					sb.append(", encodingFormat=");
+
+				sb.append(encodingFormat);
+					sb.append(", fileExtension=");
+
+				sb.append(fileExtension);
+					sb.append(", id=");
+
+				sb.append(id);
+					sb.append(", sizeInBytes=");
+
+				sb.append(sizeInBytes);
+					sb.append(", title=");
+
+				sb.append(title);
+
+			sb.append("}");
+
+			return sb.toString();
+	}
+
+	}
+
+	protected static class Page<T> {
+
+	public Collection<T> getItems() {
+			return new ArrayList<>(items);
+	}
+
+	public int getItemsPerPage() {
+			return itemsPerPage;
+	}
+
+	public int getLastPageNumber() {
+			return lastPageNumber;
+	}
+
+	public int getPageNumber() {
+			return pageNumber;
+	}
+
+	public int getTotalCount() {
+			return totalCount;
+	}
+
+	@JsonProperty
+	protected Collection<T> items;
+
+	@JsonProperty
+	protected int itemsPerPage;
+
+	@JsonProperty
+	protected int lastPageNumber;
+
+	@JsonProperty
+	protected int pageNumber;
+
+	@JsonProperty
+	protected int totalCount;
 
 	}
 

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
@@ -17,6 +17,7 @@ package com.liferay.headless.form.resource.v1_0.test;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.headless.form.dto.v1_0.Creator;
@@ -25,6 +26,7 @@ import com.liferay.headless.form.dto.v1_0.Form;
 import com.liferay.headless.form.dto.v1_0.FormRecord;
 import com.liferay.headless.form.dto.v1_0.Options;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -33,12 +35,14 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.StringPool;
-import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.net.URL;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 import javax.annotation.Generated;
 
@@ -150,7 +154,7 @@ public abstract class BaseFormRecordResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/forms/{form-id}/form-records", formId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<FormRecordImpl>>() {});
 	}
 
 	protected Http.Response invokeGetFormFormRecordsPageResponse(
@@ -195,6 +199,29 @@ public abstract class BaseFormRecordResourceTestCase {
 			HttpUtil.URLtoString(options);
 
 			return options.getResponse();
+	}
+
+	protected void assertEquals(FormRecord formRecord1, FormRecord formRecord2) {
+		Assert.assertTrue(formRecord1 + " does not equal " + formRecord2, equals(formRecord1, formRecord2));
+	}
+
+	protected void assertEquals(List<FormRecord> formRecords1, List<FormRecord> formRecords2) {
+		Assert.assertEquals(formRecords1.size(), formRecords2.size());
+
+		for (int i = 0; i < formRecords1.size(); i++) {
+			FormRecord formRecord1 = formRecords1.get(i);
+			FormRecord formRecord2 = formRecords2.get(i);
+
+			assertEquals(formRecord1, formRecord2);
+	}
+	}
+
+	protected boolean equals(FormRecord formRecord1, FormRecord formRecord2) {
+		if (formRecord1 == formRecord2) {
+			return true;
+	}
+
+		return false;
 	}
 
 	protected FormRecord randomFormRecord() {
@@ -413,6 +440,83 @@ public abstract class BaseFormRecordResourceTestCase {
 
 	@JsonProperty
 	protected Long id;
+
+	public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append("{");
+
+					sb.append("creator=");
+
+				sb.append(creator);
+					sb.append(", dateCreated=");
+
+				sb.append(dateCreated);
+					sb.append(", dateModified=");
+
+				sb.append(dateModified);
+					sb.append(", datePublished=");
+
+				sb.append(datePublished);
+					sb.append(", draft=");
+
+				sb.append(draft);
+					sb.append(", fieldValues=");
+
+				sb.append(fieldValues);
+					sb.append(", form=");
+
+				sb.append(form);
+					sb.append(", formId=");
+
+				sb.append(formId);
+					sb.append(", id=");
+
+				sb.append(id);
+
+			sb.append("}");
+
+			return sb.toString();
+	}
+
+	}
+
+	protected static class Page<T> {
+
+	public Collection<T> getItems() {
+			return new ArrayList<>(items);
+	}
+
+	public int getItemsPerPage() {
+			return itemsPerPage;
+	}
+
+	public int getLastPageNumber() {
+			return lastPageNumber;
+	}
+
+	public int getPageNumber() {
+			return pageNumber;
+	}
+
+	public int getTotalCount() {
+			return totalCount;
+	}
+
+	@JsonProperty
+	protected Collection<T> items;
+
+	@JsonProperty
+	protected int itemsPerPage;
+
+	@JsonProperty
+	protected int lastPageNumber;
+
+	@JsonProperty
+	protected int pageNumber;
+
+	@JsonProperty
+	protected int totalCount;
 
 	}
 

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormResourceTestCase.java
@@ -17,6 +17,7 @@ package com.liferay.headless.form.resource.v1_0.test;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.headless.form.dto.v1_0.Creator;
@@ -25,6 +26,7 @@ import com.liferay.headless.form.dto.v1_0.FormRecord;
 import com.liferay.headless.form.dto.v1_0.FormStructure;
 import com.liferay.headless.form.dto.v1_0.Options;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -33,12 +35,14 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.StringPool;
-import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.net.URL;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 import javax.annotation.Generated;
 
@@ -100,7 +104,7 @@ public abstract class BaseFormResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/content-spaces/{content-space-id}/form", contentSpaceId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<FormImpl>>() {});
 	}
 
 	protected Http.Response invokeGetContentSpaceFormsPageResponse(
@@ -222,6 +226,29 @@ public abstract class BaseFormResourceTestCase {
 			HttpUtil.URLtoString(options);
 
 			return options.getResponse();
+	}
+
+	protected void assertEquals(Form form1, Form form2) {
+		Assert.assertTrue(form1 + " does not equal " + form2, equals(form1, form2));
+	}
+
+	protected void assertEquals(List<Form> forms1, List<Form> forms2) {
+		Assert.assertEquals(forms1.size(), forms2.size());
+
+		for (int i = 0; i < forms1.size(); i++) {
+			Form form1 = forms1.get(i);
+			Form form2 = forms2.get(i);
+
+			assertEquals(form1, form2);
+	}
+	}
+
+	protected boolean equals(Form form1, Form form2) {
+		if (form1 == form2) {
+			return true;
+	}
+
+		return false;
 	}
 
 	protected Form randomForm() {
@@ -553,6 +580,98 @@ public abstract class BaseFormResourceTestCase {
 
 	@JsonProperty
 	protected Long structureId;
+
+	public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append("{");
+
+					sb.append("availableLanguages=");
+
+				sb.append(availableLanguages);
+					sb.append(", contentSpace=");
+
+				sb.append(contentSpace);
+					sb.append(", creator=");
+
+				sb.append(creator);
+					sb.append(", dateCreated=");
+
+				sb.append(dateCreated);
+					sb.append(", dateModified=");
+
+				sb.append(dateModified);
+					sb.append(", datePublished=");
+
+				sb.append(datePublished);
+					sb.append(", defaultLanguage=");
+
+				sb.append(defaultLanguage);
+					sb.append(", description=");
+
+				sb.append(description);
+					sb.append(", formRecords=");
+
+				sb.append(formRecords);
+					sb.append(", formRecordsIds=");
+
+				sb.append(formRecordsIds);
+					sb.append(", id=");
+
+				sb.append(id);
+					sb.append(", name=");
+
+				sb.append(name);
+					sb.append(", structure=");
+
+				sb.append(structure);
+					sb.append(", structureId=");
+
+				sb.append(structureId);
+
+			sb.append("}");
+
+			return sb.toString();
+	}
+
+	}
+
+	protected static class Page<T> {
+
+	public Collection<T> getItems() {
+			return new ArrayList<>(items);
+	}
+
+	public int getItemsPerPage() {
+			return itemsPerPage;
+	}
+
+	public int getLastPageNumber() {
+			return lastPageNumber;
+	}
+
+	public int getPageNumber() {
+			return pageNumber;
+	}
+
+	public int getTotalCount() {
+			return totalCount;
+	}
+
+	@JsonProperty
+	protected Collection<T> items;
+
+	@JsonProperty
+	protected int itemsPerPage;
+
+	@JsonProperty
+	protected int lastPageNumber;
+
+	@JsonProperty
+	protected int pageNumber;
+
+	@JsonProperty
+	protected int totalCount;
 
 	}
 

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormStructureResourceTestCase.java
@@ -17,6 +17,7 @@ package com.liferay.headless.form.resource.v1_0.test;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.headless.form.dto.v1_0.Creator;
@@ -25,18 +26,21 @@ import com.liferay.headless.form.dto.v1_0.FormStructure;
 import com.liferay.headless.form.dto.v1_0.Options;
 import com.liferay.headless.form.dto.v1_0.SuccessPage;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
-import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.net.URL;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 import javax.annotation.Generated;
 
@@ -86,7 +90,7 @@ public abstract class BaseFormStructureResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/content-spaces/{content-space-id}/form-structures", contentSpaceId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<FormStructureImpl>>() {});
 	}
 
 	protected Http.Response invokeGetContentSpaceFormStructuresPageResponse(
@@ -123,6 +127,29 @@ public abstract class BaseFormStructureResourceTestCase {
 			HttpUtil.URLtoString(options);
 
 			return options.getResponse();
+	}
+
+	protected void assertEquals(FormStructure formStructure1, FormStructure formStructure2) {
+		Assert.assertTrue(formStructure1 + " does not equal " + formStructure2, equals(formStructure1, formStructure2));
+	}
+
+	protected void assertEquals(List<FormStructure> formStructures1, List<FormStructure> formStructures2) {
+		Assert.assertEquals(formStructures1.size(), formStructures2.size());
+
+		for (int i = 0; i < formStructures1.size(); i++) {
+			FormStructure formStructure1 = formStructures1.get(i);
+			FormStructure formStructure2 = formStructures2.get(i);
+
+			assertEquals(formStructure1, formStructure2);
+	}
+	}
+
+	protected boolean equals(FormStructure formStructure1, FormStructure formStructure2) {
+		if (formStructure1 == formStructure2) {
+			return true;
+	}
+
+		return false;
 	}
 
 	protected FormStructure randomFormStructure() {
@@ -363,6 +390,86 @@ public abstract class BaseFormStructureResourceTestCase {
 
 	@JsonProperty
 	protected SuccessPage successPage;
+
+	public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append("{");
+
+					sb.append("availableLanguages=");
+
+				sb.append(availableLanguages);
+					sb.append(", contentSpace=");
+
+				sb.append(contentSpace);
+					sb.append(", creator=");
+
+				sb.append(creator);
+					sb.append(", dateCreated=");
+
+				sb.append(dateCreated);
+					sb.append(", dateModified=");
+
+				sb.append(dateModified);
+					sb.append(", description=");
+
+				sb.append(description);
+					sb.append(", formPages=");
+
+				sb.append(formPages);
+					sb.append(", id=");
+
+				sb.append(id);
+					sb.append(", name=");
+
+				sb.append(name);
+					sb.append(", successPage=");
+
+				sb.append(successPage);
+
+			sb.append("}");
+
+			return sb.toString();
+	}
+
+	}
+
+	protected static class Page<T> {
+
+	public Collection<T> getItems() {
+			return new ArrayList<>(items);
+	}
+
+	public int getItemsPerPage() {
+			return itemsPerPage;
+	}
+
+	public int getLastPageNumber() {
+			return lastPageNumber;
+	}
+
+	public int getPageNumber() {
+			return pageNumber;
+	}
+
+	public int getTotalCount() {
+			return totalCount;
+	}
+
+	@JsonProperty
+	protected Collection<T> items;
+
+	@JsonProperty
+	protected int itemsPerPage;
+
+	@JsonProperty
+	protected int lastPageNumber;
+
+	@JsonProperty
+	protected int pageNumber;
+
+	@JsonProperty
+	protected int totalCount;
 
 	}
 

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/build.gradle
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/build.gradle
@@ -5,5 +5,6 @@ dependencies {
 	testIntegrationCompile project(":apps:headless:headless-foundation:headless-foundation-api")
 	testIntegrationCompile project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationCompile project(":core:petra:petra-function")
+	testIntegrationCompile project(":core:petra:petra-string")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseCategoryResourceTestCase.java
@@ -17,6 +17,7 @@ package com.liferay.headless.foundation.resource.v1_0.test;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.headless.foundation.dto.v1_0.Category;
@@ -24,6 +25,7 @@ import com.liferay.headless.foundation.dto.v1_0.Creator;
 import com.liferay.headless.foundation.dto.v1_0.ParentCategory;
 import com.liferay.headless.foundation.dto.v1_0.ParentVocabulary;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
@@ -34,12 +36,14 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.StringPool;
-import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.net.URL;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 import javax.annotation.Generated;
 
@@ -190,7 +194,7 @@ public abstract class BaseCategoryResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/categories/{category-id}/categories", categoryId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<CategoryImpl>>() {});
 	}
 
 	protected Http.Response invokeGetCategoryCategoriesPageResponse(
@@ -244,7 +248,7 @@ public abstract class BaseCategoryResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/vocabularies/{vocabulary-id}/categories", vocabularyId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<CategoryImpl>>() {});
 	}
 
 	protected Http.Response invokeGetVocabularyCategoriesPageResponse(
@@ -289,6 +293,29 @@ public abstract class BaseCategoryResourceTestCase {
 			HttpUtil.URLtoString(options);
 
 			return options.getResponse();
+	}
+
+	protected void assertEquals(Category category1, Category category2) {
+		Assert.assertTrue(category1 + " does not equal " + category2, equals(category1, category2));
+	}
+
+	protected void assertEquals(List<Category> categories1, List<Category> categories2) {
+		Assert.assertEquals(categories1.size(), categories2.size());
+
+		for (int i = 0; i < categories1.size(); i++) {
+			Category category1 = categories1.get(i);
+			Category category2 = categories2.get(i);
+
+			assertEquals(category1, category2);
+	}
+	}
+
+	protected boolean equals(Category category1, Category category2) {
+		if (category1 == category2) {
+			return true;
+	}
+
+		return false;
 	}
 
 	protected Category randomCategory() {
@@ -575,6 +602,92 @@ public abstract class BaseCategoryResourceTestCase {
 
 	@JsonProperty
 	protected Long parentVocabularyId;
+
+	public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append("{");
+
+					sb.append("availableLanguages=");
+
+				sb.append(availableLanguages);
+					sb.append(", parentCategory=");
+
+				sb.append(parentCategory);
+					sb.append(", creator=");
+
+				sb.append(creator);
+					sb.append(", creatorId=");
+
+				sb.append(creatorId);
+					sb.append(", dateCreated=");
+
+				sb.append(dateCreated);
+					sb.append(", dateModified=");
+
+				sb.append(dateModified);
+					sb.append(", description=");
+
+				sb.append(description);
+					sb.append(", hasCategories=");
+
+				sb.append(hasCategories);
+					sb.append(", id=");
+
+				sb.append(id);
+					sb.append(", name=");
+
+				sb.append(name);
+					sb.append(", parentVocabulary=");
+
+				sb.append(parentVocabulary);
+					sb.append(", parentVocabularyId=");
+
+				sb.append(parentVocabularyId);
+
+			sb.append("}");
+
+			return sb.toString();
+	}
+
+	}
+
+	protected static class Page<T> {
+
+	public Collection<T> getItems() {
+			return new ArrayList<>(items);
+	}
+
+	public int getItemsPerPage() {
+			return itemsPerPage;
+	}
+
+	public int getLastPageNumber() {
+			return lastPageNumber;
+	}
+
+	public int getPageNumber() {
+			return pageNumber;
+	}
+
+	public int getTotalCount() {
+			return totalCount;
+	}
+
+	@JsonProperty
+	protected Collection<T> items;
+
+	@JsonProperty
+	protected int itemsPerPage;
+
+	@JsonProperty
+	protected int lastPageNumber;
+
+	@JsonProperty
+	protected int pageNumber;
+
+	@JsonProperty
+	protected int totalCount;
 
 	}
 

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseEmailResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseEmailResourceTestCase.java
@@ -17,20 +17,25 @@ package com.liferay.headless.foundation.resource.v1_0.test;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.headless.foundation.dto.v1_0.Email;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
-import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.net.URL;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 import javax.annotation.Generated;
 
@@ -80,7 +85,7 @@ public abstract class BaseEmailResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/emails", genericParentId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<EmailImpl>>() {});
 	}
 
 	protected Http.Response invokeGetGenericParentEmailsPageResponse(
@@ -117,6 +122,29 @@ public abstract class BaseEmailResourceTestCase {
 			HttpUtil.URLtoString(options);
 
 			return options.getResponse();
+	}
+
+	protected void assertEquals(Email email1, Email email2) {
+		Assert.assertTrue(email1 + " does not equal " + email2, equals(email1, email2));
+	}
+
+	protected void assertEquals(List<Email> emails1, List<Email> emails2) {
+		Assert.assertEquals(emails1.size(), emails2.size());
+
+		for (int i = 0; i < emails1.size(); i++) {
+			Email email1 = emails1.get(i);
+			Email email2 = emails2.get(i);
+
+			assertEquals(email1, email2);
+	}
+	}
+
+	protected boolean equals(Email email1, Email email2) {
+		if (email1 == email2) {
+			return true;
+	}
+
+		return false;
 	}
 
 	protected Email randomEmail() {
@@ -200,6 +228,65 @@ public abstract class BaseEmailResourceTestCase {
 
 	@JsonProperty
 	protected String type;
+
+	public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append("{");
+
+					sb.append("email=");
+
+				sb.append(email);
+					sb.append(", id=");
+
+				sb.append(id);
+					sb.append(", type=");
+
+				sb.append(type);
+
+			sb.append("}");
+
+			return sb.toString();
+	}
+
+	}
+
+	protected static class Page<T> {
+
+	public Collection<T> getItems() {
+			return new ArrayList<>(items);
+	}
+
+	public int getItemsPerPage() {
+			return itemsPerPage;
+	}
+
+	public int getLastPageNumber() {
+			return lastPageNumber;
+	}
+
+	public int getPageNumber() {
+			return pageNumber;
+	}
+
+	public int getTotalCount() {
+			return totalCount;
+	}
+
+	@JsonProperty
+	protected Collection<T> items;
+
+	@JsonProperty
+	protected int itemsPerPage;
+
+	@JsonProperty
+	protected int lastPageNumber;
+
+	@JsonProperty
+	protected int pageNumber;
+
+	@JsonProperty
+	protected int totalCount;
 
 	}
 

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -17,11 +17,13 @@ package com.liferay.headless.foundation.resource.v1_0.test;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.headless.foundation.dto.v1_0.Creator;
 import com.liferay.headless.foundation.dto.v1_0.Keyword;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
@@ -32,12 +34,14 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.StringPool;
-import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.net.URL;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 import javax.annotation.Generated;
 
@@ -99,7 +103,7 @@ public abstract class BaseKeywordResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/content-spaces/{content-space-id}/keywords", contentSpaceId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<KeywordImpl>>() {});
 	}
 
 	protected Http.Response invokeGetContentSpaceKeywordsPageResponse(
@@ -225,6 +229,29 @@ public abstract class BaseKeywordResourceTestCase {
 			HttpUtil.URLtoString(options);
 
 			return options.getResponse();
+	}
+
+	protected void assertEquals(Keyword keyword1, Keyword keyword2) {
+		Assert.assertTrue(keyword1 + " does not equal " + keyword2, equals(keyword1, keyword2));
+	}
+
+	protected void assertEquals(List<Keyword> keywords1, List<Keyword> keywords2) {
+		Assert.assertEquals(keywords1.size(), keywords2.size());
+
+		for (int i = 0; i < keywords1.size(); i++) {
+			Keyword keyword1 = keywords1.get(i);
+			Keyword keyword2 = keywords2.get(i);
+
+			assertEquals(keyword1, keyword2);
+	}
+	}
+
+	protected boolean equals(Keyword keyword1, Keyword keyword2) {
+		if (keyword1 == keyword2) {
+			return true;
+	}
+
+		return false;
 	}
 
 	protected Keyword randomKeyword() {
@@ -398,6 +425,77 @@ public abstract class BaseKeywordResourceTestCase {
 
 	@JsonProperty
 	protected String name;
+
+	public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append("{");
+
+					sb.append("contentSpace=");
+
+				sb.append(contentSpace);
+					sb.append(", creator=");
+
+				sb.append(creator);
+					sb.append(", dateCreated=");
+
+				sb.append(dateCreated);
+					sb.append(", dateModified=");
+
+				sb.append(dateModified);
+					sb.append(", id=");
+
+				sb.append(id);
+					sb.append(", keywordUsageCount=");
+
+				sb.append(keywordUsageCount);
+					sb.append(", name=");
+
+				sb.append(name);
+
+			sb.append("}");
+
+			return sb.toString();
+	}
+
+	}
+
+	protected static class Page<T> {
+
+	public Collection<T> getItems() {
+			return new ArrayList<>(items);
+	}
+
+	public int getItemsPerPage() {
+			return itemsPerPage;
+	}
+
+	public int getLastPageNumber() {
+			return lastPageNumber;
+	}
+
+	public int getPageNumber() {
+			return pageNumber;
+	}
+
+	public int getTotalCount() {
+			return totalCount;
+	}
+
+	@JsonProperty
+	protected Collection<T> items;
+
+	@JsonProperty
+	protected int itemsPerPage;
+
+	@JsonProperty
+	protected int lastPageNumber;
+
+	@JsonProperty
+	protected int pageNumber;
+
+	@JsonProperty
+	protected int totalCount;
 
 	}
 

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseOrganizationResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseOrganizationResourceTestCase.java
@@ -17,6 +17,7 @@ package com.liferay.headless.foundation.resource.v1_0.test;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.headless.foundation.dto.v1_0.ContactInformation;
@@ -25,16 +26,20 @@ import com.liferay.headless.foundation.dto.v1_0.Organization;
 import com.liferay.headless.foundation.dto.v1_0.Services;
 import com.liferay.headless.foundation.dto.v1_0.UserAccount;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
-import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.net.URL;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 import javax.annotation.Generated;
 
@@ -96,7 +101,7 @@ public abstract class BaseOrganizationResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/my-user-accounts/{my-user-account-id}/organizations", myUserAccountId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<OrganizationImpl>>() {});
 	}
 
 	protected Http.Response invokeGetMyUserAccountOrganizationsPageResponse(
@@ -119,7 +124,7 @@ public abstract class BaseOrganizationResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/organizations", pagination));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<OrganizationImpl>>() {});
 	}
 
 	protected Http.Response invokeGetOrganizationsPageResponse(
@@ -165,7 +170,7 @@ public abstract class BaseOrganizationResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/organizations/{organization-id}/organizations", organizationId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<OrganizationImpl>>() {});
 	}
 
 	protected Http.Response invokeGetOrganizationOrganizationsPageResponse(
@@ -188,7 +193,7 @@ public abstract class BaseOrganizationResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/user-accounts/{user-account-id}/organizations", userAccountId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<OrganizationImpl>>() {});
 	}
 
 	protected Http.Response invokeGetUserAccountOrganizationsPageResponse(
@@ -202,6 +207,29 @@ public abstract class BaseOrganizationResourceTestCase {
 			HttpUtil.URLtoString(options);
 
 			return options.getResponse();
+	}
+
+	protected void assertEquals(Organization organization1, Organization organization2) {
+		Assert.assertTrue(organization1 + " does not equal " + organization2, equals(organization1, organization2));
+	}
+
+	protected void assertEquals(List<Organization> organizations1, List<Organization> organizations2) {
+		Assert.assertEquals(organizations1.size(), organizations2.size());
+
+		for (int i = 0; i < organizations1.size(); i++) {
+			Organization organization1 = organizations1.get(i);
+			Organization organization2 = organizations2.get(i);
+
+			assertEquals(organization1, organization2);
+	}
+	}
+
+	protected boolean equals(Organization organization1, Organization organization2) {
+		if (organization1 == organization2) {
+			return true;
+	}
+
+		return false;
 	}
 
 	protected Organization randomOrganization() {
@@ -507,6 +535,95 @@ public abstract class BaseOrganizationResourceTestCase {
 
 	@JsonProperty
 	protected Long[] subOrganizationIds;
+
+	public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append("{");
+
+					sb.append("comment=");
+
+				sb.append(comment);
+					sb.append(", contactInformation=");
+
+				sb.append(contactInformation);
+					sb.append(", id=");
+
+				sb.append(id);
+					sb.append(", location=");
+
+				sb.append(location);
+					sb.append(", logo=");
+
+				sb.append(logo);
+					sb.append(", members=");
+
+				sb.append(members);
+					sb.append(", membersIds=");
+
+				sb.append(membersIds);
+					sb.append(", name=");
+
+				sb.append(name);
+					sb.append(", parentOrganization=");
+
+				sb.append(parentOrganization);
+					sb.append(", parentOrganizationId=");
+
+				sb.append(parentOrganizationId);
+					sb.append(", services=");
+
+				sb.append(services);
+					sb.append(", subOrganization=");
+
+				sb.append(subOrganization);
+					sb.append(", subOrganizationIds=");
+
+				sb.append(subOrganizationIds);
+
+			sb.append("}");
+
+			return sb.toString();
+	}
+
+	}
+
+	protected static class Page<T> {
+
+	public Collection<T> getItems() {
+			return new ArrayList<>(items);
+	}
+
+	public int getItemsPerPage() {
+			return itemsPerPage;
+	}
+
+	public int getLastPageNumber() {
+			return lastPageNumber;
+	}
+
+	public int getPageNumber() {
+			return pageNumber;
+	}
+
+	public int getTotalCount() {
+			return totalCount;
+	}
+
+	@JsonProperty
+	protected Collection<T> items;
+
+	@JsonProperty
+	protected int itemsPerPage;
+
+	@JsonProperty
+	protected int lastPageNumber;
+
+	@JsonProperty
+	protected int pageNumber;
+
+	@JsonProperty
+	protected int totalCount;
 
 	}
 

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BasePhoneResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BasePhoneResourceTestCase.java
@@ -17,20 +17,25 @@ package com.liferay.headless.foundation.resource.v1_0.test;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.headless.foundation.dto.v1_0.Phone;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
-import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.net.URL;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 import javax.annotation.Generated;
 
@@ -80,7 +85,7 @@ public abstract class BasePhoneResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/phones", genericParentId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<PhoneImpl>>() {});
 	}
 
 	protected Http.Response invokeGetGenericParentPhonesPageResponse(
@@ -117,6 +122,29 @@ public abstract class BasePhoneResourceTestCase {
 			HttpUtil.URLtoString(options);
 
 			return options.getResponse();
+	}
+
+	protected void assertEquals(Phone phone1, Phone phone2) {
+		Assert.assertTrue(phone1 + " does not equal " + phone2, equals(phone1, phone2));
+	}
+
+	protected void assertEquals(List<Phone> phones1, List<Phone> phones2) {
+		Assert.assertEquals(phones1.size(), phones2.size());
+
+		for (int i = 0; i < phones1.size(); i++) {
+			Phone phone1 = phones1.get(i);
+			Phone phone2 = phones2.get(i);
+
+			assertEquals(phone1, phone2);
+	}
+	}
+
+	protected boolean equals(Phone phone1, Phone phone2) {
+		if (phone1 == phone2) {
+			return true;
+	}
+
+		return false;
 	}
 
 	protected Phone randomPhone() {
@@ -223,6 +251,68 @@ public abstract class BasePhoneResourceTestCase {
 
 	@JsonProperty
 	protected String phoneType;
+
+	public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append("{");
+
+					sb.append("extension=");
+
+				sb.append(extension);
+					sb.append(", id=");
+
+				sb.append(id);
+					sb.append(", phoneNumber=");
+
+				sb.append(phoneNumber);
+					sb.append(", phoneType=");
+
+				sb.append(phoneType);
+
+			sb.append("}");
+
+			return sb.toString();
+	}
+
+	}
+
+	protected static class Page<T> {
+
+	public Collection<T> getItems() {
+			return new ArrayList<>(items);
+	}
+
+	public int getItemsPerPage() {
+			return itemsPerPage;
+	}
+
+	public int getLastPageNumber() {
+			return lastPageNumber;
+	}
+
+	public int getPageNumber() {
+			return pageNumber;
+	}
+
+	public int getTotalCount() {
+			return totalCount;
+	}
+
+	@JsonProperty
+	protected Collection<T> items;
+
+	@JsonProperty
+	protected int itemsPerPage;
+
+	@JsonProperty
+	protected int lastPageNumber;
+
+	@JsonProperty
+	protected int pageNumber;
+
+	@JsonProperty
+	protected int totalCount;
 
 	}
 

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BasePostalAddressResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BasePostalAddressResourceTestCase.java
@@ -17,20 +17,25 @@ package com.liferay.headless.foundation.resource.v1_0.test;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.headless.foundation.dto.v1_0.PostalAddress;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
-import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.net.URL;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 import javax.annotation.Generated;
 
@@ -80,7 +85,7 @@ public abstract class BasePostalAddressResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/addresses", genericParentId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<PostalAddressImpl>>() {});
 	}
 
 	protected Http.Response invokeGetGenericParentPostalAddressesPageResponse(
@@ -117,6 +122,29 @@ public abstract class BasePostalAddressResourceTestCase {
 			HttpUtil.URLtoString(options);
 
 			return options.getResponse();
+	}
+
+	protected void assertEquals(PostalAddress postalAddress1, PostalAddress postalAddress2) {
+		Assert.assertTrue(postalAddress1 + " does not equal " + postalAddress2, equals(postalAddress1, postalAddress2));
+	}
+
+	protected void assertEquals(List<PostalAddress> postalAddresses1, List<PostalAddress> postalAddresses2) {
+		Assert.assertEquals(postalAddresses1.size(), postalAddresses2.size());
+
+		for (int i = 0; i < postalAddresses1.size(); i++) {
+			PostalAddress postalAddress1 = postalAddresses1.get(i);
+			PostalAddress postalAddress2 = postalAddresses2.get(i);
+
+			assertEquals(postalAddress1, postalAddress2);
+	}
+	}
+
+	protected boolean equals(PostalAddress postalAddress1, PostalAddress postalAddress2) {
+		if (postalAddress1 == postalAddress2) {
+			return true;
+	}
+
+		return false;
 	}
 
 	protected PostalAddress randomPostalAddress() {
@@ -338,6 +366,83 @@ public abstract class BasePostalAddressResourceTestCase {
 
 	@JsonProperty
 	protected String streetAddressLine3;
+
+	public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append("{");
+
+					sb.append("addressCountry=");
+
+				sb.append(addressCountry);
+					sb.append(", addressLocality=");
+
+				sb.append(addressLocality);
+					sb.append(", addressRegion=");
+
+				sb.append(addressRegion);
+					sb.append(", addressType=");
+
+				sb.append(addressType);
+					sb.append(", id=");
+
+				sb.append(id);
+					sb.append(", postalCode=");
+
+				sb.append(postalCode);
+					sb.append(", streetAddressLine1=");
+
+				sb.append(streetAddressLine1);
+					sb.append(", streetAddressLine2=");
+
+				sb.append(streetAddressLine2);
+					sb.append(", streetAddressLine3=");
+
+				sb.append(streetAddressLine3);
+
+			sb.append("}");
+
+			return sb.toString();
+	}
+
+	}
+
+	protected static class Page<T> {
+
+	public Collection<T> getItems() {
+			return new ArrayList<>(items);
+	}
+
+	public int getItemsPerPage() {
+			return itemsPerPage;
+	}
+
+	public int getLastPageNumber() {
+			return lastPageNumber;
+	}
+
+	public int getPageNumber() {
+			return pageNumber;
+	}
+
+	public int getTotalCount() {
+			return totalCount;
+	}
+
+	@JsonProperty
+	protected Collection<T> items;
+
+	@JsonProperty
+	protected int itemsPerPage;
+
+	@JsonProperty
+	protected int lastPageNumber;
+
+	@JsonProperty
+	protected int pageNumber;
+
+	@JsonProperty
+	protected int totalCount;
 
 	}
 

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseRoleResourceTestCase.java
@@ -17,23 +17,27 @@ package com.liferay.headless.foundation.resource.v1_0.test;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.headless.foundation.dto.v1_0.Creator;
 import com.liferay.headless.foundation.dto.v1_0.Role;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
-import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.net.URL;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 import javax.annotation.Generated;
 
@@ -91,7 +95,7 @@ public abstract class BaseRoleResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/my-user-accounts/{my-user-account-id}/roles", myUserAccountId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<RoleImpl>>() {});
 	}
 
 	protected Http.Response invokeGetMyUserAccountRolesPageResponse(
@@ -114,7 +118,7 @@ public abstract class BaseRoleResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/roles", pagination));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<RoleImpl>>() {});
 	}
 
 	protected Http.Response invokeGetRolesPageResponse(
@@ -160,7 +164,7 @@ public abstract class BaseRoleResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/user-accounts/{user-account-id}/roles", userAccountId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<RoleImpl>>() {});
 	}
 
 	protected Http.Response invokeGetUserAccountRolesPageResponse(
@@ -174,6 +178,29 @@ public abstract class BaseRoleResourceTestCase {
 			HttpUtil.URLtoString(options);
 
 			return options.getResponse();
+	}
+
+	protected void assertEquals(Role role1, Role role2) {
+		Assert.assertTrue(role1 + " does not equal " + role2, equals(role1, role2));
+	}
+
+	protected void assertEquals(List<Role> roles1, List<Role> roles2) {
+		Assert.assertEquals(roles1.size(), roles2.size());
+
+		for (int i = 0; i < roles1.size(); i++) {
+			Role role1 = roles1.get(i);
+			Role role2 = roles2.get(i);
+
+			assertEquals(role1, role2);
+	}
+	}
+
+	protected boolean equals(Role role1, Role role2) {
+		if (role1 == role2) {
+			return true;
+	}
+
+		return false;
 	}
 
 	protected Role randomRole() {
@@ -370,6 +397,80 @@ public abstract class BaseRoleResourceTestCase {
 
 	@JsonProperty
 	protected String roleType;
+
+	public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append("{");
+
+					sb.append("availableLanguages=");
+
+				sb.append(availableLanguages);
+					sb.append(", creator=");
+
+				sb.append(creator);
+					sb.append(", dateCreated=");
+
+				sb.append(dateCreated);
+					sb.append(", dateModified=");
+
+				sb.append(dateModified);
+					sb.append(", description=");
+
+				sb.append(description);
+					sb.append(", id=");
+
+				sb.append(id);
+					sb.append(", name=");
+
+				sb.append(name);
+					sb.append(", roleType=");
+
+				sb.append(roleType);
+
+			sb.append("}");
+
+			return sb.toString();
+	}
+
+	}
+
+	protected static class Page<T> {
+
+	public Collection<T> getItems() {
+			return new ArrayList<>(items);
+	}
+
+	public int getItemsPerPage() {
+			return itemsPerPage;
+	}
+
+	public int getLastPageNumber() {
+			return lastPageNumber;
+	}
+
+	public int getPageNumber() {
+			return pageNumber;
+	}
+
+	public int getTotalCount() {
+			return totalCount;
+	}
+
+	@JsonProperty
+	protected Collection<T> items;
+
+	@JsonProperty
+	protected int itemsPerPage;
+
+	@JsonProperty
+	protected int lastPageNumber;
+
+	@JsonProperty
+	protected int pageNumber;
+
+	@JsonProperty
+	protected int totalCount;
 
 	}
 

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -17,6 +17,7 @@ package com.liferay.headless.foundation.resource.v1_0.test;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.headless.foundation.dto.v1_0.ContactInformation;
@@ -24,6 +25,7 @@ import com.liferay.headless.foundation.dto.v1_0.Organization;
 import com.liferay.headless.foundation.dto.v1_0.Role;
 import com.liferay.headless.foundation.dto.v1_0.UserAccount;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -32,12 +34,14 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.StringPool;
-import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.net.URL;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 import javax.annotation.Generated;
 
@@ -134,7 +138,7 @@ public abstract class BaseUserAccountResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/organizations/{organization-id}/user-accounts", organizationId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<UserAccountImpl>>() {});
 	}
 
 	protected Http.Response invokeGetOrganizationUserAccountsPageResponse(
@@ -157,7 +161,7 @@ public abstract class BaseUserAccountResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/user-accounts", fullnamequery));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<UserAccountImpl>>() {});
 	}
 
 	protected Http.Response invokeGetUserAccountsPageResponse(
@@ -288,7 +292,7 @@ public abstract class BaseUserAccountResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/web-sites/{web-site-id}/user-accounts", webSiteId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<UserAccountImpl>>() {});
 	}
 
 	protected Http.Response invokeGetWebSiteUserAccountsPageResponse(
@@ -302,6 +306,29 @@ public abstract class BaseUserAccountResourceTestCase {
 			HttpUtil.URLtoString(options);
 
 			return options.getResponse();
+	}
+
+	protected void assertEquals(UserAccount userAccount1, UserAccount userAccount2) {
+		Assert.assertTrue(userAccount1 + " does not equal " + userAccount2, equals(userAccount1, userAccount2));
+	}
+
+	protected void assertEquals(List<UserAccount> userAccounts1, List<UserAccount> userAccounts2) {
+		Assert.assertEquals(userAccounts1.size(), userAccounts2.size());
+
+		for (int i = 0; i < userAccounts1.size(); i++) {
+			UserAccount userAccount1 = userAccounts1.get(i);
+			UserAccount userAccount2 = userAccounts2.get(i);
+
+			assertEquals(userAccount1, userAccount2);
+	}
+	}
+
+	protected boolean equals(UserAccount userAccount1, UserAccount userAccount2) {
+		if (userAccount1 == userAccount2) {
+			return true;
+	}
+
+		return false;
 	}
 
 	protected UserAccount randomUserAccount() {
@@ -792,6 +819,119 @@ public abstract class BaseUserAccountResourceTestCase {
 
 	@JsonProperty
 	protected String[] tasksAssignedToMyRoles;
+
+	public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append("{");
+
+					sb.append("additionalName=");
+
+				sb.append(additionalName);
+					sb.append(", alternateName=");
+
+				sb.append(alternateName);
+					sb.append(", birthDate=");
+
+				sb.append(birthDate);
+					sb.append(", contactInformation=");
+
+				sb.append(contactInformation);
+					sb.append(", dashboardURL=");
+
+				sb.append(dashboardURL);
+					sb.append(", email=");
+
+				sb.append(email);
+					sb.append(", familyName=");
+
+				sb.append(familyName);
+					sb.append(", givenName=");
+
+				sb.append(givenName);
+					sb.append(", honorificPrefix=");
+
+				sb.append(honorificPrefix);
+					sb.append(", honorificSuffix=");
+
+				sb.append(honorificSuffix);
+					sb.append(", id=");
+
+				sb.append(id);
+					sb.append(", image=");
+
+				sb.append(image);
+					sb.append(", jobTitle=");
+
+				sb.append(jobTitle);
+					sb.append(", myOrganizations=");
+
+				sb.append(myOrganizations);
+					sb.append(", myOrganizationsIds=");
+
+				sb.append(myOrganizationsIds);
+					sb.append(", name=");
+
+				sb.append(name);
+					sb.append(", profileURL=");
+
+				sb.append(profileURL);
+					sb.append(", roles=");
+
+				sb.append(roles);
+					sb.append(", rolesIds=");
+
+				sb.append(rolesIds);
+					sb.append(", tasksAssignedToMe=");
+
+				sb.append(tasksAssignedToMe);
+					sb.append(", tasksAssignedToMyRoles=");
+
+				sb.append(tasksAssignedToMyRoles);
+
+			sb.append("}");
+
+			return sb.toString();
+	}
+
+	}
+
+	protected static class Page<T> {
+
+	public Collection<T> getItems() {
+			return new ArrayList<>(items);
+	}
+
+	public int getItemsPerPage() {
+			return itemsPerPage;
+	}
+
+	public int getLastPageNumber() {
+			return lastPageNumber;
+	}
+
+	public int getPageNumber() {
+			return pageNumber;
+	}
+
+	public int getTotalCount() {
+			return totalCount;
+	}
+
+	@JsonProperty
+	protected Collection<T> items;
+
+	@JsonProperty
+	protected int itemsPerPage;
+
+	@JsonProperty
+	protected int lastPageNumber;
+
+	@JsonProperty
+	protected int pageNumber;
+
+	@JsonProperty
+	protected int totalCount;
 
 	}
 

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseVocabularyResourceTestCase.java
@@ -17,11 +17,13 @@ package com.liferay.headless.foundation.resource.v1_0.test;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.headless.foundation.dto.v1_0.Creator;
 import com.liferay.headless.foundation.dto.v1_0.Vocabulary;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
@@ -32,12 +34,14 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.StringPool;
-import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.net.URL;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 import javax.annotation.Generated;
 
@@ -99,7 +103,7 @@ public abstract class BaseVocabularyResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/content-spaces/{content-space-id}/vocabularies", contentSpaceId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<VocabularyImpl>>() {});
 	}
 
 	protected Http.Response invokeGetContentSpaceVocabulariesPageResponse(
@@ -225,6 +229,29 @@ public abstract class BaseVocabularyResourceTestCase {
 			HttpUtil.URLtoString(options);
 
 			return options.getResponse();
+	}
+
+	protected void assertEquals(Vocabulary vocabulary1, Vocabulary vocabulary2) {
+		Assert.assertTrue(vocabulary1 + " does not equal " + vocabulary2, equals(vocabulary1, vocabulary2));
+	}
+
+	protected void assertEquals(List<Vocabulary> vocabularies1, List<Vocabulary> vocabularies2) {
+		Assert.assertEquals(vocabularies1.size(), vocabularies2.size());
+
+		for (int i = 0; i < vocabularies1.size(); i++) {
+			Vocabulary vocabulary1 = vocabularies1.get(i);
+			Vocabulary vocabulary2 = vocabularies2.get(i);
+
+			assertEquals(vocabulary1, vocabulary2);
+	}
+	}
+
+	protected boolean equals(Vocabulary vocabulary1, Vocabulary vocabulary2) {
+		if (vocabulary1 == vocabulary2) {
+			return true;
+	}
+
+		return false;
 	}
 
 	protected Vocabulary randomVocabulary() {
@@ -444,6 +471,83 @@ public abstract class BaseVocabularyResourceTestCase {
 
 	@JsonProperty
 	protected String name;
+
+	public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append("{");
+
+					sb.append("availableLanguages=");
+
+				sb.append(availableLanguages);
+					sb.append(", contentSpace=");
+
+				sb.append(contentSpace);
+					sb.append(", creator=");
+
+				sb.append(creator);
+					sb.append(", dateCreated=");
+
+				sb.append(dateCreated);
+					sb.append(", dateModified=");
+
+				sb.append(dateModified);
+					sb.append(", description=");
+
+				sb.append(description);
+					sb.append(", hasCategories=");
+
+				sb.append(hasCategories);
+					sb.append(", id=");
+
+				sb.append(id);
+					sb.append(", name=");
+
+				sb.append(name);
+
+			sb.append("}");
+
+			return sb.toString();
+	}
+
+	}
+
+	protected static class Page<T> {
+
+	public Collection<T> getItems() {
+			return new ArrayList<>(items);
+	}
+
+	public int getItemsPerPage() {
+			return itemsPerPage;
+	}
+
+	public int getLastPageNumber() {
+			return lastPageNumber;
+	}
+
+	public int getPageNumber() {
+			return pageNumber;
+	}
+
+	public int getTotalCount() {
+			return totalCount;
+	}
+
+	@JsonProperty
+	protected Collection<T> items;
+
+	@JsonProperty
+	protected int itemsPerPage;
+
+	@JsonProperty
+	protected int lastPageNumber;
+
+	@JsonProperty
+	protected int pageNumber;
+
+	@JsonProperty
+	protected int totalCount;
 
 	}
 

--- a/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseWebUrlResourceTestCase.java
+++ b/modules/apps/headless/headless-foundation/headless-foundation-test/src/testIntegration/java/com/liferay/headless/foundation/resource/v1_0/test/BaseWebUrlResourceTestCase.java
@@ -17,20 +17,25 @@ package com.liferay.headless.foundation.resource.v1_0.test;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.headless.foundation.dto.v1_0.WebUrl;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
-import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.net.URL;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 import javax.annotation.Generated;
 
@@ -80,7 +85,7 @@ public abstract class BaseWebUrlResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/web-urls", genericParentId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<WebUrlImpl>>() {});
 	}
 
 	protected Http.Response invokeGetGenericParentWebUrlsPageResponse(
@@ -117,6 +122,29 @@ public abstract class BaseWebUrlResourceTestCase {
 			HttpUtil.URLtoString(options);
 
 			return options.getResponse();
+	}
+
+	protected void assertEquals(WebUrl webUrl1, WebUrl webUrl2) {
+		Assert.assertTrue(webUrl1 + " does not equal " + webUrl2, equals(webUrl1, webUrl2));
+	}
+
+	protected void assertEquals(List<WebUrl> webUrls1, List<WebUrl> webUrls2) {
+		Assert.assertEquals(webUrls1.size(), webUrls2.size());
+
+		for (int i = 0; i < webUrls1.size(); i++) {
+			WebUrl webUrl1 = webUrls1.get(i);
+			WebUrl webUrl2 = webUrls2.get(i);
+
+			assertEquals(webUrl1, webUrl2);
+	}
+	}
+
+	protected boolean equals(WebUrl webUrl1, WebUrl webUrl2) {
+		if (webUrl1 == webUrl2) {
+			return true;
+	}
+
+		return false;
 	}
 
 	protected WebUrl randomWebUrl() {
@@ -200,6 +228,65 @@ public abstract class BaseWebUrlResourceTestCase {
 
 	@JsonProperty
 	protected String urlType;
+
+	public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append("{");
+
+					sb.append("id=");
+
+				sb.append(id);
+					sb.append(", url=");
+
+				sb.append(url);
+					sb.append(", urlType=");
+
+				sb.append(urlType);
+
+			sb.append("}");
+
+			return sb.toString();
+	}
+
+	}
+
+	protected static class Page<T> {
+
+	public Collection<T> getItems() {
+			return new ArrayList<>(items);
+	}
+
+	public int getItemsPerPage() {
+			return itemsPerPage;
+	}
+
+	public int getLastPageNumber() {
+			return lastPageNumber;
+	}
+
+	public int getPageNumber() {
+			return pageNumber;
+	}
+
+	public int getTotalCount() {
+			return totalCount;
+	}
+
+	@JsonProperty
+	protected Collection<T> items;
+
+	@JsonProperty
+	protected int itemsPerPage;
+
+	@JsonProperty
+	protected int lastPageNumber;
+
+	@JsonProperty
+	protected int pageNumber;
+
+	@JsonProperty
+	protected int totalCount;
 
 	}
 

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-test/build.gradle
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-test/build.gradle
@@ -5,5 +5,6 @@ dependencies {
 	testIntegrationCompile project(":apps:headless:headless-web-experience:headless-web-experience-api")
 	testIntegrationCompile project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationCompile project(":core:petra:petra-function")
+	testIntegrationCompile project(":core:petra:petra-string")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-test/src/testIntegration/java/com/liferay/headless/web/experience/resource/v1_0/test/BaseCommentResourceTestCase.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-test/src/testIntegration/java/com/liferay/headless/web/experience/resource/v1_0/test/BaseCommentResourceTestCase.java
@@ -17,24 +17,28 @@ package com.liferay.headless.web.experience.resource.v1_0.test;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.headless.web.experience.dto.v1_0.Comment;
 import com.liferay.headless.web.experience.dto.v1_0.Creator;
 import com.liferay.headless.web.experience.dto.v1_0.Options;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
-import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.net.URL;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 import javax.annotation.Generated;
 
@@ -111,7 +115,7 @@ public abstract class BaseCommentResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/comments/{comment-id}/comments", commentId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<CommentImpl>>() {});
 	}
 
 	protected Http.Response invokeGetCommentCommentsPageResponse(
@@ -134,7 +138,7 @@ public abstract class BaseCommentResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/structured-contents/{structured-content-id}/comments", structuredContentId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<CommentImpl>>() {});
 	}
 
 	protected Http.Response invokeGetStructuredContentCommentsPageResponse(
@@ -148,6 +152,29 @@ public abstract class BaseCommentResourceTestCase {
 			HttpUtil.URLtoString(options);
 
 			return options.getResponse();
+	}
+
+	protected void assertEquals(Comment comment1, Comment comment2) {
+		Assert.assertTrue(comment1 + " does not equal " + comment2, equals(comment1, comment2));
+	}
+
+	protected void assertEquals(List<Comment> comments1, List<Comment> comments2) {
+		Assert.assertEquals(comments1.size(), comments2.size());
+
+		for (int i = 0; i < comments1.size(); i++) {
+			Comment comment1 = comments1.get(i);
+			Comment comment2 = comments2.get(i);
+
+			assertEquals(comment1, comment2);
+	}
+	}
+
+	protected boolean equals(Comment comment1, Comment comment2) {
+		if (comment1 == comment2) {
+			return true;
+	}
+
+		return false;
 	}
 
 	protected Comment randomComment() {
@@ -321,6 +348,77 @@ public abstract class BaseCommentResourceTestCase {
 
 	@JsonProperty
 	protected String text;
+
+	public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append("{");
+
+					sb.append("comments=");
+
+				sb.append(comments);
+					sb.append(", creator=");
+
+				sb.append(creator);
+					sb.append(", dateCreated=");
+
+				sb.append(dateCreated);
+					sb.append(", dateModified=");
+
+				sb.append(dateModified);
+					sb.append(", hasComments=");
+
+				sb.append(hasComments);
+					sb.append(", id=");
+
+				sb.append(id);
+					sb.append(", text=");
+
+				sb.append(text);
+
+			sb.append("}");
+
+			return sb.toString();
+	}
+
+	}
+
+	protected static class Page<T> {
+
+	public Collection<T> getItems() {
+			return new ArrayList<>(items);
+	}
+
+	public int getItemsPerPage() {
+			return itemsPerPage;
+	}
+
+	public int getLastPageNumber() {
+			return lastPageNumber;
+	}
+
+	public int getPageNumber() {
+			return pageNumber;
+	}
+
+	public int getTotalCount() {
+			return totalCount;
+	}
+
+	@JsonProperty
+	protected Collection<T> items;
+
+	@JsonProperty
+	protected int itemsPerPage;
+
+	@JsonProperty
+	protected int lastPageNumber;
+
+	@JsonProperty
+	protected int pageNumber;
+
+	@JsonProperty
+	protected int totalCount;
 
 	}
 

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-test/src/testIntegration/java/com/liferay/headless/web/experience/resource/v1_0/test/BaseContentStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-test/src/testIntegration/java/com/liferay/headless/web/experience/resource/v1_0/test/BaseContentStructureResourceTestCase.java
@@ -17,6 +17,7 @@ package com.liferay.headless.web.experience.resource.v1_0.test;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.headless.web.experience.dto.v1_0.ContentStructure;
@@ -24,6 +25,7 @@ import com.liferay.headless.web.experience.dto.v1_0.Creator;
 import com.liferay.headless.web.experience.dto.v1_0.Fields;
 import com.liferay.headless.web.experience.dto.v1_0.Options;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
@@ -32,12 +34,14 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
-import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.net.URL;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 import javax.annotation.Generated;
 
@@ -87,7 +91,7 @@ public abstract class BaseContentStructureResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/content-spaces/{content-space-id}/content-structures", contentSpaceId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<ContentStructureImpl>>() {});
 	}
 
 	protected Http.Response invokeGetContentSpaceContentStructuresPageResponse(
@@ -124,6 +128,29 @@ public abstract class BaseContentStructureResourceTestCase {
 			HttpUtil.URLtoString(options);
 
 			return options.getResponse();
+	}
+
+	protected void assertEquals(ContentStructure contentStructure1, ContentStructure contentStructure2) {
+		Assert.assertTrue(contentStructure1 + " does not equal " + contentStructure2, equals(contentStructure1, contentStructure2));
+	}
+
+	protected void assertEquals(List<ContentStructure> contentStructures1, List<ContentStructure> contentStructures2) {
+		Assert.assertEquals(contentStructures1.size(), contentStructures2.size());
+
+		for (int i = 0; i < contentStructures1.size(); i++) {
+			ContentStructure contentStructure1 = contentStructures1.get(i);
+			ContentStructure contentStructure2 = contentStructures2.get(i);
+
+			assertEquals(contentStructure1, contentStructure2);
+	}
+	}
+
+	protected boolean equals(ContentStructure contentStructure1, ContentStructure contentStructure2) {
+		if (contentStructure1 == contentStructure2) {
+			return true;
+	}
+
+		return false;
 	}
 
 	protected ContentStructure randomContentStructure() {
@@ -342,6 +369,83 @@ public abstract class BaseContentStructureResourceTestCase {
 
 	@JsonProperty
 	protected String name;
+
+	public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append("{");
+
+					sb.append("availableLanguages=");
+
+				sb.append(availableLanguages);
+					sb.append(", contentSpace=");
+
+				sb.append(contentSpace);
+					sb.append(", creator=");
+
+				sb.append(creator);
+					sb.append(", dateCreated=");
+
+				sb.append(dateCreated);
+					sb.append(", dateModified=");
+
+				sb.append(dateModified);
+					sb.append(", description=");
+
+				sb.append(description);
+					sb.append(", fields=");
+
+				sb.append(fields);
+					sb.append(", id=");
+
+				sb.append(id);
+					sb.append(", name=");
+
+				sb.append(name);
+
+			sb.append("}");
+
+			return sb.toString();
+	}
+
+	}
+
+	protected static class Page<T> {
+
+	public Collection<T> getItems() {
+			return new ArrayList<>(items);
+	}
+
+	public int getItemsPerPage() {
+			return itemsPerPage;
+	}
+
+	public int getLastPageNumber() {
+			return lastPageNumber;
+	}
+
+	public int getPageNumber() {
+			return pageNumber;
+	}
+
+	public int getTotalCount() {
+			return totalCount;
+	}
+
+	@JsonProperty
+	protected Collection<T> items;
+
+	@JsonProperty
+	protected int itemsPerPage;
+
+	@JsonProperty
+	protected int lastPageNumber;
+
+	@JsonProperty
+	protected int pageNumber;
+
+	@JsonProperty
+	protected int totalCount;
 
 	}
 

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-test/src/testIntegration/java/com/liferay/headless/web/experience/resource/v1_0/test/BaseStructuredContentImageResourceTestCase.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-test/src/testIntegration/java/com/liferay/headless/web/experience/resource/v1_0/test/BaseStructuredContentImageResourceTestCase.java
@@ -17,23 +17,27 @@ package com.liferay.headless.web.experience.resource.v1_0.test;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.headless.web.experience.dto.v1_0.Creator;
 import com.liferay.headless.web.experience.dto.v1_0.Options;
 import com.liferay.headless.web.experience.dto.v1_0.StructuredContentImage;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
-import com.liferay.portal.vulcan.pagination.Page;
 
 import java.net.URL;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 import javax.annotation.Generated;
 
@@ -87,7 +91,7 @@ public abstract class BaseStructuredContentImageResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/structured-contents/{structured-content-id}/structured-content-images", structuredContentId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<StructuredContentImageImpl>>() {});
 	}
 
 	protected Http.Response invokeGetStructuredContentStructuredContentImagesPageResponse(
@@ -151,6 +155,29 @@ public abstract class BaseStructuredContentImageResourceTestCase {
 			HttpUtil.URLtoString(options);
 
 			return options.getResponse();
+	}
+
+	protected void assertEquals(StructuredContentImage structuredContentImage1, StructuredContentImage structuredContentImage2) {
+		Assert.assertTrue(structuredContentImage1 + " does not equal " + structuredContentImage2, equals(structuredContentImage1, structuredContentImage2));
+	}
+
+	protected void assertEquals(List<StructuredContentImage> structuredContentImages1, List<StructuredContentImage> structuredContentImages2) {
+		Assert.assertEquals(structuredContentImages1.size(), structuredContentImages2.size());
+
+		for (int i = 0; i < structuredContentImages1.size(); i++) {
+			StructuredContentImage structuredContentImage1 = structuredContentImages1.get(i);
+			StructuredContentImage structuredContentImage2 = structuredContentImages2.get(i);
+
+			assertEquals(structuredContentImage1, structuredContentImage2);
+	}
+	}
+
+	protected boolean equals(StructuredContentImage structuredContentImage1, StructuredContentImage structuredContentImage2) {
+		if (structuredContentImage1 == structuredContentImage2) {
+			return true;
+	}
+
+		return false;
 	}
 
 	protected StructuredContentImage randomStructuredContentImage() {
@@ -370,6 +397,83 @@ public abstract class BaseStructuredContentImageResourceTestCase {
 
 	@JsonProperty
 	protected String title;
+
+	public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append("{");
+
+					sb.append("contentUrl=");
+
+				sb.append(contentUrl);
+					sb.append(", creator=");
+
+				sb.append(creator);
+					sb.append(", dateCreated=");
+
+				sb.append(dateCreated);
+					sb.append(", dateModified=");
+
+				sb.append(dateModified);
+					sb.append(", encodingFormat=");
+
+				sb.append(encodingFormat);
+					sb.append(", fileExtension=");
+
+				sb.append(fileExtension);
+					sb.append(", id=");
+
+				sb.append(id);
+					sb.append(", sizeInBytes=");
+
+				sb.append(sizeInBytes);
+					sb.append(", title=");
+
+				sb.append(title);
+
+			sb.append("}");
+
+			return sb.toString();
+	}
+
+	}
+
+	protected static class Page<T> {
+
+	public Collection<T> getItems() {
+			return new ArrayList<>(items);
+	}
+
+	public int getItemsPerPage() {
+			return itemsPerPage;
+	}
+
+	public int getLastPageNumber() {
+			return lastPageNumber;
+	}
+
+	public int getPageNumber() {
+			return pageNumber;
+	}
+
+	public int getTotalCount() {
+			return totalCount;
+	}
+
+	@JsonProperty
+	protected Collection<T> items;
+
+	@JsonProperty
+	protected int itemsPerPage;
+
+	@JsonProperty
+	protected int lastPageNumber;
+
+	@JsonProperty
+	protected int pageNumber;
+
+	@JsonProperty
+	protected int totalCount;
 
 	}
 

--- a/modules/apps/headless/headless-web-experience/headless-web-experience-test/src/testIntegration/java/com/liferay/headless/web/experience/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-web-experience/headless-web-experience-test/src/testIntegration/java/com/liferay/headless/web/experience/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -17,6 +17,7 @@ package com.liferay.headless.web.experience.resource.v1_0.test;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.headless.web.experience.dto.v1_0.AggregateRating;
@@ -28,6 +29,7 @@ import com.liferay.headless.web.experience.dto.v1_0.RenderedContentsURL;
 import com.liferay.headless.web.experience.dto.v1_0.StructuredContent;
 import com.liferay.headless.web.experience.dto.v1_0.Values;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
@@ -38,12 +40,14 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.StringPool;
-import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.net.URL;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 import javax.annotation.Generated;
 
@@ -117,7 +121,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/content-structures/{content-structure-id}/structured-contents", contentSpaceId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<StructuredContentImpl>>() {});
 	}
 
 	protected Http.Response invokeGetContentSpaceContentStructureStructuredContentsPageResponse(
@@ -140,7 +144,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/content-spaces/{content-space-id}/structured-contents", contentSpaceId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<StructuredContentImpl>>() {});
 	}
 
 	protected Http.Response invokeGetContentSpaceStructuredContentsPageResponse(
@@ -312,6 +316,29 @@ public abstract class BaseStructuredContentResourceTestCase {
 			HttpUtil.URLtoString(options);
 
 			return options.getResponse();
+	}
+
+	protected void assertEquals(StructuredContent structuredContent1, StructuredContent structuredContent2) {
+		Assert.assertTrue(structuredContent1 + " does not equal " + structuredContent2, equals(structuredContent1, structuredContent2));
+	}
+
+	protected void assertEquals(List<StructuredContent> structuredContents1, List<StructuredContent> structuredContents2) {
+		Assert.assertEquals(structuredContents1.size(), structuredContents2.size());
+
+		for (int i = 0; i < structuredContents1.size(); i++) {
+			StructuredContent structuredContent1 = structuredContents1.get(i);
+			StructuredContent structuredContent2 = structuredContents2.get(i);
+
+			assertEquals(structuredContent1, structuredContent2);
+	}
+	}
+
+	protected boolean equals(StructuredContent structuredContent1, StructuredContent structuredContent2) {
+		if (structuredContent1 == structuredContent2) {
+			return true;
+	}
+
+		return false;
 	}
 
 	protected StructuredContent randomStructuredContent() {
@@ -709,6 +736,107 @@ public abstract class BaseStructuredContentResourceTestCase {
 
 	@JsonProperty
 	protected Values[] values;
+
+	public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append("{");
+
+					sb.append("aggregateRating=");
+
+				sb.append(aggregateRating);
+					sb.append(", availableLanguages=");
+
+				sb.append(availableLanguages);
+					sb.append(", categories=");
+
+				sb.append(categories);
+					sb.append(", comment=");
+
+				sb.append(comment);
+					sb.append(", contentSpace=");
+
+				sb.append(contentSpace);
+					sb.append(", contentStructureId=");
+
+				sb.append(contentStructureId);
+					sb.append(", creator=");
+
+				sb.append(creator);
+					sb.append(", dateCreated=");
+
+				sb.append(dateCreated);
+					sb.append(", dateModified=");
+
+				sb.append(dateModified);
+					sb.append(", datePublished=");
+
+				sb.append(datePublished);
+					sb.append(", description=");
+
+				sb.append(description);
+					sb.append(", id=");
+
+				sb.append(id);
+					sb.append(", keywords=");
+
+				sb.append(keywords);
+					sb.append(", lastReviewed=");
+
+				sb.append(lastReviewed);
+					sb.append(", renderedContentsURL=");
+
+				sb.append(renderedContentsURL);
+					sb.append(", title=");
+
+				sb.append(title);
+					sb.append(", values=");
+
+				sb.append(values);
+
+			sb.append("}");
+
+			return sb.toString();
+	}
+
+	}
+
+	protected static class Page<T> {
+
+	public Collection<T> getItems() {
+			return new ArrayList<>(items);
+	}
+
+	public int getItemsPerPage() {
+			return itemsPerPage;
+	}
+
+	public int getLastPageNumber() {
+			return lastPageNumber;
+	}
+
+	public int getPageNumber() {
+			return pageNumber;
+	}
+
+	public int getTotalCount() {
+			return totalCount;
+	}
+
+	@JsonProperty
+	protected Collection<T> items;
+
+	@JsonProperty
+	protected int itemsPerPage;
+
+	@JsonProperty
+	protected int lastPageNumber;
+
+	@JsonProperty
+	protected int pageNumber;
+
+	@JsonProperty
+	protected int totalCount;
 
 	}
 

--- a/modules/apps/headless/headless-workflow/headless-workflow-test/build.gradle
+++ b/modules/apps/headless/headless-workflow/headless-workflow-test/build.gradle
@@ -5,5 +5,6 @@ dependencies {
 	testIntegrationCompile project(":apps:headless:headless-workflow:headless-workflow-api")
 	testIntegrationCompile project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationCompile project(":core:petra:petra-function")
+	testIntegrationCompile project(":core:petra:petra-string")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/headless/headless-workflow/headless-workflow-test/src/testIntegration/java/com/liferay/headless/workflow/resource/v1_0/test/BaseWorkflowLogResourceTestCase.java
+++ b/modules/apps/headless/headless-workflow/headless-workflow-test/src/testIntegration/java/com/liferay/headless/workflow/resource/v1_0/test/BaseWorkflowLogResourceTestCase.java
@@ -17,23 +17,27 @@ package com.liferay.headless.workflow.resource.v1_0.test;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.headless.workflow.dto.v1_0.WorkflowLog;
 import com.liferay.headless.workflow.dto.v1_0.WorkflowTask;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
-import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.net.URL;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 import javax.annotation.Generated;
 
@@ -106,7 +110,7 @@ public abstract class BaseWorkflowLogResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/workflow-tasks/{workflow-task-id}/workflow-logs", workflowTaskId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<WorkflowLogImpl>>() {});
 	}
 
 	protected Http.Response invokeGetWorkflowTaskWorkflowLogsPageResponse(
@@ -120,6 +124,29 @@ public abstract class BaseWorkflowLogResourceTestCase {
 			HttpUtil.URLtoString(options);
 
 			return options.getResponse();
+	}
+
+	protected void assertEquals(WorkflowLog workflowLog1, WorkflowLog workflowLog2) {
+		Assert.assertTrue(workflowLog1 + " does not equal " + workflowLog2, equals(workflowLog1, workflowLog2));
+	}
+
+	protected void assertEquals(List<WorkflowLog> workflowLogs1, List<WorkflowLog> workflowLogs2) {
+		Assert.assertEquals(workflowLogs1.size(), workflowLogs2.size());
+
+		for (int i = 0; i < workflowLogs1.size(); i++) {
+			WorkflowLog workflowLog1 = workflowLogs1.get(i);
+			WorkflowLog workflowLog2 = workflowLogs2.get(i);
+
+			assertEquals(workflowLog1, workflowLog2);
+	}
+	}
+
+	protected boolean equals(WorkflowLog workflowLog1, WorkflowLog workflowLog2) {
+		if (workflowLog1 == workflowLog2) {
+			return true;
+	}
+
+		return false;
 	}
 
 	protected WorkflowLog randomWorkflowLog() {
@@ -386,6 +413,89 @@ public abstract class BaseWorkflowLogResourceTestCase {
 
 	@JsonProperty
 	protected String type;
+
+	public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append("{");
+
+					sb.append("auditPerson=");
+
+				sb.append(auditPerson);
+					sb.append(", commentLog=");
+
+				sb.append(commentLog);
+					sb.append(", dateCreated=");
+
+				sb.append(dateCreated);
+					sb.append(", id=");
+
+				sb.append(id);
+					sb.append(", person=");
+
+				sb.append(person);
+					sb.append(", previousPerson=");
+
+				sb.append(previousPerson);
+					sb.append(", previousState=");
+
+				sb.append(previousState);
+					sb.append(", state=");
+
+				sb.append(state);
+					sb.append(", task=");
+
+				sb.append(task);
+					sb.append(", taskId=");
+
+				sb.append(taskId);
+					sb.append(", type=");
+
+				sb.append(type);
+
+			sb.append("}");
+
+			return sb.toString();
+	}
+
+	}
+
+	protected static class Page<T> {
+
+	public Collection<T> getItems() {
+			return new ArrayList<>(items);
+	}
+
+	public int getItemsPerPage() {
+			return itemsPerPage;
+	}
+
+	public int getLastPageNumber() {
+			return lastPageNumber;
+	}
+
+	public int getPageNumber() {
+			return pageNumber;
+	}
+
+	public int getTotalCount() {
+			return totalCount;
+	}
+
+	@JsonProperty
+	protected Collection<T> items;
+
+	@JsonProperty
+	protected int itemsPerPage;
+
+	@JsonProperty
+	protected int lastPageNumber;
+
+	@JsonProperty
+	protected int pageNumber;
+
+	@JsonProperty
+	protected int totalCount;
 
 	}
 

--- a/modules/apps/headless/headless-workflow/headless-workflow-test/src/testIntegration/java/com/liferay/headless/workflow/resource/v1_0/test/BaseWorkflowTaskResourceTestCase.java
+++ b/modules/apps/headless/headless-workflow/headless-workflow-test/src/testIntegration/java/com/liferay/headless/workflow/resource/v1_0/test/BaseWorkflowTaskResourceTestCase.java
@@ -17,12 +17,14 @@ package com.liferay.headless.workflow.resource.v1_0.test;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.headless.workflow.dto.v1_0.ObjectReviewed;
 import com.liferay.headless.workflow.dto.v1_0.WorkflowLog;
 import com.liferay.headless.workflow.dto.v1_0.WorkflowTask;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -31,12 +33,14 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.StringPool;
-import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.net.URL;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 import javax.annotation.Generated;
 
@@ -106,7 +110,7 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/roles/{role-id}/workflow-tasks", roleId));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<WorkflowTaskImpl>>() {});
 	}
 
 	protected Http.Response invokeGetRoleWorkflowTasksPageResponse(
@@ -129,7 +133,7 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 
 			options.setLocation(_resourceURL + _toPath("/workflow-tasks", pagination));
 
-				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), Page.class);
+				return _outputObjectMapper.readValue(HttpUtil.URLtoString(options), new TypeReference<Page<WorkflowTaskImpl>>() {});
 	}
 
 	protected Http.Response invokeGetWorkflowTasksPageResponse(
@@ -290,6 +294,29 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 			HttpUtil.URLtoString(options);
 
 			return options.getResponse();
+	}
+
+	protected void assertEquals(WorkflowTask workflowTask1, WorkflowTask workflowTask2) {
+		Assert.assertTrue(workflowTask1 + " does not equal " + workflowTask2, equals(workflowTask1, workflowTask2));
+	}
+
+	protected void assertEquals(List<WorkflowTask> workflowTasks1, List<WorkflowTask> workflowTasks2) {
+		Assert.assertEquals(workflowTasks1.size(), workflowTasks2.size());
+
+		for (int i = 0; i < workflowTasks1.size(); i++) {
+			WorkflowTask workflowTask1 = workflowTasks1.get(i);
+			WorkflowTask workflowTask2 = workflowTasks2.get(i);
+
+			assertEquals(workflowTask1, workflowTask2);
+	}
+	}
+
+	protected boolean equals(WorkflowTask workflowTask1, WorkflowTask workflowTask2) {
+		if (workflowTask1 == workflowTask2) {
+			return true;
+	}
+
+		return false;
 	}
 
 	protected WorkflowTask randomWorkflowTask() {
@@ -576,6 +603,92 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 
 	@JsonProperty
 	protected String[] transitions;
+
+	public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append("{");
+
+					sb.append("completed=");
+
+				sb.append(completed);
+					sb.append(", dateCompleted=");
+
+				sb.append(dateCompleted);
+					sb.append(", dateCreated=");
+
+				sb.append(dateCreated);
+					sb.append(", definitionName=");
+
+				sb.append(definitionName);
+					sb.append(", description=");
+
+				sb.append(description);
+					sb.append(", dueDate=");
+
+				sb.append(dueDate);
+					sb.append(", id=");
+
+				sb.append(id);
+					sb.append(", logs=");
+
+				sb.append(logs);
+					sb.append(", logsIds=");
+
+				sb.append(logsIds);
+					sb.append(", name=");
+
+				sb.append(name);
+					sb.append(", objectReviewed=");
+
+				sb.append(objectReviewed);
+					sb.append(", transitions=");
+
+				sb.append(transitions);
+
+			sb.append("}");
+
+			return sb.toString();
+	}
+
+	}
+
+	protected static class Page<T> {
+
+	public Collection<T> getItems() {
+			return new ArrayList<>(items);
+	}
+
+	public int getItemsPerPage() {
+			return itemsPerPage;
+	}
+
+	public int getLastPageNumber() {
+			return lastPageNumber;
+	}
+
+	public int getPageNumber() {
+			return pageNumber;
+	}
+
+	public int getTotalCount() {
+			return totalCount;
+	}
+
+	@JsonProperty
+	protected Collection<T> items;
+
+	@JsonProperty
+	protected int itemsPerPage;
+
+	@JsonProperty
+	protected int lastPageNumber;
+
+	@JsonProperty
+	protected int pageNumber;
+
+	@JsonProperty
+	protected int totalCount;
 
 	}
 

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
@@ -17,6 +17,7 @@ package com.liferay.portal.tools.rest.builder;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.StringUtil_IW;
+import com.liferay.portal.kernel.util.TextFormatter;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.Validator_IW;
 import com.liferay.portal.tools.ArgumentsUtil;
@@ -139,14 +140,7 @@ public class RESTBuilder {
 
 				Schema schema = entry.getValue();
 
-				context.put("schema", schema);
-
-				context.put("schemaName", schemaName);
-				context.put(
-					"schemaPath", CamelCaseUtil.fromCamelCase(schemaName));
-				context.put(
-					"schemaVarName",
-					StringUtil.lowerCaseFirstLetter(schemaName));
+				_putSchema(context, schema, schemaName);
 
 				_createBaseResourceImplFile(
 					context, schemaName, versionDirName);
@@ -164,17 +158,9 @@ public class RESTBuilder {
 
 			for (Map.Entry<String, Schema> entry : allSchemas.entrySet()) {
 				Schema schema = entry.getValue();
-
-				context.put("schema", schema);
-
 				String schemaName = entry.getKey();
 
-				context.put("schemaName", schemaName);
-				context.put(
-					"schemaPath", CamelCaseUtil.fromCamelCase(schemaName));
-				context.put(
-					"schemaVarName",
-					StringUtil.lowerCaseFirstLetter(schemaName));
+				_putSchema(context, schema, schemaName);
 
 				_createDTOFile(context, schemaName, versionDirName);
 				_createDTOImplFile(context, schemaName, versionDirName);
@@ -566,6 +552,20 @@ public class RESTBuilder {
 			file,
 			FreeMarkerUtil.processTemplate(
 				_copyrightFileName, "resource_test", context));
+	}
+
+	private void _putSchema(
+		Map<String, Object> context, Schema schema, String schemaName) {
+
+		context.put("schema", schema);
+		context.put("schemaName", schemaName);
+		context.put("schemaPath", CamelCaseUtil.fromCamelCase(schemaName));
+
+		String schemaVarName = StringUtil.lowerCaseFirstLetter(schemaName);
+
+		context.put("schemaVarName", schemaVarName);
+		context.put(
+			"schemaVarNames", TextFormatter.formatPlural(schemaVarName));
 	}
 
 	private final File _configDir;

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -75,8 +75,8 @@ public abstract class Base${schemaName}ResourceImpl implements ${schemaName}Reso
 
 				<#list freeMarkerTool.getDTOJavaParameters(configYAML, openAPIYAML, schemaName, false) as javaParameter>
 					<#if !freeMarkerTool.isSchemaParameter(javaParameter, openAPIYAML)>
-						if (Validator.isNotNull(${schemaName?uncap_first}.get${javaParameter.parameterName?cap_first}())) {
-							existing${schemaName}.set${javaParameter.parameterName?cap_first}(${schemaName?uncap_first}.get${javaParameter.parameterName?cap_first}());
+						if (Validator.isNotNull(${schemaVarName}.get${javaParameter.parameterName?cap_first}())) {
+							existing${schemaName}.set${javaParameter.parameterName?cap_first}(${schemaVarName}.get${javaParameter.parameterName?cap_first}());
 						}
 					</#if>
 				</#list>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Blogs.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Blogs.macro
@@ -551,6 +551,12 @@ definition {
 		AssertTextEquals(locator1 = "Button#ANY", value1 = "RSS");
 	}
 
+	macro viewEntryPresent {
+		LexiconCard.viewCardPresent(
+			card = "${entryTitle}"
+		);
+	}
+
 	macro viewNoEntryCP {
 		AssertTextEquals(
 			locator1 = "Message#EMPTY_INFO",

--- a/portal-web/test/functional/com/liferay/portalweb/macros/BlogsEntry.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/BlogsEntry.macro
@@ -294,7 +294,10 @@ definition {
 
 		Portlet.mouseOverPortletTitle(portletTitleName = "Blogs");
 
-		Click(locator1 = "Icon#BODY_VERTICAL_ELLIPSIS");
+		Click(
+			locator1 = "Blogs#WIDGET_VIEW_ENTRY_ELLIPSIS",
+			key_entryTitle = "${entryTitle}"
+		);
 
 		MenuItem.viewNotPresent(menuItem = "Edit");
 	}
@@ -516,9 +519,12 @@ definition {
 
 		Portlet.mouseOverPortletTitle(portletTitleName = "Blogs");
 
-		Click(locator1 = "Icon#BODY_VERTICAL_ELLIPSIS");
-
-		MenuItem.click(menuItem = "Permissions");
+		var key_entryTitle = "${entryTitle}";
+		
+		Blogs.clickEllipsisItemPG(
+			entryTitle = "${entryTitle}",
+			item = "Permissions"
+		);
 
 		IFrame.selectPermissionsFrame();
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/BlogsEntry.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/BlogsEntry.macro
@@ -520,7 +520,7 @@ definition {
 		Portlet.mouseOverPortletTitle(portletTitleName = "Blogs");
 
 		var key_entryTitle = "${entryTitle}";
-		
+
 		Blogs.clickEllipsisItemPG(
 			entryTitle = "${entryTitle}",
 			item = "Permissions"

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DMDocument.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DMDocument.macro
@@ -1246,6 +1246,12 @@ definition {
 			value1 = "${userEmailAddress}"
 		);
 
+		Click(locator1 = "DocumentsAndMediaShare#INVITE_TO_COLLABORATE_DROPDOWN");
+
+		var key_userName = "${userName}";
+
+		AssertElementPresent(locator1 = "DocumentsAndMediaShare#INVITE_TO_COLLABORATE_TAG");
+
 		if (isSet(shareable)) {
 			FormFields.enableCheckbox(fieldName = "shareable");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaShare.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaShare.path
@@ -9,8 +9,18 @@
 </thead>
 <tbody>
 <tr>
+	<td>INVITE_TO_COLLABORATE_DROPDOWN</td>
+	<td>//ul[contains(@class,'dropdown-menu')]//a[contains(@class,'dropdown-item')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>INVITE_TO_COLLABORATE_INPUT</td>
 	<td>//div[contains(@class,'form-control')]/input[contains(@type,'text')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>INVITE_TO_COLLABORATE_TAG</td>
+	<td>//div/span[contains(@id,'item-tag')]/span[contains(.,'${key_userName}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaShare.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaShare.path
@@ -10,7 +10,7 @@
 <tbody>
 <tr>
 	<td>INVITE_TO_COLLABORATE_INPUT</td>
-	<td>//div/input[contains(@id,'userEmailAddress')]</td>
+	<td>//div[contains(@class,'form-control')]/input[contains(@type,'text')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/rolesandpermissions/cproles/CPRolesPGBlogs.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/rolesandpermissions/cproles/CPRolesPGBlogs.testcase
@@ -756,7 +756,7 @@ definition {
 
 		Navigator.gotoSitePage(pageName = "Blogs Page", siteName = "Organization Name");
 
-		BlogsNavigator.gotoBlogsEntryPermissionsPG();
+		BlogsNavigator.gotoBlogsEntryPermissionsPG(entryTitle = "Blogs Entry Title");
 
 		Role.definePermissionPG(
 			permissionDefinitionKey = "CONTENT_PERMISSIONS_DELETE_CHECKBOX",
@@ -793,7 +793,7 @@ definition {
 
 		Navigator.gotoSitePage(pageName = "Blogs Page", siteName = "Organization Name");
 
-		BlogsNavigator.gotoBlogsEntryPermissionsPG();
+		BlogsNavigator.gotoBlogsEntryPermissionsPG(entryTitle = "Blogs Entry Title");
 
 		Role.removePermissionPG(
 			permissionDefinitionKey = "CONTENT_PERMISSIONS_DELETE_CHECKBOX",
@@ -854,7 +854,7 @@ definition {
 
 		Navigator.gotoPage(pageName = "Blogs Page");
 
-		BlogsNavigator.gotoBlogsEntryPermissionsPG();
+		BlogsNavigator.gotoBlogsEntryPermissionsPG(entryTitle = "Blogs Entry Title");
 
 		Role.removePermissionPG(
 			permissionDefinitionKey = "CONTENT_PERMISSIONS_DELETE_CHECKBOX",
@@ -877,7 +877,7 @@ definition {
 
 		Navigator.gotoPage(pageName = "Blogs Page");
 
-		BlogsNavigator.gotoBlogsEntryPermissionsPG();
+		BlogsNavigator.gotoBlogsEntryPermissionsPG(entryTitle = "Blogs Entry Title");
 
 		Role.definePermissionPG(
 			permissionDefinitionKey = "CONTENT_PERMISSIONS_DELETE_CHECKBOX",
@@ -1005,7 +1005,7 @@ definition {
 
 		Navigator.gotoPage(pageName = "Blogs Page");
 
-		BlogsNavigator.gotoBlogsEntryPermissionsPG();
+		BlogsNavigator.gotoBlogsEntryPermissionsPG(entryTitle = "Blogs Entry Title");
 
 		Role.definePermissionPG(
 			permissionDefinitionKey = "CONTENT_PERMISSIONS_DELETE_CHECKBOX",
@@ -1035,7 +1035,7 @@ definition {
 
 		Navigator.gotoPage(pageName = "Blogs Page");
 
-		BlogsNavigator.gotoBlogsEntryPermissionsPG();
+		BlogsNavigator.gotoBlogsEntryPermissionsPG(entryTitle = "Blogs Entry Title");
 
 		Role.removePermissionPG(
 			permissionDefinitionKey = "CONTENT_PERMISSIONS_DELETE_CHECKBOX",
@@ -1180,7 +1180,7 @@ definition {
 
 		Navigator.gotoSitePage(pageName = "Blogs Page", siteName = "Site Name");
 
-		BlogsNavigator.gotoBlogsEntryPermissionsPG();
+		BlogsNavigator.gotoBlogsEntryPermissionsPG(entryTitle = "Blogs Entry Title");
 
 		Role.definePermissionPG(
 			permissionDefinitionKey = "CONTENT_PERMISSIONS_DELETE_CHECKBOX",
@@ -1212,7 +1212,7 @@ definition {
 
 		Navigator.gotoSitePage(pageName = "Blogs Page", siteName = "Site Name");
 
-		BlogsNavigator.gotoBlogsEntryPermissionsPG();
+		BlogsNavigator.gotoBlogsEntryPermissionsPG(entryTitle = "Blogs Entry Title");
 
 		Role.removePermissionPG(
 			permissionDefinitionKey = "CONTENT_PERMISSIONS_DELETE_CHECKBOX",
@@ -1272,7 +1272,7 @@ definition {
 
 		Navigator.gotoSitePage(pageName = "Blogs Page", siteName = "Site Name");
 
-		BlogsNavigator.gotoBlogsEntryPermissionsPG();
+		BlogsNavigator.gotoBlogsEntryPermissionsPG(entryTitle = "Blogs Entry Title");
 
 		Team.definePermissionPG(
 			permissionDefinitionKey = "_ACTION_DELETE",
@@ -1304,7 +1304,7 @@ definition {
 
 		Navigator.gotoSitePage(pageName = "Blogs Page", siteName = "Site Name");
 
-		BlogsNavigator.gotoBlogsEntryPermissionsPG();
+		BlogsNavigator.gotoBlogsEntryPermissionsPG(entryTitle = "Blogs Entry Title");
 
 		Team.removePermissionPG(
 			permissionDefinitionKey = "_ACTION_DELETE",
@@ -1365,7 +1365,7 @@ definition {
 
 		Navigator.gotoPage(pageName = "Blogs Page");
 
-		BlogsNavigator.gotoBlogsEntryPermissionsPG();
+		BlogsNavigator.gotoBlogsEntryPermissionsPG(entryTitle = "Blogs Entry Title");
 
 		Role.removePermissionPG(
 			permissionDefinitionKey = "CONTENT_PERMISSIONS_UPDATE_CHECKBOX",
@@ -1391,7 +1391,7 @@ definition {
 
 		Navigator.gotoPage(pageName = "Blogs Page");
 
-		BlogsNavigator.gotoBlogsEntryPermissionsPG();
+		BlogsNavigator.gotoBlogsEntryPermissionsPG(entryTitle = "Blogs Entry Title");
 
 		Role.definePermissionPG(
 			permissionDefinitionKey = "CONTENT_PERMISSIONS_UPDATE_CHECKBOX",
@@ -1661,7 +1661,7 @@ definition {
 
 		Navigator.gotoPage(pageName = "Blogs Page");
 
-		BlogsNavigator.gotoBlogsEntryPermissionsPG();
+		BlogsNavigator.gotoBlogsEntryPermissionsPG(entryTitle = "Blogs Entry Title");
 
 		Role.removePermissionPG(
 			permissionDefinitionKey = "CONTENT_PERMISSIONS_PERMISSIONS_CHECKBOX",
@@ -1684,7 +1684,7 @@ definition {
 
 		Navigator.gotoPage(pageName = "Blogs Page");
 
-		BlogsNavigator.gotoBlogsEntryPermissionsPG();
+		BlogsNavigator.gotoBlogsEntryPermissionsPG(entryTitle = "Blogs Entry Title");
 
 		Role.definePermissionPG(
 			permissionDefinitionKey = "CONTENT_PERMISSIONS_PERMISSIONS_CHECKBOX",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/PGBlogs.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/PGBlogs.testcase
@@ -1540,7 +1540,7 @@ definition {
 
 		Navigator.gotoPage(pageName = "Blogs Page");
 
-		BlogsNavigator.gotoBlogsEntryPermissionsPG();
+		BlogsNavigator.gotoBlogsEntryPermissionsPG(entryTitle = "Blogs Entry Title");
 
 		Role.removePermissionPG(
 			entryTitle = "Blogs Entry Title",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/PGBlogs.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/PGBlogs.testcase
@@ -1866,7 +1866,10 @@ definition {
 
 		Navigator.gotoPage(pageName = "Blogs Page");
 
-		BlogsEntry.removeViewPermissionsPG(roleTitle = "Guest");
+		BlogsEntry.removeViewPermissionsPG(
+			entryTitle = "Blogs Entry2 Title",
+			roleTitle = "Guest"
+		);
 
 		User.logoutPG();
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/StagingBlogs.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/StagingBlogs.testcase
@@ -194,10 +194,7 @@ definition {
 
 		LexiconEntry.changeDisplayStyle(displayStyle = "cards");
 
-		AssertElementPresent(
-			locator1 = "Blogs#ICON_VIEW_ENTRY_TITLE",
-			key_entryTitle = "Blogs Entry Title"
-		);
+		Blogs.viewEntryPresent(entryTitle = "Blogs Entry Title");
 
 		Navigator.gotoStagedSitePage(
 			pageName = "Staging Blogs Page",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/assetsharing/DMSharing.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/assetsharing/DMSharing.testcase
@@ -82,7 +82,10 @@ definition {
 
 		DMNavigator.gotoShare(dmDocumentTitle = "DM Document Title");
 
-		DMDocument.sharePG(userEmailAddress = "userea@liferay.com");
+		DMDocument.sharePG(
+			userEmailAddress = "userea@liferay.com",
+			userName = "userfn userln"
+		);
 
 		User.logoutPG();
 
@@ -166,7 +169,10 @@ definition {
 
 		DMNavigator.gotoShare(dmDocumentTitle = "DM Document Title");
 
-		DMDocument.sharePG(userEmailAddress = "userea2@liferay.com");
+		DMDocument.sharePG(
+			userEmailAddress = "userea2@liferay.com",
+			userName = "userfn2 userln2"
+		);
 
 		User.logoutPG();
 
@@ -176,7 +182,10 @@ definition {
 
 		DMNavigator.gotoShare(dmDocumentTitle = "DM Document Title");
 
-		DMDocument.sharePG(userEmailAddress = "userea2@liferay.com");
+		DMDocument.sharePG(
+			userEmailAddress = "userea2@liferay.com",
+			userName = "userfn2 userln2"
+		);
 
 		User.logoutPG();
 
@@ -231,7 +240,10 @@ definition {
 
 		DMNavigator.gotoShare(dmDocumentTitle = "Document_1.jpeg");
 
-		DMDocument.sharePG(userEmailAddress = "userea@liferay.com");
+		DMDocument.sharePG(
+			userEmailAddress = "userea@liferay.com",
+			userName = "userfn userln"
+		);
 
 		User.logoutPG();
 
@@ -332,7 +344,10 @@ definition {
 
 		DMNavigator.gotoShare(dmDocumentTitle = "DM Document Title");
 
-		DMDocument.sharePG(userEmailAddress = PropsUtil.get("email.address.3"));
+		DMDocument.sharePG(
+			userEmailAddress = PropsUtil.get("email.address.3"),
+			userName = "userfn1 userln1"
+		);
 
 		User.logoutPG();
 
@@ -375,7 +390,10 @@ definition {
 
 		DMNavigator.gotoShare(dmDocumentTitle = "DM Document Title");
 
-		DMDocument.sharePG(userEmailAddress = "userea@liferay.com");
+		DMDocument.sharePG(
+			userEmailAddress = "userea@liferay.com",
+			userName = "userfn userln"
+		);
 
 		User.logoutPG();
 
@@ -409,7 +427,10 @@ definition {
 
 		DMNavigator.gotoShare(dmDocumentTitle = "DM Document Title");
 
-		DMDocument.sharePG(userEmailAddress = "userea@liferay.com");
+		DMDocument.sharePG(
+			userEmailAddress = "userea@liferay.com",
+			userName = "userfn userln"
+		);
 
 		User.logoutPG();
 
@@ -495,13 +516,19 @@ definition {
 
 		DMNavigator.gotoShare(dmDocumentTitle = "Document_1.jpeg");
 
-		DMDocument.sharePG(userEmailAddress = "userea@liferay.com");
+		DMDocument.sharePG(
+			userEmailAddress = "userea@liferay.com",
+			userName = "userfn userln"
+		);
 
 		Navigator.gotoPage(pageName = "Documents and Media Page");
 
 		DMNavigator.gotoShare(dmDocumentTitle = "Document_2.docx");
 
-		DMDocument.sharePG(userEmailAddress = "userea@liferay.com");
+		DMDocument.sharePG(
+			userEmailAddress = "userea@liferay.com",
+			userName = "userfn userln"
+		);
 
 		User.logoutPG();
 
@@ -553,7 +580,8 @@ definition {
 
 		DMDocument.sharePG(
 			shareable = "true",
-			userEmailAddress = "userea@liferay.com"
+			userEmailAddress = "userea@liferay.com",
+			userName = "userfn userln"
 		);
 
 		User.logoutPG();
@@ -572,7 +600,8 @@ definition {
 
 		DMDocument.sharePG(
 			shareable = "true",
-			userEmailAddress = "userea2@liferay.com"
+			userEmailAddress = "userea2@liferay.com",
+			userName = "userfn2 userln2"
 		);
 
 		User.logoutPG();
@@ -619,7 +648,19 @@ definition {
 
 		DMNavigator.gotoShare(dmDocumentTitle = "DM Document Title");
 
-		DMDocument.sharePG(userEmailAddress = "userea@liferay.com,userea2@liferay.com");
+		DMDocument.sharePG(
+			userEmailAddress = "userea@liferay.com",
+			userName = "userfn userln"
+		);
+
+		Navigator.gotoPage(pageName = "Documents and Media Page");
+
+		DMNavigator.gotoShare(dmDocumentTitle = "DM Document Title");
+
+		DMDocument.sharePG(
+			userEmailAddress = "userea2@liferay.com",
+			userName = "userfn2 userln2"
+		);
 
 		Navigator.gotoPage(pageName = "Documents and Media Page");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/workflow/WorkflowMyWorkflowTasks.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/workflow/WorkflowMyWorkflowTasks.testcase
@@ -633,7 +633,7 @@ definition {
 
 		var key_entryTitle = "Blogs Entry Title";
 
-		AssertElementPresent(locator1 = "Blogs#ICON_VIEW_ENTRY_TITLE");
+		Blogs.viewEntryPresent(entryTitle = "Blogs Entry Title");
 
 		AssertTextEquals(locator1 = "Blogs#ICON_VIEW_ENTRY_STATUS", value1 = "Pending");
 


### PR DESCRIPTION
Hi Tina,

This pull removes two methods in AlloyServiceInvoker since these two methods got deprecated since 6.2. We just keep SF the comments so it looks like "deprecated as 7.1.x" now.

Deprecated method 
       public void invoke(Method method) 
in BaseAlloyControllerImpl is not touched because it's deprecated since 7.1

All deprecated methods in AlloyMockUtil are not touched since all these methods in corresponding interfaces are deprecated as well.

Thanks
Lance