### PR TITLE
[TS] LPS-92726 - Upgrade jgroups.jar library from 3.6.4.Final to 3.6.16.Final version

### DIFF
--- a/modules/apps/portal/portal-cluster-multiple/build.gradle
+++ b/modules/apps/portal/portal-cluster-multiple/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-	compileInclude group: "org.jgroups", name: "jgroups", version: "3.6.4.Final"
+	compileInclude group: "org.jgroups", name: "jgroups", version: "3.6.16.Final"
 
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-92726

Hi @tinatian ,

The goal of this update is to include a bug fix in JGroups to resolve a slow cluster startup time.

For additional information, please see my comment on the ticket: [LPS-92726#comment-1750301](https://issues.liferay.com/browse/LPS-92726?focusedCommentId=1750301#comment-1750301)
Thanks!