### PR TITLE
LPS-122988 Always try to check resource actions during startup

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/StartupAction.java
+++ b/portal-impl/src/com/liferay/portal/events/StartupAction.java
@@ -151,9 +151,9 @@ public class StartupAction extends SimpleAction {
 			_log.debug("Check resource actions");
 		}
 
-		if (StartupHelperUtil.isDBNew()) {
-			StartupHelperUtil.initResourceActions();
+		StartupHelperUtil.initResourceActions();
 
+		if (StartupHelperUtil.isDBNew()) {
 			ResourceActionLocalServiceUtil.checkResourceActions();
 
 			DBUpgrader.verify();

--- a/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
+++ b/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java
@@ -47,13 +47,11 @@ import com.liferay.portal.kernel.portlet.PortletConfigFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletInstanceFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
-import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutTemplateLocalServiceUtil;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
-import com.liferay.portal.kernel.service.ResourceActionLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.servlet.InactiveRequestHandler;
 import com.liferay.portal.kernel.servlet.PortalSessionThreadLocal;
@@ -404,13 +402,6 @@ public class MainServlet extends HttpServlet {
 
 		if (_log.isDebugEnabled()) {
 			_log.debug("Initialize resource actions");
-		}
-
-		try {
-			_initResourceActions(portlets);
-		}
-		catch (Exception exception) {
-			_log.error(exception, exception);
 		}
 
 		try {
@@ -975,29 +966,6 @@ public class MainServlet extends HttpServlet {
 		servletContext.setAttribute(WebKeys.PLUGIN_PORTLETS, portlets);
 
 		return portlets;
-	}
-
-	private void _initResourceActions(List<Portlet> portlets) throws Exception {
-		for (Portlet portlet : portlets) {
-			List<String> portletActions =
-				ResourceActionsUtil.getPortletResourceActions(
-					portlet.getPortletId());
-
-			ResourceActionLocalServiceUtil.checkResourceActions(
-				portlet.getPortletId(), portletActions);
-
-			List<String> modelNames =
-				ResourceActionsUtil.getPortletModelResources(
-					portlet.getPortletId());
-
-			for (String modelName : modelNames) {
-				List<String> modelActions =
-					ResourceActionsUtil.getModelResourceActions(modelName);
-
-				ResourceActionLocalServiceUtil.checkResourceActions(
-					modelName, modelActions);
-			}
-		}
 	}
 
 	private void _initServlet() {


### PR DESCRIPTION
@tinatian

Lily has verified that this change works with our generated SQL.

For startup performance:

Version|Thread/Create Count|Open File Number|Open Count of PreparedStatement|The Open Count of SQL|Warmup time(ms)|Average Time(ms)
-------|-------------------|----------------|-------------------------------|---------------------|---------------|---------------- 
99d5e0e3db6567853292ce00ec0b44dab79f7fec|111|132|254|389|50502|22910.6
This pull|111|132|294|403|49347|22973.6

There are prepared statement & SQL increase, but the final result is only 63ms slower with the pull. I think it's acceptable.