### PR TITLE
LPS-129902 DB Partition: fix errors on startup

### DIFF
--- a/modules/apps/commerce/commerce-price-list-service/build.gradle
+++ b/modules/apps/commerce/commerce-price-list-service/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	compileOnly project(":apps:portal:portal-spring-extender-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")
+	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/internal/verify/CommercePriceListServiceVerifyProcess.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/internal/verify/CommercePriceListServiceVerifyProcess.java
@@ -44,18 +44,18 @@ public class CommercePriceListServiceVerifyProcess extends VerifyProcess {
 
 	protected void verifyBasePriceLists() throws Exception {
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
-			List<Company> companies = _companyLocalService.getCompanies();
+			_companyLocalService.forEachCompanyId(
+				companyId -> {
+					List<CommerceCatalog> commerceCatalogs =
+						_commerceCatalogLocalService.getCommerceCatalogs(
+							companyId, true);
 
-			for (Company company : companies) {
-				List<CommerceCatalog> commerceCatalogs =
-					_commerceCatalogLocalService.getCommerceCatalogs(
-						company.getCompanyId(), true);
-
-				for (CommerceCatalog commerceCatalog : commerceCatalogs) {
-					_commerceBasePriceListHelper.
-						addCatalogBaseCommercePriceList(commerceCatalog);
+					for (CommerceCatalog commerceCatalog : commerceCatalogs) {
+						_commerceBasePriceListHelper.
+							addCatalogBaseCommercePriceList(commerceCatalog);
+					}
 				}
-			}
+			);
 		}
 	}
 

--- a/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/internal/verify/CommercePriceListServiceVerifyProcess.java
+++ b/modules/apps/commerce/commerce-price-list-service/src/main/java/com/liferay/commerce/price/list/internal/verify/CommercePriceListServiceVerifyProcess.java
@@ -17,7 +17,6 @@ package com.liferay.commerce.price.list.internal.verify;
 import com.liferay.commerce.price.list.internal.helper.CommerceBasePriceListHelper;
 import com.liferay.commerce.product.model.CommerceCatalog;
 import com.liferay.commerce.product.service.CommerceCatalogLocalService;
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.verify.VerifyProcess;
@@ -54,8 +53,7 @@ public class CommercePriceListServiceVerifyProcess extends VerifyProcess {
 						_commerceBasePriceListHelper.
 							addCatalogBaseCommercePriceList(commerceCatalog);
 					}
-				}
-			);
+				});
 		}
 	}
 

--- a/modules/apps/data-engine/data-engine-service/src/main/java/com/liferay/data/engine/internal/petra/executor/DataEngineNativeObjectPortalExecutor.java
+++ b/modules/apps/data-engine/data-engine-service/src/main/java/com/liferay/data/engine/internal/petra/executor/DataEngineNativeObjectPortalExecutor.java
@@ -329,10 +329,8 @@ public class DataEngineNativeObjectPortalExecutor {
 			throws Exception {
 
 			_companyLocalService.forEachCompanyId(
-				companyId ->
-					createDataEngineNativeObject(
-						companyId, dataEngineNativeObject)
-			);
+				companyId -> createDataEngineNativeObject(
+					companyId, dataEngineNativeObject));
 		}
 
 		private String _getFieldType(String customType, int sqlType) {

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -327,8 +327,12 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 		clearCache();
 
 		companyLocalService.forEachCompanyId(
-			companyId -> _deployRemotePortlet(
-				portlet, categoryNames, companyId));
+			companyId -> {
+				_deployRemotePortlet(
+					portlet, categoryNames, companyId);
+
+				portletPersistence.flush();
+			});
 
 		return portlet;
 	}

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -328,8 +328,7 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 
 		companyLocalService.forEachCompanyId(
 			companyId -> {
-				_deployRemotePortlet(
-					portlet, categoryNames, companyId);
+				_deployRemotePortlet(portlet, categoryNames, companyId);
 
 				portletPersistence.flush();
 			});


### PR DESCRIPTION
Hi @tinatian,

This solves the issues with DB Partition on startup.

This is the second issue I found regarding Hibernate and its buffer for the transactions. For that reason I had to do a flush here:
https://github.com/tinatian/liferay-portal/pull/2206/files#diff-b616dab9f6e1810a2fa02b1f41c0783a708546810989fc34973a5c6491728fe5R333

Before removing the companyId from the CompanyThreadLocal. Otherwise the companyId is wrong when executing the statement:
https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/db/partition/DBPartitionUtil.java#L265

For the same reason I had to do this in another ticket:
liferay@fc42860

To solve in a more generic way maybe we can do a flush anytime before restoring the old companyId value in the CompanyThreadLocal but I am worried about the performance. But maybe this is something specific due to:
https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/service/impl/ResourcePermissionLocalServiceImpl.java#L2001

And we don't need to do flush for other cases.

Let me know what you think about this.

Thanks.