### PR TITLE
[TS] LPS-119524 

### DIFF
--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_references.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_references.ftl
@@ -5,6 +5,11 @@
 	)
 	public void setConfiguration(Configuration configuration) {
 		<#if serviceBuilder.isVersionLTE_7_2_0()>
+			<#if !entity.isCacheEnabled()>
+				entityCacheEnabled = false;
+				finderCacheEnabled = false;
+			</#if>
+
 			super.setConfiguration(configuration);
 
 			<#if persistence>

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/BasePersistenceImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/BasePersistenceImpl.java
@@ -907,13 +907,13 @@ public class BasePersistenceImpl<T extends BaseModel<T>>
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
 	 */
 	@Deprecated
-	protected boolean entityCacheEnabled;
+	protected boolean entityCacheEnabled = true;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
 	 */
 	@Deprecated
-	protected boolean finderCacheEnabled;
+	protected boolean finderCacheEnabled = true;
 
 	private static Type _getType(Expression<?> expression) {
 		if (expression instanceof Column) {

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/BasePersistenceImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/BasePersistenceImpl.java
@@ -613,11 +613,11 @@ public class BasePersistenceImpl<T extends BaseModel<T>>
 		entityCacheEnabled = GetterUtil.getBoolean(
 			configuration.get(
 				"value.object.entity.cache.enabled.".concat(modelClassName)),
-			true);
+			entityCacheEnabled);
 		finderCacheEnabled = GetterUtil.getBoolean(
 			configuration.get(
 				"value.object.finder.cache.enabled.".concat(modelClassName)),
-			true);
+			finderCacheEnabled);
 	}
 
 	@Override


### PR DESCRIPTION
Hi @tinatian ,

I noticed you've been working on Service Builder changes, can you help review this related SB fix?

**Issue** 
The **cache-enabled** attribute is broken in 72x when using OSGI DS for the dependency injection.

Note: This issue technically doesn't apply to master (since we no longer allow disabling Entity/Finder caches). However, the fix involves Service Builder and it would also keep things consistent if we commit this to master first, before backporting to 72x.

**Fix**
This approach was suggested by Preston, he helped take a quick look when I mentioned this issue during the stand-up meeting. From what I can tell, this resolves the issue and should respect the current logic for both OSGI DS and Spring.

Please let me know if you have any questions.
Thanks!