### PR TITLE
LPS-111757 Avoid wrong paths in Windows beginning with /C:/path... that cause Elasticsearch Sidecar to not start correctly

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/util/ClassUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/ClassUtil.java
@@ -189,6 +189,12 @@ public class ClassUtil {
 			parentPath = parentPath.substring(6);
 		}
 
+		if ((parentPath.charAt(0) == CharPool.SLASH) &&
+			(parentPath.charAt(2) == CharPool.COLON)) {
+
+			parentPath = parentPath.substring(1);
+		}
+
 		return parentPath;
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/ClassUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/ClassUtil.java
@@ -134,24 +134,7 @@ public class ClassUtil {
 		return clazz.getName();
 	}
 
-	public static String getParentPath(
-		ClassLoader classLoader, String className) {
-
-		if (_log.isDebugEnabled()) {
-			_log.debug("Class name " + className);
-		}
-
-		if (!className.endsWith(_CLASS_EXTENSION)) {
-			className += _CLASS_EXTENSION;
-		}
-
-		className = StringUtil.replace(
-			className, CharPool.PERIOD, CharPool.SLASH);
-
-		className = StringUtil.replace(className, "/class", _CLASS_EXTENSION);
-
-		URL url = classLoader.getResource(className);
-
+	public static String getNormalizedParentPath(URL url, String resourceName) {
 		String path = null;
 
 		try {
@@ -194,7 +177,7 @@ public class ClassUtil {
 			_log.debug("Path " + path);
 		}
 
-		int pos = path.indexOf(className);
+		int pos = path.indexOf(resourceName);
 
 		String parentPath = path.substring(0, pos);
 
@@ -205,6 +188,29 @@ public class ClassUtil {
 		if (parentPath.startsWith("file:/")) {
 			parentPath = parentPath.substring(6);
 		}
+
+		return parentPath;
+	}
+
+	public static String getParentPath(
+		ClassLoader classLoader, String className) {
+
+		if (_log.isDebugEnabled()) {
+			_log.debug("Class name " + className);
+		}
+
+		if (!className.endsWith(_CLASS_EXTENSION)) {
+			className += _CLASS_EXTENSION;
+		}
+
+		className = StringUtil.replace(
+			className, CharPool.PERIOD, CharPool.SLASH);
+
+		className = StringUtil.replace(className, "/class", _CLASS_EXTENSION);
+
+		URL url = classLoader.getResource(className);
+
+		String parentPath = getNormalizedParentPath(url, className);
 
 		if (_log.isDebugEnabled()) {
 			_log.debug("Parent path " + parentPath);

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/ClassUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/ClassUtilTest.java
@@ -18,6 +18,9 @@ import com.liferay.petra.string.StringPool;
 
 import java.io.StringReader;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -52,6 +55,18 @@ public class ClassUtilTest {
 			"AnnotationClass.Annotation", "AnnotationClass", "A", "B");
 		testGetClassesFromAnnotation(
 			"AnnotationClass.Annotation", "AnnotationClass", "A", "B", "C");
+	}
+
+	@Test
+	public void testGetNormalizeParentPath() throws Exception {
+		testGetNormalizedParentPath(
+			"jar:file:/opt/liferay/tomcat/lib/servlet-api.jar" +
+				"!/javax/servlet/Servlet.class",
+			"/opt/liferay/tomcat/lib/servlet-api.jar!/");
+		testGetNormalizedParentPath(
+			"jar:file:/C:/Liferay/tomcat/lib/servlet-api.jar" +
+				"!/javax/servlet/Servlet.class",
+			"C:/Liferay/tomcat/lib/servlet-api.jar!/");
 	}
 
 	protected void testGetClassesFromAnnotation(
@@ -90,6 +105,17 @@ public class ClassUtilTest {
 		Collections.addAll(expectedClassNames, arrayParameterClassNames);
 
 		Assert.assertEquals(expectedClassNames, actualClassNames);
+	}
+
+	protected void testGetNormalizedParentPath(String url, String expectedPath)
+		throws MalformedURLException {
+
+		String resourceName = url.substring(url.indexOf("!/") + 2);
+
+		String normalizedPath = ClassUtil.getNormalizedParentPath(
+			new URL(url), resourceName);
+
+		Assert.assertEquals(expectedPath, normalizedPath);
 	}
 
 }


### PR DESCRIPTION
"Illegal char <:> at index 2: /C:/path..." error if you run `Paths.get(PortalUtil.getGlobalLibDir())` java code in a Windows machine.

This can be reproduced for example if you activate Elasticsearch Sidecar in a Windows machine.
An **"Illegal char <:> at index 2: /C:/path..."** error is produced in this line of Sidecar.java
* https://github.com/liferay/liferay-portal/blob/4df4c092a3f1158a4d554b9efd60d8655069d80f/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/sidecar/Sidecar.java#L321

Instead of fixing the problem in Sidecar code, I think it is better to fix the problem in **PropsUtil._getLibDir** to store correct values in both `liferay.lib.global.dir` and `liferay.lib.global.shared.dir` environment variables.