### PR TITLE
LPS-128186 Do not export jackson from core, required-dependencies had already deployed the jar as module. This may cause a "uses" constraint violation which is discovered when upgrade Log4J.

### DIFF
--- a/modules/core/portal-bootstrap/system.packages.extra.bnd
+++ b/modules/core/portal-bootstrap/system.packages.extra.bnd
@@ -347,7 +347,6 @@ Provide-Capability:\
 	@../../../lib/portal/dom4j.jar,\
 	@../../../lib/portal/hibernate-commons-annotations.jar,\
 	@../../../lib/portal/hibernate-core.jar,\
-	@../../../lib/portal/jackson-databind.jar,\
 	@../../../lib/portal/jaxen.jar,\
 	@../../../lib/portal/jaxrpc.jar,\
 	@../../../lib/portal/jdom.jar!/org/**,\


### PR DESCRIPTION
@tinatian This is extracted from the log4j 2 upgrade pull.﻿
