### PR TITLE
[TS] LPS-135731

### DIFF
--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-tracker/build.gradle
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-tracker/build.gradle
@@ -10,7 +10,10 @@ dependencies {
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-osgi-web:portal-osgi-web-servlet-context-helper-api")
+	compileOnly project(":core:petra:petra-concurrent")
+	compileOnly project(":core:petra:petra-executor")
 	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-reflect")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-tracker/source-formatter-suppressions.xml
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-tracker/source-formatter-suppressions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<suppressions>
+	<checkstyle>
+		<suppress checks="CompanyIterationCheck" files="src/main/java/com/liferay/portal/osgi/web/portlet/tracker/internal/PortletTracker\.java" />
+	</checkstyle>
+</suppressions>

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-tracker/src/main/java/com/liferay/portal/osgi/web/portlet/tracker/internal/PortletTracker.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-tracker/src/main/java/com/liferay/portal/osgi/web/portlet/tracker/internal/PortletTracker.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.ResourceActionsException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.EventDefinition;
 import com.liferay.portal.kernel.model.PortletApp;
@@ -1274,8 +1275,15 @@ public class PortletTracker
 			categoryNames.add("category.undefined");
 		}
 
-		_portletLocalService.deployRemotePortlet(
-			portletModel, ArrayUtil.toStringArray(categoryNames), false);
+		List<Company> companies = _companyLocalService.getCompanies(false);
+
+		_portletLocalService.clearCache();
+
+		for (Company company : companies) {
+			_portletLocalService.deployRemotePortlet(
+				portletModel, ArrayUtil.toStringArray(categoryNames), false,
+				false, new long[] {company.getCompanyId()});
+		}
 	}
 
 	protected Object get(

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 12.0.1
+Bundle-Version: 12.1.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.test.*,\

--- a/portal-kernel/src/com/liferay/portal/kernel/service/PortletLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/PortletLocalService.java
@@ -168,6 +168,11 @@ public interface PortletLocalService
 			Portlet portlet, String[] categoryNames, boolean eagerDestroy)
 		throws PortalException;
 
+	public Portlet deployRemotePortlet(
+			Portlet portlet, String[] categoryNames, boolean eagerDestroy,
+			boolean clearCache, long[] companyIds)
+		throws PortalException;
+
 	@Transactional(enabled = false)
 	public void destroyPortlet(Portlet portlet);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/PortletLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/PortletLocalServiceUtil.java
@@ -183,6 +183,15 @@ public class PortletLocalServiceUtil {
 			portlet, categoryNames, eagerDestroy);
 	}
 
+	public static Portlet deployRemotePortlet(
+			Portlet portlet, String[] categoryNames, boolean eagerDestroy,
+			boolean clearCache, long[] companyIds)
+		throws PortalException {
+
+		return getService().deployRemotePortlet(
+			portlet, categoryNames, eagerDestroy, clearCache, companyIds);
+	}
+
 	public static void destroyPortlet(Portlet portlet) {
 		getService().destroyPortlet(portlet);
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/service/PortletLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/PortletLocalServiceWrapper.java
@@ -203,6 +203,17 @@ public class PortletLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.portal.kernel.model.Portlet deployRemotePortlet(
+			com.liferay.portal.kernel.model.Portlet portlet,
+			java.lang.String[] categoryNames, boolean eagerDestroy,
+			boolean clearCache, long[] companyIds)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _portletLocalService.deployRemotePortlet(
+			portlet, categoryNames, eagerDestroy, clearCache, companyIds);
+	}
+
+	@Override
 	public void destroyPortlet(
 		com.liferay.portal.kernel.model.Portlet portlet) {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-135731
https://issues.liferay.com/browse/PTR-2492

Hi @tinatian ,

Here is the PR for adding multi-threading to improve the portlet deployment time during startup, when a Liferay instance has a large number of companies.

For this PR, I focused on:
- Avoiding any logic change
- Avoiding introducing multi-threading logic in a service call

**Additional Thoughts**
Regarding the multi-threading executor service, I ended up using the PortalExecutor. I tried to make it not overly aggressive, since I'm assuming some users may be deploying modules with portlets during production.

Not sure if we should make the number of threads a configurable value.

Please let me know if you have any questions and if there's any changes you would like me to make.
Thanks!

/cc @dantewang @istvansajtos 

----

**Additional Testing Notes**
During my testing, I did run into this issue quite a few times: [LPS-121471 - Random NPE on startup with theme getColorScheme](https://issues.liferay.com/browse/LPS-121471)

From what I can tell, this issue happens if MainServlet starts serving requests, before the themes are available for use. 

I run into this less often if I clear osgi/state.