### PR TITLE
LPS-87074 Unscheduling a job from the master node causes NPE on slave rejoin

### DIFF
--- a/modules/apps/portal-scheduler/portal-scheduler-multiple/src/main/java/com/liferay/portal/scheduler/multiple/internal/ClusterSchedulerEngine.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-multiple/src/main/java/com/liferay/portal/scheduler/multiple/internal/ClusterSchedulerEngine.java
@@ -891,7 +891,7 @@ public class ClusterSchedulerEngine
 					if (oldTrigger == null) {
 						if (_log.isInfoEnabled()) {
 							_log.info(
-								"Unable to scedule memory clustered job " +
+								"Unable to schedule memory clustered job " +
 									schedulerResponse);
 						}
 

--- a/modules/apps/portal-scheduler/portal-scheduler-multiple/src/main/java/com/liferay/portal/scheduler/multiple/internal/ClusterSchedulerEngine.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-multiple/src/main/java/com/liferay/portal/scheduler/multiple/internal/ClusterSchedulerEngine.java
@@ -886,6 +886,16 @@ public class ClusterSchedulerEngine
 					SchedulerResponse schedulerResponse =
 						memoryClusteredJob.getKey();
 
+					if (schedulerResponse.getTrigger() == null) {
+						if (_log.isInfoEnabled()) {
+							_log.info(
+								"Unable to scedule memory clustered job " +
+									schedulerResponse);
+						}
+
+						continue;
+					}
+
 					Trigger oldTrigger = schedulerResponse.getTrigger();
 
 					Date startDate = oldTrigger.getFireDateAfter(new Date());

--- a/modules/apps/portal-scheduler/portal-scheduler-multiple/src/main/java/com/liferay/portal/scheduler/multiple/internal/ClusterSchedulerEngine.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-multiple/src/main/java/com/liferay/portal/scheduler/multiple/internal/ClusterSchedulerEngine.java
@@ -886,7 +886,9 @@ public class ClusterSchedulerEngine
 					SchedulerResponse schedulerResponse =
 						memoryClusteredJob.getKey();
 
-					if (schedulerResponse.getTrigger() == null) {
+					Trigger oldTrigger = schedulerResponse.getTrigger();
+
+					if (oldTrigger == null) {
 						if (_log.isInfoEnabled()) {
 							_log.info(
 								"Unable to scedule memory clustered job " +
@@ -895,8 +897,6 @@ public class ClusterSchedulerEngine
 
 						continue;
 					}
-
-					Trigger oldTrigger = schedulerResponse.getTrigger();
 
 					Date startDate = oldTrigger.getFireDateAfter(new Date());
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-87074

Hi @tinatian ,

Here are some additional notes from @istvansajtos
>The issue is that slave node throws NullPointerException if there is an unscheduled job on master. This is very similar to LPS-77562 and I used the same approach to fix it.

Please let us know if you have any questions.
Thanks!