### PR TITLE
LPS-92576 Configure default JAX-B implementation to the one provided in jaxb-impl.jar

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PropsUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsUtil.java
@@ -365,6 +365,10 @@ public class PropsUtil {
 		SystemProperties.set(
 			PropsKeys.DEFAULT_LIFERAY_HOME, _getDefaultLiferayHome());
 
+		SystemProperties.set(
+			PropsKeys.JAVAX_XML_BIND_JAXBCONTEXT_FACTORY,
+			"com.sun.xml.bind.v2.ContextFactory");
+		
 		// Global shared lib directory
 
 		String globalSharedLibDir = _getLibDir(Servlet.class);
@@ -435,6 +439,7 @@ public class PropsUtil {
 
 		SystemProperties.set(
 			"ehcache.disk.store.dir", liferayHome + "/data/ehcache");
+
 
 		if (GetterUtil.getBoolean(
 				SystemProperties.get("company-id-properties"))) {

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1623,6 +1623,9 @@ public interface PropsKeys {
 	public static final String JAVASCRIPT_SINGLE_PAGE_APPLICATION_TIMEOUT =
 		"javascript.single.page.application.timeout";
 
+	public static final String JAVAX_XML_BIND_JAXBCONTEXT_FACTORY =
+		"javax.xml.bind.JAXBContextFactory";
+
 	public static final String JDBC_DEFAULT_DRIVER_CLASS_NAME =
 		"jdbc.default.driverClassName";
 


### PR DESCRIPTION
Hi @tinatian, 
as discussed in https://issues.liferay.com/browse/LPS-92576 this is the property that we can set so the provided jaxb-api finds the provided jaxb-impl. 
Since we are boot delegating `com.sun.xml` packages and providing the implementation in jaxb-impl in the web application class loader we don't seem to need anything else. 
I don't know if this is the correct way for setting system properties or if we have some better way. I guess we would do this configurable but it should be still be possible to choose a different implementation using the TCCL to find another implementation. 
This is only an example, so I understand this would not be merged as it is. 

Thx for looking into this. 

Carlos. 