### PR TITLE
[TS] LPS-115438

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -236,7 +236,7 @@ public class ResourceActionsImpl implements ResourceActions {
 			value = key;
 		}
 
-		return value;
+		return LanguageResources.fixValue(value);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -52,6 +52,7 @@ import com.liferay.portal.kernel.xml.DocumentException;
 import com.liferay.portal.kernel.xml.DocumentType;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.UnsecureSAXReaderUtil;
+import com.liferay.portal.language.LanguageResources;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.registry.collections.ServiceTrackerCollections;
 import com.liferay.registry.collections.ServiceTrackerList;
@@ -252,7 +253,7 @@ public class ResourceActionsImpl implements ResourceActions {
 			value = key;
 		}
 
-		return value;
+		return LanguageResources.fixValue(value);
 	}
 
 	@Override


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-115438

From @wanderlast:

> When using a beta or partially supported language/locale in Liferay some language keys may still be displayed with the words "Automatic Copy" or "Automatic Translation" appended to them. When we fail to find a key-value match in our given locale (which is likely when it comes to our beta languages since we don't have full language.properties coverage for them), we check the aggregate bundle. However, after retrieving from the aggregate bundle, we do not do the same processing (e.g. running fixValue()) that we do when retrieving using LanguageUtil. This adds that missing check to ensure we properly strip the automatically added notations from the displayed value.