### PR TITLE
[Bug fix] LPS-129966

### DIFF
--- a/modules/apps/dispatch/dispatch-talend-api/src/main/java/com/liferay/dispatch/talend/archive/TalendArchiveParserUtil.java
+++ b/modules/apps/dispatch/dispatch-talend-api/src/main/java/com/liferay/dispatch/talend/archive/TalendArchiveParserUtil.java
@@ -91,31 +91,38 @@ public class TalendArchiveParserUtil {
 
 		TalendArchive talendArchive = parse(jobArchiveInputStream);
 
-		if (talendArchive.hasJVMOptions()) {
-			String newJVMOptions = talendArchive.getJVMOptions();
+		try {
+			if (talendArchive.hasJVMOptions()) {
+				String newJVMOptions = talendArchive.getJVMOptions();
 
-			if (unicodeProperties.containsKey("JAVA_OPTS")) {
-				newJVMOptions = getJVMOptions(
-					newJVMOptions, unicodeProperties.get("JAVA_OPTS"));
+				if (unicodeProperties.containsKey("JAVA_OPTS")) {
+					newJVMOptions = getJVMOptions(
+						newJVMOptions, unicodeProperties.get("JAVA_OPTS"));
+				}
+
+				unicodeProperties.put("JAVA_OPTS", newJVMOptions);
+			}
+			else {
+				unicodeProperties.put("JAVA_OPTS", "-Xms256M -Xmx1024M");
 			}
 
-			unicodeProperties.put("JAVA_OPTS", newJVMOptions);
-		}
-		else {
-			unicodeProperties.put("JAVA_OPTS", "-Xms256M -Xmx1024M");
-		}
+			Properties contextProperties = talendArchive.getContextProperties();
 
-		Properties contextProperties = talendArchive.getContextProperties();
+			for (String propertyName :
+					contextProperties.stringPropertyNames()) {
 
-		for (String propertyName : contextProperties.stringPropertyNames()) {
-			if (unicodeProperties.containsKey(propertyName)) {
-				continue;
+				if (unicodeProperties.containsKey(propertyName)) {
+					continue;
+				}
+
+				unicodeProperties.put(
+					propertyName,
+					contextProperties.getProperty(propertyName) +
+						" (Automatic Copy)");
 			}
-
-			unicodeProperties.put(
-				propertyName,
-				contextProperties.getProperty(propertyName) +
-					" (Automatic Copy)");
+		}
+		finally {
+			FileUtil.deltree(talendArchive.getJobDirectory());
 		}
 	}
 

--- a/modules/apps/site/site-welcome-site-initializer/src/main/java/com/liferay/site/welcome/site/initializer/internal/WelcomeSiteInitializer.java
+++ b/modules/apps/site/site-welcome-site-initializer/src/main/java/com/liferay/site/welcome/site/initializer/internal/WelcomeSiteInitializer.java
@@ -245,11 +245,9 @@ public class WelcomeSiteInitializer implements SiteInitializer {
 		if (fileEntry == null) {
 			URL url = _bundle.getEntry(_PATH + _FILE_NAME_TREE_IMAGE);
 
-			File file = FileUtil.createTempFile(url.openStream());
-
 			byte[] bytes = null;
 
-			try (InputStream inputStream = new FileInputStream(file)) {
+			try (InputStream inputStream = url.openStream()) {
 				bytes = FileUtil.getBytes(inputStream);
 			}
 


### PR DESCRIPTION
- LPS-129966 WelcomeSiteInitializer: don't create temp file, directly read from url stream into bytes
- LPS-129966 TalendArchiveParserUtil: remove temp dir after parsing, as the actual output of the method should be the UnicodeProperties
