### PR TITLE
LPS-135570 9 27

### DIFF
--- a/modules/core/portal-web/build.gradle
+++ b/modules/core/portal-web/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.util.java", version: "default"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-io")
 	compileOnly project(":core:shielded-container-api")
 }
 

--- a/modules/core/portal-web/build.gradle
+++ b/modules/core/portal-web/build.gradle
@@ -7,6 +7,8 @@ dependencies {
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-io")
 	compileOnly project(":core:shielded-container-api")
+
+	testCompile project(":core:petra:petra-process")
 }
 
 liferay {

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/PortalWebShieldedContainerInitializer.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/PortalWebShieldedContainerInitializer.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.servlet.AxisServlet;
 import com.liferay.portal.servlet.PortalSessionListener;
 import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.web.internal.session.replication.SessionReplicationFilter;
 import com.liferay.shielded.container.Ordered;
 import com.liferay.shielded.container.ShieldedContainerInitializer;
 
@@ -60,6 +61,17 @@ public class PortalWebShieldedContainerInitializer
 	@Override
 	public void initialize(ServletContext servletContext)
 		throws ServletException {
+
+		if (PropsValues.PORTLET_SESSION_REPLICATE_ENABLED) {
+			FilterRegistration.Dynamic dynamic = servletContext.addFilter(
+				SessionReplicationFilter.class.getName(),
+				new SessionReplicationFilter());
+
+			dynamic.setAsyncSupported(true);
+
+			dynamic.addMappingForUrlPatterns(
+				EnumSet.of(DispatcherType.REQUEST), false, "/*");
+		}
 
 		DocumentBuilderFactory documentBuilderFactory =
 			DocumentBuilderFactory.newInstance();

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationFilter.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationFilter.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.web.internal.session.replication;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Dante Wang
+ */
+public class SessionReplicationFilter implements Filter {
+
+	@Override
+	public void destroy() {
+	}
+
+	@Override
+	public void doFilter(
+			ServletRequest servletRequest, ServletResponse servletResponse,
+			FilterChain filterChain)
+		throws IOException, ServletException {
+
+		if ((servletRequest instanceof HttpServletRequest) &&
+			!(servletRequest instanceof SessionReplicationHttpServletRequest)) {
+
+			servletRequest = new SessionReplicationHttpServletRequest(
+				(HttpServletRequest)servletRequest);
+		}
+
+		filterChain.doFilter(servletRequest, servletResponse);
+	}
+
+	@Override
+	public void init(FilterConfig filterConfig) throws ServletException {
+	}
+
+}

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationFilter.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationFilter.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.web.internal.session.replication;
 
+import com.liferay.portal.kernel.util.StringBundler;
+
 import java.io.IOException;
 
 import javax.servlet.Filter;
@@ -55,13 +57,14 @@ public class SessionReplicationFilter implements Filter {
 						lastHttpServletRequestWrapper.getRequest();
 			}
 
-			if (!(httpServletRequest instanceof
-					SessionReplicationHttpServletRequest)) {
+			Class<?> clazz = httpServletRequest.getClass();
 
-				SessionReplicationHttpServletRequest
-					sessionReplicationHttpServletRequest =
-						new SessionReplicationHttpServletRequest(
-							httpServletRequest);
+			String className = clazz.getName();
+
+			if (!className.equals(_ASM_WRAPPER_CLASS_NAME)) {
+				HttpServletRequest sessionReplicationHttpServletRequest =
+					SessionReplicationHttpServletRequestDelegate.create(
+						httpServletRequest);
 
 				if (lastHttpServletRequestWrapper == null) {
 					servletRequest = sessionReplicationHttpServletRequest;
@@ -78,6 +81,22 @@ public class SessionReplicationFilter implements Filter {
 
 	@Override
 	public void init(FilterConfig filterConfig) throws ServletException {
+	}
+
+	private static final String _ASM_WRAPPER_CLASS_NAME;
+
+	static {
+		Package pkg =
+			SessionReplicationHttpServletRequestDelegate.class.getPackage();
+
+		StringBundler sb = new StringBundler(4);
+
+		sb.append(pkg.getName());
+		sb.append(".");
+		sb.append(HttpServletRequest.class.getSimpleName());
+		sb.append("ASMWrapper");
+
+		_ASM_WRAPPER_CLASS_NAME = sb.toString();
 	}
 
 }

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationFilter.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationFilter.java
@@ -23,6 +23,7 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
 
 /**
  * @author Dante Wang
@@ -39,11 +40,37 @@ public class SessionReplicationFilter implements Filter {
 			FilterChain filterChain)
 		throws IOException, ServletException {
 
-		if ((servletRequest instanceof HttpServletRequest) &&
-			!(servletRequest instanceof SessionReplicationHttpServletRequest)) {
+		if (servletRequest instanceof HttpServletRequest) {
+			HttpServletRequest httpServletRequest =
+				(HttpServletRequest)servletRequest;
 
-			servletRequest = new SessionReplicationHttpServletRequest(
-				(HttpServletRequest)servletRequest);
+			HttpServletRequestWrapper lastHttpServletRequestWrapper = null;
+
+			while (httpServletRequest instanceof HttpServletRequestWrapper) {
+				lastHttpServletRequestWrapper =
+					(HttpServletRequestWrapper)httpServletRequest;
+
+				httpServletRequest =
+					(HttpServletRequest)
+						lastHttpServletRequestWrapper.getRequest();
+			}
+
+			if (!(httpServletRequest instanceof
+					SessionReplicationHttpServletRequest)) {
+
+				SessionReplicationHttpServletRequest
+					sessionReplicationHttpServletRequest =
+						new SessionReplicationHttpServletRequest(
+							httpServletRequest);
+
+				if (lastHttpServletRequestWrapper == null) {
+					servletRequest = sessionReplicationHttpServletRequest;
+				}
+				else {
+					lastHttpServletRequestWrapper.setRequest(
+						sessionReplicationHttpServletRequest);
+				}
+			}
 		}
 
 		filterChain.doFilter(servletRequest, servletResponse);

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationFilter.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationFilter.java
@@ -67,7 +67,8 @@ public class SessionReplicationFilter implements Filter {
 						httpServletRequest);
 
 				if (lastHttpServletRequestWrapper == null) {
-					servletRequest = sessionReplicationHttpServletRequest;
+					servletRequest = new HttpServletRequestWrapper(
+						sessionReplicationHttpServletRequest);
 				}
 				else {
 					lastHttpServletRequestWrapper.setRequest(

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpServletRequest.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpServletRequest.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.web.internal.session.replication;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpSession;
+
+/**
+ * @author Dante Wang
+ */
+public class SessionReplicationHttpServletRequest
+	extends HttpServletRequestWrapper {
+
+	public SessionReplicationHttpServletRequest(
+		HttpServletRequest httpServletRequest) {
+
+		super(httpServletRequest);
+	}
+
+	@Override
+	public HttpSession getSession() {
+		return new SessionReplicationHttpSessionWrapper(super.getSession());
+	}
+
+	@Override
+	public HttpSession getSession(boolean create) {
+		return new SessionReplicationHttpSessionWrapper(
+			super.getSession(create));
+	}
+
+}

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpServletRequest.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpServletRequest.java
@@ -32,13 +32,24 @@ public class SessionReplicationHttpServletRequest
 
 	@Override
 	public HttpSession getSession() {
-		return new SessionReplicationHttpSessionWrapper(super.getSession());
+		HttpSession httpSession = super.getSession();
+
+		if (httpSession == null) {
+			return null;
+		}
+
+		return new SessionReplicationHttpSessionWrapper(httpSession);
 	}
 
 	@Override
 	public HttpSession getSession(boolean create) {
-		return new SessionReplicationHttpSessionWrapper(
-			super.getSession(create));
+		HttpSession httpSession = super.getSession(create);
+
+		if (httpSession == null) {
+			return null;
+		}
+
+		return new SessionReplicationHttpSessionWrapper(httpSession);
 	}
 
 }

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpServletRequestDelegate.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpServletRequestDelegate.java
@@ -14,25 +14,50 @@
 
 package com.liferay.portal.web.internal.session.replication;
 
+import com.liferay.portal.asm.ASMWrapperUtil;
+
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpSession;
 
 /**
  * @author Dante Wang
  */
-public class SessionReplicationHttpServletRequest
-	extends HttpServletRequestWrapper {
+public class SessionReplicationHttpServletRequestDelegate {
 
-	public SessionReplicationHttpServletRequest(
+	public static HttpServletRequest create(
 		HttpServletRequest httpServletRequest) {
 
-		super(httpServletRequest);
+		return ASMWrapperUtil.createASMWrapper(
+			SessionReplicationHttpServletRequestDelegate.class.getClassLoader(),
+			HttpServletRequest.class,
+			new SessionReplicationHttpServletRequestDelegate(
+				httpServletRequest),
+			httpServletRequest);
 	}
 
 	@Override
+	public boolean equals(Object object) {
+		if (!(object instanceof HttpServletRequest)) {
+			return false;
+		}
+
+		HttpServletRequest httpServletRequest = (HttpServletRequest)object;
+
+		return httpServletRequest.equals(_httpServletRequest);
+	}
+
 	public HttpSession getSession() {
-		HttpSession httpSession = super.getSession();
+		HttpSession httpSession = _httpServletRequest.getSession();
+
+		if (httpSession == null) {
+			return null;
+		}
+
+		return new SessionReplicationHttpSessionWrapper(httpSession);
+	}
+
+	public HttpSession getSession(boolean create) {
+		HttpSession httpSession = _httpServletRequest.getSession(create);
 
 		if (httpSession == null) {
 			return null;
@@ -42,14 +67,16 @@ public class SessionReplicationHttpServletRequest
 	}
 
 	@Override
-	public HttpSession getSession(boolean create) {
-		HttpSession httpSession = super.getSession(create);
-
-		if (httpSession == null) {
-			return null;
-		}
-
-		return new SessionReplicationHttpSessionWrapper(httpSession);
+	public int hashCode() {
+		return _httpServletRequest.hashCode();
 	}
+
+	private SessionReplicationHttpServletRequestDelegate(
+		HttpServletRequest httpServletRequest) {
+
+		_httpServletRequest = httpServletRequest;
+	}
+
+	private final HttpServletRequest _httpServletRequest;
 
 }

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpServletRequestDelegate.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpServletRequestDelegate.java
@@ -16,6 +16,7 @@ package com.liferay.portal.web.internal.session.replication;
 
 import com.liferay.portal.asm.ASMWrapperUtil;
 
+import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
@@ -53,7 +54,13 @@ public class SessionReplicationHttpServletRequestDelegate {
 			return null;
 		}
 
-		return new SessionReplicationHttpSessionWrapper(httpSession);
+		httpSession = new SessionReplicationHttpSessionWrapper(httpSession);
+
+		ServletContext servletContext = _httpServletRequest.getServletContext();
+
+		servletContext.setAttribute(httpSession.getId(), httpSession);
+
+		return httpSession;
 	}
 
 	public HttpSession getSession(boolean create) {

--- a/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpSessionWrapper.java
+++ b/modules/core/portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpSessionWrapper.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.web.internal.session.replication;
+
+import com.liferay.petra.io.Deserializer;
+import com.liferay.petra.io.Serializer;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.servlet.HttpSessionWrapper;
+import com.liferay.portal.kernel.util.TransientValue;
+
+import java.io.Serializable;
+
+import java.nio.ByteBuffer;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
+
+import javax.servlet.http.HttpSession;
+
+/**
+ * @author Dante Wang
+ */
+public class SessionReplicationHttpSessionWrapper extends HttpSessionWrapper {
+
+	public SessionReplicationHttpSessionWrapper(HttpSession httpSession) {
+		super(httpSession);
+	}
+
+	@Override
+	public Object getAttribute(String name) {
+		Object value = super.getAttribute(name);
+
+		Set<String> scrubbedNames = (Set<String>)super.getAttribute(
+			_SCRUBBED_NAMES_NAME);
+
+		if ((value == null) || (scrubbedNames == null) ||
+			!scrubbedNames.contains(name)) {
+
+			return value;
+		}
+
+		if (value instanceof String) {
+			return _transientValues.get(value);
+		}
+
+		Deserializer deserializer = new Deserializer(
+			ByteBuffer.wrap((byte[])value));
+
+		try {
+			return deserializer.readObject();
+		}
+		catch (Exception exception) {
+			_log.error("Unable to deserialize object", exception);
+
+			return null;
+		}
+	}
+
+	@Override
+	public void removeAttribute(String name) {
+		if (!_transientValues.isEmpty()) {
+			Object value = super.getAttribute(name);
+
+			if (value instanceof String) {
+				String string = (String)value;
+
+				if (string.startsWith(_TRANSIENT_VALUE_PREFIX)) {
+					_transientValues.remove((String)value);
+				}
+			}
+		}
+
+		super.removeAttribute(name);
+
+		Set<String> scrubbedNames = (Set<String>)super.getAttribute(
+			_SCRUBBED_NAMES_NAME);
+
+		if (scrubbedNames != null) {
+			scrubbedNames.remove(name);
+
+			super.setAttribute(_SCRUBBED_NAMES_NAME, scrubbedNames);
+		}
+	}
+
+	@Override
+	public void setAttribute(String name, Object value) {
+		Object originalValue = value;
+
+		if (value instanceof TransientValue) {
+			TransientValue<?> transientValue = (TransientValue<?>)value;
+
+			if (transientValue.isNull()) {
+				value = null;
+			}
+			else {
+				value = _TRANSIENT_VALUE_PREFIX + value;
+
+				_transientValues.put((String)value, transientValue);
+			}
+		}
+		else if (value instanceof Serializable) {
+			Class<?> clazz = value.getClass();
+
+			if (!_safeClassLoaders.contains(clazz.getClassLoader())) {
+				Serializer serializer = new Serializer();
+
+				serializer.writeObject((Serializable)value);
+
+				ByteBuffer byteBuffer = serializer.toByteBuffer();
+
+				value = byteBuffer.array();
+			}
+		}
+
+		super.setAttribute(name, value);
+
+		if (originalValue != value) {
+			Set<String> scrubbedNames = (Set<String>)super.getAttribute(
+				_SCRUBBED_NAMES_NAME);
+
+			if (scrubbedNames == null) {
+				scrubbedNames = Collections.newSetFromMap(
+					new ConcurrentHashMap<>());
+			}
+
+			scrubbedNames.add(name);
+
+			super.setAttribute(_SCRUBBED_NAMES_NAME, scrubbedNames);
+		}
+	}
+
+	private static final String _SCRUBBED_NAMES_NAME =
+		SessionReplicationHttpSessionWrapper.class.getName() +
+			"._SCRUBBED_NAMES_NAME";
+
+	private static final String _TRANSIENT_VALUE_PREFIX = "TRANSIENT_VALUE_";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SessionReplicationHttpSessionWrapper.class);
+
+	private static final Set<ClassLoader> _safeClassLoaders =
+		new HashSet<ClassLoader>() {
+			{
+				add(String.class.getClassLoader());
+				add(HttpSession.class.getClassLoader());
+				add(Logger.class.getClassLoader());
+			}
+		};
+
+	private final Map<String, TransientValue<?>> _transientValues =
+		new ConcurrentHashMap<>();
+
+}

--- a/modules/core/portal-web/src/test/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpSessionWrapperTest.java
+++ b/modules/core/portal-web/src/test/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpSessionWrapperTest.java
@@ -1,0 +1,251 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.web.internal.session.replication;
+
+import com.liferay.petra.process.ClassPathUtil;
+import com.liferay.portal.kernel.servlet.HttpSessionWrapper;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
+import com.liferay.portal.kernel.util.ProxyFactory;
+import com.liferay.portal.kernel.util.TransientValue;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.lang.reflect.Constructor;
+
+import java.net.URLClassLoader;
+
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+
+import javax.servlet.http.HttpSession;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Tina Tian
+ */
+public class SessionReplicationHttpSessionWrapperTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			CodeCoverageAssertor.INSTANCE, LiferayUnitTestRule.INSTANCE);
+
+	@Test
+	public void testGetAttributeWithException() throws Exception {
+		TestHttpSession testHttpSession = new TestHttpSession();
+
+		SessionReplicationHttpSessionWrapper
+			sessionReplicationHttpSessionWrapper =
+				new SessionReplicationHttpSessionWrapper(testHttpSession);
+
+		sessionReplicationHttpSessionWrapper.setAttribute(
+			_TEST_KEY, new TransientValue<>(new Object()));
+
+		testHttpSession.setAttribute(_TEST_KEY, new byte[0]);
+
+		try (LogCapture logCapture = LoggerTestUtil.configureJDKLogger(
+				SessionReplicationHttpSessionWrapper.class.getName(),
+				Level.SEVERE)) {
+
+			sessionReplicationHttpSessionWrapper.getAttribute(_TEST_KEY);
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(
+				"Unable to deserialize object", logEntry.getMessage());
+		}
+	}
+
+	@Test
+	public void testGetSetAndRemoveAttributeWithNonserializableValue() {
+		_testGetSetAndRemoveAttribute(new Object(), false);
+	}
+
+	@Test
+	public void testGetSetAndRemoveAttributeWithSerializableValue()
+		throws Exception {
+
+		_testGetSetAndRemoveAttribute(
+			_getSessionReplicationHttpSessionWrapperTestValue(_TEST_CONTENT),
+			true);
+	}
+
+	@Test
+	public void testGetSetAndRemoveAttributeWithStringValue() {
+		_testGetSetAndRemoveAttribute(_TEST_CONTENT, false);
+	}
+
+	@Test
+	public void testGetSetAndRemoveAttributeWithTransientValue() {
+		_testGetSetAndRemoveAttribute(new TransientValue<>(null), true);
+		_testGetSetAndRemoveAttribute(new TransientValue<>(new Object()), true);
+	}
+
+	@Test
+	public void testMisc() {
+		TestHttpSession testHttpSession = new TestHttpSession();
+
+		SessionReplicationHttpSessionWrapper
+			sessionReplicationHttpSessionWrapper =
+				new SessionReplicationHttpSessionWrapper(testHttpSession);
+
+		Assert.assertNull(
+			sessionReplicationHttpSessionWrapper.getAttribute(_TEST_KEY));
+
+		sessionReplicationHttpSessionWrapper.setAttribute(
+			"test.key.1", "test.value.1");
+		sessionReplicationHttpSessionWrapper.setAttribute(
+			"test.key.2", new TransientValue<>(new Object()));
+		sessionReplicationHttpSessionWrapper.setAttribute(
+			"test.key.3", new TransientValue<>(new Object()));
+		sessionReplicationHttpSessionWrapper.setAttribute(
+			"test.key.4", new Object());
+
+		Assert.assertEquals(
+			"test.value.1",
+			sessionReplicationHttpSessionWrapper.getAttribute("test.key.1"));
+
+		sessionReplicationHttpSessionWrapper.removeAttribute("test.key.1");
+
+		Assert.assertNull(
+			sessionReplicationHttpSessionWrapper.getAttribute("test.key.1"));
+
+		sessionReplicationHttpSessionWrapper.removeAttribute("test.key.4");
+
+		Assert.assertNull(
+			sessionReplicationHttpSessionWrapper.getAttribute("test.key.4"));
+	}
+
+	private Object _getSessionReplicationHttpSessionWrapperTestValue(
+			String value)
+		throws Exception {
+
+		ClassLoader classLoader = new URLClassLoader(
+			ClassPathUtil.getClassPathURLs(_CLASS_PATH), null);
+
+		Class<?> clazz = classLoader.loadClass(
+			SessionReplicationHttpSessionWrapperTestValue.class.getName());
+
+		Constructor<?> constructor = clazz.getDeclaredConstructor(String.class);
+
+		return constructor.newInstance(value);
+	}
+
+	private void _testGetSetAndRemoveAttribute(
+		Object testValue, boolean scrubbed) {
+
+		TestHttpSession testHttpSession = new TestHttpSession();
+
+		SessionReplicationHttpSessionWrapper
+			sessionReplicationHttpSessionWrapper =
+				new SessionReplicationHttpSessionWrapper(testHttpSession);
+
+		sessionReplicationHttpSessionWrapper.setAttribute(_TEST_KEY, testValue);
+
+		Object retrievedValue =
+			sessionReplicationHttpSessionWrapper.getAttribute(_TEST_KEY);
+
+		if (testValue instanceof TransientValue) {
+			TransientValue<?> transientValue = (TransientValue<?>)testValue;
+
+			if (transientValue.isNull()) {
+				Assert.assertNull(retrievedValue);
+			}
+		}
+		else if (scrubbed) {
+			SessionReplicationHttpSessionWrapperTestValue
+				sessionReplicationHttpSessionWrapperTestValue =
+					(SessionReplicationHttpSessionWrapperTestValue)
+						retrievedValue;
+
+			Assert.assertEquals(
+				_TEST_CONTENT,
+				sessionReplicationHttpSessionWrapperTestValue.getValue());
+		}
+		else {
+			Assert.assertSame(testValue, retrievedValue);
+		}
+
+		if (scrubbed) {
+			Assert.assertNotEquals(
+				testValue, testHttpSession.getAttribute(_TEST_KEY));
+		}
+		else {
+			Assert.assertEquals(
+				testValue, testHttpSession.getAttribute(_TEST_KEY));
+		}
+
+		sessionReplicationHttpSessionWrapper.removeAttribute(_TEST_KEY);
+
+		Assert.assertNull(
+			sessionReplicationHttpSessionWrapper.getAttribute(_TEST_KEY));
+
+		Assert.assertNull(testHttpSession.getAttribute(_TEST_KEY));
+	}
+
+	private static final String _CLASS_PATH = ClassPathUtil.getJVMClassPath(
+		true);
+
+	private static final String _TEST_CONTENT = "_TEST_CONTENT";
+
+	private static final String _TEST_KEY = "TEST_KEY";
+
+	private class TestHttpSession extends HttpSessionWrapper {
+
+		@Override
+		public Object getAttribute(String name) {
+			return _attributes.get(name);
+		}
+
+		@Override
+		public Enumeration<String> getAttributeNames() {
+			return Collections.enumeration(_attributes.keySet());
+		}
+
+		@Override
+		public void removeAttribute(String name) {
+			_attributes.remove(name);
+		}
+
+		@Override
+		public void setAttribute(String name, Object value) {
+			_attributes.put(name, value);
+		}
+
+		private TestHttpSession() {
+			super(ProxyFactory.newDummyInstance(HttpSession.class));
+		}
+
+		private Map<String, Object> _attributes = new HashMap<>();
+
+	}
+
+}

--- a/modules/core/portal-web/src/test/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpSessionWrapperTestValue.java
+++ b/modules/core/portal-web/src/test/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpSessionWrapperTestValue.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.web.internal.session.replication;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+/**
+ * @author Tina Tian
+ */
+public class SessionReplicationHttpSessionWrapperTestValue
+	implements Serializable {
+
+	public SessionReplicationHttpSessionWrapperTestValue(String value) {
+		_value = value;
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof
+				SessionReplicationHttpSessionWrapperTestValue)) {
+
+			return false;
+		}
+
+		SessionReplicationHttpSessionWrapperTestValue
+			sessionReplicationHttpSessionWrapperTestValue =
+				(SessionReplicationHttpSessionWrapperTestValue)object;
+
+		if (Objects.equals(
+				_value, sessionReplicationHttpSessionWrapperTestValue._value)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	public String getValue() {
+		return _value;
+	}
+
+	@Override
+	public int hashCode() {
+		return _value.hashCode();
+	}
+
+	private final String _value;
+
+}

--- a/modules/core/shielded-container-impl/src/main/java/com/liferay/shielded/container/internal/ShieldedContainerServletContainerInitializer.java
+++ b/modules/core/shielded-container-impl/src/main/java/com/liferay/shielded/container/internal/ShieldedContainerServletContainerInitializer.java
@@ -62,7 +62,8 @@ public class ShieldedContainerServletContainerInitializer
 
 		servletContextDelegate.setProxiedServletContext(servletContext);
 
-		servletContext.addListener(ShieldedContainerHttpSessionListener.class);
+		servletContext.addListener(
+			new ShieldedContainerHttpSessionListener(servletContext));
 
 		ServiceLoader<ShieldedContainerInitializer> serviceLoader =
 			ServiceLoader.load(

--- a/modules/core/shielded-container-impl/src/main/java/com/liferay/shielded/container/internal/proxy/EventListenerInvocationHandler.java
+++ b/modules/core/shielded-container-impl/src/main/java/com/liferay/shielded/container/internal/proxy/EventListenerInvocationHandler.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.shielded.container.internal.proxy;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import java.util.EventObject;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpSession;
+
+/**
+ * @author Tina Tian
+ */
+public class EventListenerInvocationHandler
+	extends ContextClassLoaderInvocationHandler {
+
+	public EventListenerInvocationHandler(
+		ServletContext servletContext, ClassLoader contextClassLoader,
+		Object target) {
+
+		super(contextClassLoader, target);
+
+		_servletContext = servletContext;
+	}
+
+	@Override
+	public Object invoke(Object proxy, Method method, Object[] args)
+		throws Throwable {
+
+		if ((args != null) && (args[0] instanceof EventObject)) {
+			EventObject eventObject = (EventObject)args[0];
+
+			Object source = eventObject.getSource();
+
+			if (source instanceof ServletContext) {
+				_sourceField.set(eventObject, _servletContext);
+			}
+			else if (source instanceof HttpSession) {
+				HttpSession httpSession = (HttpSession)source;
+
+				Object updatedHttpSession = _servletContext.getAttribute(
+					httpSession.getId());
+
+				if (updatedHttpSession != null) {
+					_sourceField.set(eventObject, updatedHttpSession);
+				}
+			}
+		}
+
+		return super.invoke(proxy, method, args);
+	}
+
+	private static Field _sourceField;
+
+	static {
+		try {
+			_sourceField = EventObject.class.getDeclaredField("source");
+
+			_sourceField.setAccessible(true);
+		}
+		catch (NoSuchFieldException noSuchFieldException) {
+			throw new ExceptionInInitializerError(noSuchFieldException);
+		}
+	}
+
+	private final ServletContext _servletContext;
+
+}

--- a/modules/core/shielded-container-impl/src/main/java/com/liferay/shielded/container/internal/proxy/ServletContextDelegate.java
+++ b/modules/core/shielded-container-impl/src/main/java/com/liferay/shielded/container/internal/proxy/ServletContextDelegate.java
@@ -121,7 +121,8 @@ public class ServletContextDelegate {
 		}
 
 		InvocationHandler invocationHandler =
-			new ContextClassLoaderInvocationHandler(_classLoader, t);
+			new EventListenerInvocationHandler(
+				_proxiedServletContext, _classLoader, t);
 
 		if (interfaceClasses.contains(HttpSessionListener.class)) {
 			invocationHandler = new HttpSessionListenerInvocationHandlerWrapper(

--- a/modules/core/shielded-container-impl/src/main/java/com/liferay/shielded/container/internal/session/ShieldedContainerHttpSessionListener.java
+++ b/modules/core/shielded-container-impl/src/main/java/com/liferay/shielded/container/internal/session/ShieldedContainerHttpSessionListener.java
@@ -14,6 +14,7 @@
 
 package com.liferay.shielded.container.internal.session;
 
+import javax.servlet.ServletContext;
 import javax.servlet.http.HttpSession;
 import javax.servlet.http.HttpSessionEvent;
 import javax.servlet.http.HttpSessionListener;
@@ -23,6 +24,10 @@ import javax.servlet.http.HttpSessionListener;
  */
 public class ShieldedContainerHttpSessionListener
 	implements HttpSessionListener {
+
+	public ShieldedContainerHttpSessionListener(ServletContext servletContext) {
+		_servletContext = servletContext;
+	}
 
 	@Override
 	public void sessionCreated(HttpSessionEvent httpSessionEvent) {
@@ -35,6 +40,11 @@ public class ShieldedContainerHttpSessionListener
 
 	@Override
 	public void sessionDestroyed(HttpSessionEvent httpSessionEvent) {
+		HttpSession httpSession = httpSessionEvent.getSession();
+
+		_servletContext.removeAttribute(httpSession.getId());
 	}
+
+	private final ServletContext _servletContext;
 
 }

--- a/modules/core/source-formatter-suppressions.xml
+++ b/modules/core/source-formatter-suppressions.xml
@@ -3,6 +3,7 @@
 <suppressions>
 	<checkstyle>
 		<suppress checks="MapBuilderCheck" files="portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl\.java" />
+		<suppress checks="MethodNamingCheck" files="portal-web/src/main/java/com/liferay/portal/web/internal/session/replication/SessionReplicationHttpServletRequestDelegate\.java" />
 	</checkstyle>
 	<source-check>
 		<suppress checks="BNDDefinitionKeysCheck" files="portal-bootstrap/system.packages.extra.bnd" />

--- a/portal-impl/src/com/liferay/portlet/internal/PortletSessionImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/PortletSessionImpl.java
@@ -16,23 +16,8 @@ package com.liferay.portlet.internal;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.io.Deserializer;
-import com.liferay.portal.kernel.io.Serializer;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.LiferayPortletSession;
-import com.liferay.portal.kernel.servlet.HttpSessionWrapper;
-import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
-import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.PortletSessionAttributeMap;
-
-import java.io.Externalizable;
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import java.io.Serializable;
-
-import java.nio.ByteBuffer;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -55,7 +40,7 @@ public class PortletSessionImpl implements LiferayPortletSession {
 		HttpSession httpSession, PortletContext portletContext,
 		String portletName, long plid) {
 
-		this.httpSession = _wrapHttpSession(httpSession);
+		this.httpSession = httpSession;
 		this.portletContext = portletContext;
 
 		scopePrefix = StringBundler.concat(
@@ -214,7 +199,7 @@ public class PortletSessionImpl implements LiferayPortletSession {
 
 	@Override
 	public void setHttpSession(HttpSession httpSession) {
-		this.httpSession = _wrapHttpSession(httpSession);
+		this.httpSession = httpSession;
 	}
 
 	@Override
@@ -226,164 +211,6 @@ public class PortletSessionImpl implements LiferayPortletSession {
 	protected final PortletContext portletContext;
 	protected final String scopePrefix;
 
-	private HttpSession _wrapHttpSession(HttpSession httpSession) {
-		if (PropsValues.PORTLET_SESSION_REPLICATE_ENABLED &&
-			!(httpSession instanceof SerializableHttpSessionWrapper)) {
-
-			return new SerializableHttpSessionWrapper(httpSession);
-		}
-
-		return httpSession;
-	}
-
 	private boolean _invalidated;
-
-	private static class LazySerializable implements Serializable {
-
-		public byte[] getData() {
-			return _data;
-		}
-
-		public Serializable getSerializable() {
-			Deserializer deserializer = new Deserializer(
-				ByteBuffer.wrap(_data));
-
-			try {
-				return deserializer.readObject();
-			}
-			catch (ClassNotFoundException classNotFoundException) {
-				_log.error(
-					"Unable to deserialize object", classNotFoundException);
-
-				return null;
-			}
-		}
-
-		private LazySerializable(byte[] data) {
-			_data = data;
-		}
-
-		private static final Log _log = LogFactoryUtil.getLog(
-			LazySerializable.class);
-
-		private final byte[] _data;
-
-	}
-
-	private static class LazySerializableObjectWrapper
-		implements Externalizable {
-
-		/**
-		 * The empty constructor is required by {@link Externalizable}. Do not
-		 * use this for any other purpose.
-		 */
-		public LazySerializableObjectWrapper() {
-		}
-
-		public Serializable getSerializable() {
-			if (_serializable instanceof LazySerializable) {
-				LazySerializable lazySerializable =
-					(LazySerializable)_serializable;
-
-				Serializable serializable = lazySerializable.getSerializable();
-
-				if (serializable == null) {
-					return null;
-				}
-
-				_serializable = serializable;
-			}
-
-			return _serializable;
-		}
-
-		@Override
-		public void readExternal(ObjectInput objectInput) throws IOException {
-			byte[] data = new byte[objectInput.readInt()];
-
-			objectInput.readFully(data);
-
-			_serializable = new LazySerializable(data);
-		}
-
-		@Override
-		public void writeExternal(ObjectOutput objectOutput)
-			throws IOException {
-
-			byte[] data = _getData();
-
-			objectOutput.writeInt(data.length);
-
-			objectOutput.write(data, 0, data.length);
-		}
-
-		private LazySerializableObjectWrapper(Serializable serializable) {
-			_serializable = serializable;
-		}
-
-		private byte[] _getData() {
-			if (_serializable instanceof LazySerializable) {
-				LazySerializable lazySerializable =
-					(LazySerializable)_serializable;
-
-				return lazySerializable.getData();
-			}
-
-			Serializer serializer = new Serializer();
-
-			serializer.writeObject(_serializable);
-
-			ByteBuffer byteBuffer = serializer.toByteBuffer();
-
-			return byteBuffer.array();
-		}
-
-		private volatile Serializable _serializable;
-
-	}
-
-	private static class SerializableHttpSessionWrapper
-		extends HttpSessionWrapper {
-
-		@Override
-		public Object getAttribute(String name) {
-			Object value = super.getAttribute(name);
-
-			if (value instanceof LazySerializableObjectWrapper) {
-				LazySerializableObjectWrapper lazySerializableObjectWrapper =
-					(LazySerializableObjectWrapper)value;
-
-				return lazySerializableObjectWrapper.getSerializable();
-			}
-
-			return value;
-		}
-
-		@Override
-		public void setAttribute(String name, Object value) {
-			if (!(value instanceof Serializable)) {
-				super.setAttribute(name, value);
-
-				return;
-			}
-
-			Class<?> clazz = value.getClass();
-
-			ClassLoader classLoader = clazz.getClassLoader();
-
-			if ((classLoader != null) &&
-				!PortalClassLoaderUtil.isPortalClassLoader(classLoader)) {
-
-				value = new LazySerializableObjectWrapper((Serializable)value);
-			}
-
-			super.setAttribute(name, value);
-		}
-
-		private SerializableHttpSessionWrapper(HttpSession httpSession) {
-			super(httpSession);
-		}
-
-	}
 
 }

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -570,7 +570,7 @@
     #
     # Env: LIFERAY_PORTLET_PERIOD_SESSION_PERIOD_REPLICATE_PERIOD_ENABLED
     #
-    portlet.session.replicate.enabled=false
+    portlet.session.replicate.enabled=true
 
 ##
 ## Portlet Config

--- a/portal-kernel/src/com/liferay/portal/kernel/util/TransientValue.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/TransientValue.java
@@ -16,6 +16,8 @@ package com.liferay.portal.kernel.util;
 
 import java.io.Serializable;
 
+import java.util.Objects;
+
 /**
  * @author Brian Wing Shun Chan
  * @see    com.liferay.portal.kernel.servlet.NonSerializableObjectHandler
@@ -29,8 +31,32 @@ public class TransientValue<V> implements Serializable {
 		_value = value;
 	}
 
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof TransientValue)) {
+			return false;
+		}
+
+		TransientValue<?> transientValue = (TransientValue<?>)object;
+
+		if (Objects.equals(_value, transientValue._value)) {
+			return true;
+		}
+
+		return false;
+	}
+
 	public V getValue() {
 		return _value;
+	}
+
+	@Override
+	public int hashCode() {
+		return _value.hashCode();
 	}
 
 	public boolean isNotNull() {


### PR DESCRIPTION
@tinatian, this is just update. The pr can solved the mentioned wildfly issue (I didn't test on websphere and weblogic) from the [link](https://github.com/tinatian/liferay-portal/pull/2404#issuecomment-926836887).

For the [issue ](https://github.com/tinatian/liferay-portal/pull/2404#issuecomment-926848375), I set session.timeout=2 to test. Sometimes, I can reproduce the issue. But I don't find the fixed way to reproduce the issue. Some infos for the issue. When the issue happens, see the [code](https://github.com/yuhai/liferay-portal/blob/LPS-135570-9-27/portal-impl/src/com/liferay/portal/events/ChannelSessionDestroyAction.java#L36), 

not work when httpSession is 
com.liferay.shielded.container.internal.proxy.HttpSessionDelegate@15979741     the value is HttpSessionAMSWrapper.

work when httpSession is SessionReplicationHttpSessionWrapper.

cc @vicnate5