### PR TITLE
[TS] LPS-115438

### DIFF
--- a/modules/apps/portal-security/portal-security-permission-test/src/testIntegration/java/com/liferay/portal/security/permission/test/ResourceActionsTest.java
+++ b/modules/apps/portal-security/portal-security-permission-test/src/testIntegration/java/com/liferay/portal/security/permission/test/ResourceActionsTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.permission.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Lianne Louie
+ */
+@RunWith(Arquillian.class)
+public class ResourceActionsTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testGetModelResourceFromUnsupportedLanguage() {
+		String actual = ResourceActionsUtil.getModelResource(
+			_unsupportedLocale, _CLASS_NAME);
+
+		String expected = ResourceActionsUtil.getModelResource(
+			_usLocale, _CLASS_NAME);
+
+		Assert.assertEquals(expected, actual);
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.dynamic.data.lists.model.DDLRecord";
+
+	private final Locale _unsupportedLocale = new Locale("en", "GB");
+	private final Locale _usLocale = new Locale("en", "US");
+
+}

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -236,7 +236,7 @@ public class ResourceActionsImpl implements ResourceActions {
 			value = key;
 		}
 
-		return value;
+		return LanguageResources.fixValue(value);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java
@@ -52,6 +52,7 @@ import com.liferay.portal.kernel.xml.DocumentException;
 import com.liferay.portal.kernel.xml.DocumentType;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.UnsecureSAXReaderUtil;
+import com.liferay.portal.language.LanguageResources;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.registry.collections.ServiceTrackerCollections;
 import com.liferay.registry.collections.ServiceTrackerList;
@@ -252,7 +253,7 @@ public class ResourceActionsImpl implements ResourceActions {
 			value = key;
 		}
 
-		return value;
+		return LanguageResources.fixValue(value);
 	}
 
 	@Override


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-115438

Includes test requested on https://github.com/tinatian/liferay-portal/pull/1866
From @wanderlast 

> When using a beta or partially supported language/locale in Liferay some language keys may still be displayed with the words "Automatic Copy" or "Automatic Translation" appended to them. When we fail to find a key-value match in our given locale (which is likely when it comes to our beta languages since we don't have full language.properties coverage for them), we check the aggregate bundle. However, after retrieving from the aggregate bundle, we do not do the same processing (e.g. running fixValue()) that we do when retrieving using LanguageUtil. This adds that missing check to ensure we properly strip the automatically added notations from the displayed value.
