### PR TITLE
[Log4J] LPS-127261 packageinfo

### DIFF
--- a/modules/apps/petra/petra-log4j/src/main/resources/com/liferay/petra/log4j/packageinfo
+++ b/modules/apps/petra/petra-log4j/src/main/resources/com/liferay/petra/log4j/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0


### PR DESCRIPTION
@tinatian LPS-127261 added a new method to Log4JUtil but didn't update the packageinfo. This causes CI failures, like https://issues.liferay.com/browse/LPS-127485