### PR TITLE
[Bug fix] LPS-130946

### DIFF
--- a/portal-impl/src/com/liferay/portal/jsonwebservice/JSONWebServiceActionImpl.java
+++ b/portal-impl/src/com/liferay/portal/jsonwebservice/JSONWebServiceActionImpl.java
@@ -682,8 +682,12 @@ public class JSONWebServiceActionImpl implements JSONWebServiceAction {
 
 		private static final DateTimeFormatter _dateTimeFormatter =
 			new DateTimeFormatterBuilder().parseCaseInsensitive(
-			).append(
+			).appendOptional(
 				DateTimeFormatter.ISO_LOCAL_DATE
+			).optionalStart(
+			).appendPattern(
+				"yyyy-M-d"
+			).optionalEnd(
 			).optionalStart(
 			).optionalStart(
 			).appendLiteral(

--- a/portal-impl/src/com/liferay/portal/jsonwebservice/JSONWebServiceActionImpl.java
+++ b/portal-impl/src/com/liferay/portal/jsonwebservice/JSONWebServiceActionImpl.java
@@ -43,9 +43,17 @@ import java.io.IOException;
 import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.TemporalAccessor;
+
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -55,11 +63,14 @@ import java.util.Objects;
 import jodd.bean.BeanCopy;
 import jodd.bean.BeanUtil;
 
+import jodd.time.TimeUtil;
+
 import jodd.typeconverter.TypeConversionException;
 import jodd.typeconverter.TypeConverter;
 import jodd.typeconverter.TypeConverterManager;
 
 import jodd.util.ClassUtil;
+import jodd.util.StringUtil;
 
 /**
  * @author Igor Spasic
@@ -598,6 +609,96 @@ public class JSONWebServiceActionImpl implements JSONWebServiceAction {
 		_jsonWebServiceActionParameters;
 	private final JSONWebServiceNaming _jsonWebServiceNaming;
 
+	private static class DateTypeConverter implements TypeConverter<Date> {
+
+		@Override
+		public Date convert(Object object) {
+			if (object == null) {
+				return null;
+			}
+
+			if (object instanceof Date) {
+				return (Date)object;
+			}
+
+			if (object instanceof Calendar) {
+				Calendar calendar = (Calendar)object;
+
+				return new Date(calendar.getTimeInMillis());
+			}
+
+			if (object instanceof LocalDateTime) {
+				return TimeUtil.toDate((LocalDateTime)object);
+			}
+
+			if (object instanceof LocalDate) {
+				return TimeUtil.toDate((LocalDate)object);
+			}
+
+			if (object instanceof Number) {
+				Number number = (Number)object;
+
+				return new Date(number.longValue());
+			}
+
+			String stringValue = object.toString();
+
+			stringValue = stringValue.trim();
+
+			if (!StringUtil.containsOnlyDigits(stringValue)) {
+				TemporalAccessor temporalAccessor =
+					_dateTimeFormatter.parseBest(
+						stringValue, ZonedDateTime::from, LocalDateTime::from,
+						LocalDate::from);
+
+				if (temporalAccessor instanceof LocalDate) {
+					return TimeUtil.toDate((LocalDate)temporalAccessor);
+				}
+
+				if (temporalAccessor instanceof LocalDateTime) {
+					return TimeUtil.toDate((LocalDateTime)temporalAccessor);
+				}
+
+				if (temporalAccessor instanceof ZonedDateTime) {
+					ZonedDateTime zonedDateTime =
+						(ZonedDateTime)temporalAccessor;
+
+					return Date.from(zonedDateTime.toInstant());
+				}
+
+				throw new TypeConversionException(object);
+			}
+
+			try {
+				long milliseconds = Long.parseLong(stringValue);
+
+				return new Date(milliseconds);
+			}
+			catch (NumberFormatException numberFormatException) {
+				throw new TypeConversionException(
+					object, numberFormatException);
+			}
+		}
+
+		private static final DateTimeFormatter _dateTimeFormatter =
+			new DateTimeFormatterBuilder().parseCaseInsensitive(
+			).append(
+				DateTimeFormatter.ISO_LOCAL_DATE
+			).optionalStart(
+			).optionalStart(
+			).appendLiteral(
+				' '
+			).optionalEnd(
+			).optionalStart(
+			).appendLiteral(
+				'T'
+			).optionalEnd(
+			).appendOptional(
+				DateTimeFormatter.ISO_TIME
+			).toFormatter();
+
+	}
+
 	private static class LocaleTypeConverter implements TypeConverter<Locale> {
 
 		@Override
@@ -631,6 +732,7 @@ public class JSONWebServiceActionImpl implements JSONWebServiceAction {
 		TypeConverterManager typeConverterManager = TypeConverterManager.get();
 
 		typeConverterManager.register(Locale.class, new LocaleTypeConverter());
+		typeConverterManager.register(Date.class, new DateTypeConverter());
 	}
 
 }


### PR DESCRIPTION
@tinatian This is caused by jodd upgrade. The DateConverter in the new jodd-util assumes the date string to be either of ISO_DATE_TIME format or a linux timestamp. But we are sending yyyy-MM-dd or yyyy-M-d (in Poshi). I added logic to build a custom `DateTimeFormatter` to handle this instead of copying the old code from old jodd.

- LPS-130946 DateConverter in jodd 6 uses Java 8 LocalDateTime.parse to parse the date string, which sticks to a strict pattern. Provide a converter to use DateTimeFormatter with optional parts to support multiple formats in string parsing.
- LPS-130946 Old jodd also supports yyyy-M-d as Poshi is using this format
