### PR TITLE
[TS] LPS-110895

### DIFF
--- a/modules/apps/portal-store/portal-store-file-system/src/main/java/com/liferay/portal/store/file/system/AdvancedFileSystemStore.java
+++ b/modules/apps/portal-store/portal-store-file-system/src/main/java/com/liferay/portal/store/file/system/AdvancedFileSystemStore.java
@@ -46,6 +46,26 @@ public class AdvancedFileSystemStore extends FileSystemStore {
 		super(advancedFileSystemStoreConfiguration);
 	}
 
+	@Override
+	public String[] getFileVersions(
+		long companyId, long repositoryId, String fileName) {
+
+		String[] versions = super.getFileVersions(
+			companyId, repositoryId, fileName);
+
+		for (int i = 0; i < versions.length; i++) {
+			int x = versions[i].lastIndexOf(CharPool.UNDERLINE);
+
+			if (x > -1) {
+				int y = versions[i].lastIndexOf(CharPool.PERIOD);
+
+				versions[i] = versions[i].substring(x + 1, y);
+			}
+		}
+
+		return versions;
+	}
+
 	protected void buildPath(StringBundler sb, String fileNameFragment) {
 		int fileNameFragmentLength = fileNameFragment.length();
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPP-36834
https://issues.liferay.com/browse/LPS-110895

From @wanderlast:

> In LPS-110213, an implementation of the file moving feature was re-added to the portal. This involves a call to retrieve all file versions, retrieving each file based on the version labels retrieved and adding them to their new location. The old files are subsequently deleted.
> 
> While this works for Simple File Store (SFS), Advanced File System Store (AFS) is currently broken. This is due to the call in getFileVersions(long, long, String). Previously, the call used the same method in FileSystemStore since no overriding method implementation was made in AdvancedFileSystemStore. However, this method of retrieving file versions is incorrect for AFS. In SFS, the versions are stored as the file name (e.g. "1.0") so simply retrieving the file name as a version label is valid. However, the file naming scheme for AFS is much more complex (e.g. "1_1.0.afsh") and using that as a version label results in a file name of "1_1_1.0.afsh.afsh" since the full file name is incorrectly used for the version label. This therefore causes a failure to retrieve any file since the file names returned are all incorrect.
> 
> The fix is implementing getFileVersions(long, long, String)  in AdvancedFileSystemStore. The implementation iterates through all of the fileNames retrieved by FileSystemStore's implementation and then removes the non-version related information.
> 
> Please let me know if you have any questions or concerns. Thanks!