### PR TITLE
LPS-127445 Revert LPS-108614 (37147c5b9a6207a642019dda98338a1298f7a17…

### DIFF
--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/model_impl.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/model_impl.ftl
@@ -899,20 +899,26 @@ public class ${entity.name}ModelImpl extends BaseModelImpl<${entity.name}> imple
 				if (_columnOriginalValues == Collections.EMPTY_MAP) {
 					_setColumnOriginalValues();
 				}
-			<#elseif entityColumn.isFinderPath() || (validator.isNotNull(parentPKColumn) && (parentPKColumn.name == entityColumn.name))>
-				<#if columnBitmaskEnabled>
-					_columnBitmask |= ${entityColumn.name?upper_case}_COLUMN_BITMASK;
+			<#else>
+				<#if entityColumn.isOrderColumn() && columnBitmaskEnabled>
+					_columnBitmask = -1L;
 				</#if>
 
-				<#if entityColumn.isPrimitiveType()>
-					if (!_setOriginal${entityColumn.methodName}) {
+				<#if entityColumn.isFinderPath() || (validator.isNotNull(parentPKColumn) && (parentPKColumn.name == entityColumn.name))>
+					<#if !entityColumn.isOrderColumn() && columnBitmaskEnabled>
+						_columnBitmask |= ${entityColumn.name?upper_case}_COLUMN_BITMASK;
+					</#if>
+
+					<#if entityColumn.isPrimitiveType()>
+						if (!_setOriginal${entityColumn.methodName}) {
 						_setOriginal${entityColumn.methodName} = true;
-				<#else>
-					if (_original${entityColumn.methodName} == null) {
-				</#if>
+					<#else>
+						if (_original${entityColumn.methodName} == null) {
+					</#if>
 
 					_original${entityColumn.methodName} = _${entityColumn.name};
-				}
+					}
+				</#if>
 			</#if>
 
 			<#if entity.versionEntity?? && stringUtil.equals(entityColumn.name, "headId")>


### PR DESCRIPTION
…e) manually as we need it for the order columns which are not finder path columns. To fix this issue in the root, we need to generate column bitmask related stuff for order column like what we did for finder path column, but this will cause new API method generated and major version bump, considering this issue only affected 7.2 and earlier, I prefer to revert rather than fixing it in the root.