### PR TITLE
LPS-100336 

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -507,6 +507,7 @@ public class ObjectEntryLocalServiceImpl
 			objectEntryId, values);
 
 		objectEntry.setModifiedDate(serviceContext.getModifiedDate(null));
+		objectEntry.setValues(null);
 
 		objectEntry = objectEntryPersistence.update(objectEntry);
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -734,7 +734,12 @@ public class ObjectEntryLocalServiceTest {
 			ObjectEntryLocalServiceUtil.getValues(
 				objectEntry.getObjectEntryId());
 
-		//Assert.assertEquals(_getValuesFromCacheField(objectEntry), values);
+		ObjectEntry cachedObjectEntry =
+			ObjectEntryLocalServiceUtil.getObjectEntry(
+				objectEntry.getObjectEntryId());
+
+		Assert.assertEquals(values, cachedObjectEntry.getValues());
+
 		Assert.assertEquals(0L, values.get("ageOfDeath"));
 		Assert.assertEquals(false, values.get("authorOfGospel"));
 		Assert.assertEquals(null, values.get("birthday"));


### PR DESCRIPTION
Hi Brian,
The cached field needs to be invalidated manually if its related data changed. This can not be done in framework level as we do not know which data related to the cache field, it is the client's responsibility to make it be invalidated correctly.

Tina.