### PR TITLE
LPS-143635 Avoid using OrganizationPermissionUtil, PasswordPolicyPermissionUtil, PortalPermissionUtil directly in modules

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/application/list/ControlPanelCategoryWrapper.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/application/list/ControlPanelCategoryWrapper.java
@@ -22,7 +22,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil;
+import com.liferay.portal.kernel.service.permission.OrganizationPermission;
 
 import java.util.Locale;
 
@@ -63,7 +63,7 @@ public class ControlPanelCategoryWrapper extends BasePanelCategory {
 
 		User user = permissionChecker.getUser();
 
-		if (OrganizationPermissionUtil.contains(
+		if (_organizationPermission.contains(
 				permissionChecker, user.getOrganizationIds(true),
 				AccountActionKeys.MANAGE_ACCOUNTS)) {
 
@@ -72,6 +72,9 @@ public class ControlPanelCategoryWrapper extends BasePanelCategory {
 
 		return false;
 	}
+
+	@Reference
+	private OrganizationPermission _organizationPermission;
 
 	@Reference(
 		target = "(&(panel.category.key=" + PanelCategoryKeys.ROOT + ")(!(account.control.panel.category.wrapper=*)))"

--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/frontend/taglib/servlet/taglib/AccountGroupDetailsScreenNavigationCategory.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/frontend/taglib/servlet/taglib/AccountGroupDetailsScreenNavigationCategory.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
-import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
+import com.liferay.portal.kernel.service.permission.PortalPermission;
 
 import java.io.IOException;
 
@@ -80,7 +80,7 @@ public class AccountGroupDetailsScreenNavigationCategory
 		if (accountGroupDisplay.getAccountGroupId() ==
 				AccountConstants.ACCOUNT_ENTRY_ID_DEFAULT) {
 
-			return PortalPermissionUtil.contains(
+			return portalPermission.contains(
 				PermissionCheckerFactoryUtil.create(user),
 				AccountActionKeys.ADD_ACCOUNT_GROUP);
 		}
@@ -103,5 +103,8 @@ public class AccountGroupDetailsScreenNavigationCategory
 
 	@Reference
 	protected JSPRenderer jspRenderer;
+
+	@Reference
+	protected PortalPermission portalPermission;
 
 }

--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/portlet/AccountsControlPanelEntry.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/portlet/AccountsControlPanelEntry.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.portlet.ControlPanelEntry;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
-import com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil;
+import com.liferay.portal.kernel.service.permission.OrganizationPermission;
 
 import java.util.List;
 
@@ -53,7 +53,7 @@ public class AccountsControlPanelEntry extends BaseControlPanelEntry {
 				permissionChecker.getUserId(), true);
 
 		for (Organization organization : organizations) {
-			if (OrganizationPermissionUtil.contains(
+			if (_organizationPermission.contains(
 					permissionChecker, organization,
 					AccountActionKeys.MANAGE_ACCOUNTS) &&
 				permissionChecker.hasPermission(
@@ -70,5 +70,8 @@ public class AccountsControlPanelEntry extends BaseControlPanelEntry {
 
 	@Reference
 	private OrganizationLocalService _organizationLocalService;
+
+	@Reference
+	private OrganizationPermission _organizationPermission;
 
 }

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/search/spi/model/permission/UserSearchPermissionFilterContributor.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/search/spi/model/permission/UserSearchPermissionFilterContributor.java
@@ -29,7 +29,7 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.UserBag;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.RoleLocalService;
-import com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil;
+import com.liferay.portal.kernel.service.permission.OrganizationPermission;
 import com.liferay.portal.search.spi.model.permission.SearchPermissionFilterContributor;
 
 import java.util.List;
@@ -84,7 +84,7 @@ public class UserSearchPermissionFilterContributor
 			long[] userOrgIds = userBag.getUserOrgIds();
 
 			for (long userOrgId : userOrgIds) {
-				if (OrganizationPermissionUtil.contains(
+				if (_organizationPermission.contains(
 						permissionChecker, userOrgId,
 						AccountActionKeys.MANAGE_ACCOUNTS)) {
 
@@ -135,5 +135,8 @@ public class UserSearchPermissionFilterContributor
 
 	@Reference
 	private AccountEntryUserRelLocalService _accountEntryUserRelLocalService;
+
+	@Reference
+	private OrganizationPermission _organizationPermission;
 
 }

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/search/spi/model/query/contributor/OrganizationModelPreFilterContributor.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/search/spi/model/query/contributor/OrganizationModelPreFilterContributor.java
@@ -32,7 +32,7 @@ import com.liferay.portal.kernel.search.generic.TermQueryImpl;
 import com.liferay.portal.kernel.search.generic.WildcardQueryImpl;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
-import com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil;
+import com.liferay.portal.kernel.service.permission.OrganizationPermission;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.search.spi.model.query.contributor.ModelPreFilterContributor;
 import com.liferay.portal.search.spi.model.registrar.ModelSearchSettings;
@@ -41,6 +41,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Pei-Jung Lan
@@ -108,7 +109,7 @@ public class OrganizationModelPreFilterContributor
 					treePath = organization.buildTreePath();
 
 					if ((permissionChecker != null) &&
-						OrganizationPermissionUtil.contains(
+						_organizationPermission.contains(
 							permissionChecker, organization,
 							AccountActionKeys.
 								MANAGE_SUBORGANIZATIONS_ACCOUNTS)) {
@@ -129,5 +130,8 @@ public class OrganizationModelPreFilterContributor
 			booleanFilter.add(treePathBooleanFilter, BooleanClauseOccur.MUST);
 		}
 	}
+
+	@Reference
+	private OrganizationPermission _organizationPermission;
 
 }

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountEntryServiceImpl.java
@@ -27,7 +27,7 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.permission.OrganizationPermission;
-import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
+import com.liferay.portal.kernel.service.permission.PortalPermission;
 import com.liferay.portal.kernel.util.OrderByComparator;
 
 import java.util.LinkedHashMap;
@@ -75,7 +75,7 @@ public class AccountEntryServiceImpl extends AccountEntryServiceBaseImpl {
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		PortalPermissionUtil.check(
+		_portalPermission.check(
 			getPermissionChecker(), AccountActionKeys.ADD_ACCOUNT_ENTRY);
 
 		return accountEntryLocalService.addAccountEntry(
@@ -99,7 +99,7 @@ public class AccountEntryServiceImpl extends AccountEntryServiceBaseImpl {
 				permissionChecker.getCompanyId(), externalReferenceCode);
 
 		if (accountEntry == null) {
-			PortalPermissionUtil.check(
+			_portalPermission.check(
 				permissionChecker, AccountActionKeys.ADD_ACCOUNT_ENTRY);
 		}
 		else {
@@ -260,6 +260,9 @@ public class AccountEntryServiceImpl extends AccountEntryServiceBaseImpl {
 
 	@Reference
 	private OrganizationPermission _organizationPermission;
+
+	@Reference
+	private PortalPermission _portalPermission;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountGroupServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountGroupServiceImpl.java
@@ -23,7 +23,7 @@ import com.liferay.portal.kernel.search.BaseModelSearchResult;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
-import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
+import com.liferay.portal.kernel.service.permission.PortalPermission;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.OrderByComparator;
 
@@ -47,7 +47,7 @@ public class AccountGroupServiceImpl extends AccountGroupServiceBaseImpl {
 			long userId, String description, String name)
 		throws PortalException {
 
-		PortalPermissionUtil.check(
+		_portalPermission.check(
 			getPermissionChecker(), AccountActionKeys.ADD_ACCOUNT_GROUP);
 
 		return accountGroupLocalService.addAccountGroup(
@@ -106,5 +106,8 @@ public class AccountGroupServiceImpl extends AccountGroupServiceBaseImpl {
 	)
 	private ModelResourcePermission<AccountGroup>
 		_accountGroupModelResourcePermission;
+
+	@Reference
+	private PortalPermission _portalPermission;
 
 }

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountRoleServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountRoleServiceImpl.java
@@ -23,7 +23,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
-import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
+import com.liferay.portal.kernel.service.permission.PortalPermission;
 
 import java.util.Locale;
 import java.util.Map;
@@ -57,7 +57,7 @@ public class AccountRoleServiceImpl extends AccountRoleServiceBaseImpl {
 				AccountActionKeys.ADD_ACCOUNT_ROLE);
 		}
 		else {
-			PortalPermissionUtil.check(permissionChecker, ActionKeys.ADD_ROLE);
+			_portalPermission.check(permissionChecker, ActionKeys.ADD_ROLE);
 		}
 
 		return accountRoleLocalService.addAccountRole(
@@ -157,5 +157,8 @@ public class AccountRoleServiceImpl extends AccountRoleServiceBaseImpl {
 	)
 	private ModelResourcePermission<AccountRole>
 		_accountRoleModelResourcePermission;
+
+	@Reference
+	private PortalPermission _portalPermission;
 
 }

--- a/modules/apps/commerce/commerce-application-list/src/main/java/com/liferay/commerce/application/list/internal/panel/CommercePanelCategory.java
+++ b/modules/apps/commerce/commerce-application-list/src/main/java/com/liferay/commerce/application/list/internal/panel/CommercePanelCategory.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
+import com.liferay.portal.kernel.service.permission.PortalPermission;
 
 import java.util.Locale;
 
@@ -58,7 +58,7 @@ public class CommercePanelCategory extends BasePanelCategory {
 	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
-		if (PortalPermissionUtil.contains(
+		if (_portalPermission.contains(
 				permissionChecker, ActionKeys.VIEW_CONTROL_PANEL)) {
 
 			return true;
@@ -73,5 +73,8 @@ public class CommercePanelCategory extends BasePanelCategory {
 	}
 
 	private PanelAppRegistry _panelAppRegistry;
+
+	@Reference
+	private PortalPermission _portalPermission;
 
 }

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/application/list/ObjectDefinitionsPanelCategory.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/application/list/ObjectDefinitionsPanelCategory.java
@@ -22,11 +22,12 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
+import com.liferay.portal.kernel.service.permission.PortalPermission;
 
 import java.util.Locale;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Marco Leo
@@ -55,8 +56,11 @@ public class ObjectDefinitionsPanelCategory extends BasePanelCategory {
 	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
-		return PortalPermissionUtil.contains(
+		return _portalPermission.contains(
 			permissionChecker, ActionKeys.VIEW_CONTROL_PANEL);
 	}
+
+	@Reference
+	private PortalPermission _portalPermission;
 
 }

--- a/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/search/spi/model/query/contributor/OrganizationModelPreFilterContributor.java
+++ b/modules/apps/organizations/organizations-service/src/main/java/com/liferay/organizations/internal/search/spi/model/query/contributor/OrganizationModelPreFilterContributor.java
@@ -31,7 +31,7 @@ import com.liferay.portal.kernel.search.generic.WildcardQueryImpl;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
-import com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil;
+import com.liferay.portal.kernel.service.permission.OrganizationPermission;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -42,6 +42,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Igor Fabiano Nazar
@@ -107,7 +108,7 @@ public class OrganizationModelPreFilterContributor
 							organization.getOrganizationId()) ||
 						 permissionChecker.isOrganizationOwner(
 							 organization.getOrganizationId()) ||
-						 OrganizationPermissionUtil.contains(
+						 _organizationPermission.contains(
 							 permissionChecker, organization,
 							 ActionKeys.MANAGE_SUBORGANIZATIONS))) {
 
@@ -138,5 +139,8 @@ public class OrganizationModelPreFilterContributor
 			}
 		}
 	}
+
+	@Reference
+	private OrganizationPermission _organizationPermission;
 
 }

--- a/modules/apps/password-policies-admin/password-policies-admin-web/src/main/java/com/liferay/password/policies/admin/web/internal/portlet/configuration/icon/AssignMembersPortletConfigurationIcon.java
+++ b/modules/apps/password-policies-admin/password-policies-admin-web/src/main/java/com/liferay/password/policies/admin/web/internal/portlet/configuration/icon/AssignMembersPortletConfigurationIcon.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.portlet.PortletURLFactory;
 import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.service.permission.PasswordPolicyPermissionUtil;
+import com.liferay.portal.kernel.service.permission.PasswordPolicyPermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -85,7 +85,7 @@ public class AssignMembersPortletConfigurationIcon
 		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		if (PasswordPolicyPermissionUtil.contains(
+		if (_passwordPolicyPermission.contains(
 				themeDisplay.getPermissionChecker(),
 				_getPasswordPolicyId(portletRequest),
 				ActionKeys.ASSIGN_MEMBERS)) {
@@ -100,6 +100,9 @@ public class AssignMembersPortletConfigurationIcon
 		return ParamUtil.getLong(
 			_portal.getHttpServletRequest(portletRequest), "passwordPolicyId");
 	}
+
+	@Reference
+	private PasswordPolicyPermission _passwordPolicyPermission;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/password-policies-admin/password-policies-admin-web/src/main/java/com/liferay/password/policies/admin/web/internal/portlet/configuration/icon/DeletePasswordPolicyPortletConfigurationIcon.java
+++ b/modules/apps/password-policies-admin/password-policies-admin-web/src/main/java/com/liferay/password/policies/admin/web/internal/portlet/configuration/icon/DeletePasswordPolicyPortletConfigurationIcon.java
@@ -22,7 +22,7 @@ import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigura
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.PasswordPolicyLocalService;
-import com.liferay.portal.kernel.service.permission.PasswordPolicyPermissionUtil;
+import com.liferay.portal.kernel.service.permission.PasswordPolicyPermission;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -99,7 +99,7 @@ public class DeletePasswordPolicyPortletConfigurationIcon
 			_passwordPolicyLocalService.fetchPasswordPolicy(passwordPolicyId);
 
 		if ((passwordPolicy != null) && !passwordPolicy.isDefaultPolicy() &&
-			PasswordPolicyPermissionUtil.contains(
+			_passwordPolicyPermission.contains(
 				themeDisplay.getPermissionChecker(), passwordPolicyId,
 				ActionKeys.DELETE)) {
 
@@ -122,6 +122,9 @@ public class DeletePasswordPolicyPortletConfigurationIcon
 	}
 
 	private PasswordPolicyLocalService _passwordPolicyLocalService;
+
+	@Reference
+	private PasswordPolicyPermission _passwordPolicyPermission;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/password-policies-admin/password-policies-admin-web/src/main/java/com/liferay/password/policies/admin/web/internal/portlet/configuration/icon/EditPasswordPolicyPortletConfigurationIcon.java
+++ b/modules/apps/password-policies-admin/password-policies-admin-web/src/main/java/com/liferay/password/policies/admin/web/internal/portlet/configuration/icon/EditPasswordPolicyPortletConfigurationIcon.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.portlet.PortletURLFactory;
 import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.service.permission.PasswordPolicyPermissionUtil;
+import com.liferay.portal.kernel.service.permission.PasswordPolicyPermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -81,7 +81,7 @@ public class EditPasswordPolicyPortletConfigurationIcon
 		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		if (PasswordPolicyPermissionUtil.contains(
+		if (_passwordPolicyPermission.contains(
 				themeDisplay.getPermissionChecker(),
 				_getPasswordPolicyId(portletRequest), ActionKeys.UPDATE)) {
 
@@ -95,6 +95,9 @@ public class EditPasswordPolicyPortletConfigurationIcon
 		return ParamUtil.getLong(
 			_portal.getHttpServletRequest(portletRequest), "passwordPolicyId");
 	}
+
+	@Reference
+	private PasswordPolicyPermission _passwordPolicyPermission;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/password-policies-admin/password-policies-admin-web/src/main/java/com/liferay/password/policies/admin/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
+++ b/modules/apps/password-policies-admin/password-policies-admin-web/src/main/java/com/liferay/password/policies/admin/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.service.permission.PasswordPolicyPermissionUtil;
+import com.liferay.portal.kernel.service.permission.PasswordPolicyPermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -94,7 +94,7 @@ public class PermissionsPortletConfigurationIcon
 		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		if (PasswordPolicyPermissionUtil.contains(
+		if (_passwordPolicyPermission.contains(
 				themeDisplay.getPermissionChecker(),
 				_getPasswordPolicyId(portletRequest), ActionKeys.PERMISSIONS)) {
 
@@ -116,6 +116,9 @@ public class PermissionsPortletConfigurationIcon
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		PermissionsPortletConfigurationIcon.class);
+
+	@Reference
+	private PasswordPolicyPermission _passwordPolicyPermission;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/impl/PLOEntryServiceImpl.java
+++ b/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/impl/PLOEntryServiceImpl.java
@@ -17,7 +17,7 @@ package com.liferay.portal.language.override.service.impl;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
+import com.liferay.portal.kernel.service.permission.PortalPermission;
 import com.liferay.portal.language.override.constants.PLOActionKeys;
 import com.liferay.portal.language.override.model.PLOEntry;
 import com.liferay.portal.language.override.service.base.PLOEntryServiceBaseImpl;
@@ -26,6 +26,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Brian Wing Shun Chan
@@ -43,7 +44,7 @@ public class PLOEntryServiceImpl extends PLOEntryServiceBaseImpl {
 	public void deletePLOEntries(String key) throws PortalException {
 		PermissionChecker permissionChecker = getPermissionChecker();
 
-		PortalPermissionUtil.check(
+		_portalPermission.check(
 			permissionChecker, PLOActionKeys.MANAGE_LANGUAGE_OVERRIDES);
 
 		ploEntryLocalService.deletePLOEntries(
@@ -56,7 +57,7 @@ public class PLOEntryServiceImpl extends PLOEntryServiceBaseImpl {
 
 		PermissionChecker permissionChecker = getPermissionChecker();
 
-		PortalPermissionUtil.check(
+		_portalPermission.check(
 			permissionChecker, PLOActionKeys.MANAGE_LANGUAGE_OVERRIDES);
 
 		return ploEntryLocalService.deletePLOEntry(
@@ -69,12 +70,15 @@ public class PLOEntryServiceImpl extends PLOEntryServiceBaseImpl {
 
 		PermissionChecker permissionChecker = getPermissionChecker();
 
-		PortalPermissionUtil.check(
+		_portalPermission.check(
 			permissionChecker, PLOActionKeys.MANAGE_LANGUAGE_OVERRIDES);
 
 		ploEntryLocalService.setPLOEntries(
 			permissionChecker.getCompanyId(), permissionChecker.getUserId(),
 			key, localizationMap);
 	}
+
+	@Reference
+	private PortalPermission _portalPermission;
 
 }

--- a/modules/apps/product-navigation/product-navigation-control-panel/src/main/java/com/liferay/product/navigation/control/panel/internal/application/list/ApplicationsPanelCategory.java
+++ b/modules/apps/product-navigation/product-navigation-control-panel/src/main/java/com/liferay/product/navigation/control/panel/internal/application/list/ApplicationsPanelCategory.java
@@ -22,11 +22,12 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
+import com.liferay.portal.kernel.service.permission.PortalPermission;
 
 import java.util.Locale;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Eudaldo Alonso
@@ -56,7 +57,7 @@ public class ApplicationsPanelCategory extends BasePanelCategory {
 	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
-		if (PortalPermissionUtil.contains(
+		if (_portalPermission.contains(
 				permissionChecker, ActionKeys.VIEW_CONTROL_PANEL)) {
 
 			return true;
@@ -64,5 +65,8 @@ public class ApplicationsPanelCategory extends BasePanelCategory {
 
 		return false;
 	}
+
+	@Reference
+	private PortalPermission _portalPermission;
 
 }

--- a/modules/apps/product-navigation/product-navigation-control-panel/src/main/java/com/liferay/product/navigation/control/panel/internal/application/list/ControlPanelCategory.java
+++ b/modules/apps/product-navigation/product-navigation-control-panel/src/main/java/com/liferay/product/navigation/control/panel/internal/application/list/ControlPanelCategory.java
@@ -23,7 +23,7 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
+import com.liferay.portal.kernel.service.permission.PortalPermission;
 
 import java.util.Locale;
 
@@ -57,7 +57,7 @@ public class ControlPanelCategory extends BasePanelCategory {
 	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
-		if (PortalPermissionUtil.contains(
+		if (_portalPermission.contains(
 				permissionChecker, ActionKeys.VIEW_CONTROL_PANEL)) {
 
 			return true;
@@ -72,5 +72,8 @@ public class ControlPanelCategory extends BasePanelCategory {
 	}
 
 	private PanelAppRegistry _panelAppRegistry;
+
+	@Reference
+	private PortalPermission _portalPermission;
 
 }

--- a/modules/apps/product-navigation/product-navigation-control-panel/src/main/java/com/liferay/product/navigation/control/panel/internal/application/list/SecurityPanelCategory.java
+++ b/modules/apps/product-navigation/product-navigation-control-panel/src/main/java/com/liferay/product/navigation/control/panel/internal/application/list/SecurityPanelCategory.java
@@ -22,11 +22,12 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
+import com.liferay.portal.kernel.service.permission.PortalPermission;
 
 import java.util.Locale;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Eudaldo Alonso
@@ -55,7 +56,7 @@ public class SecurityPanelCategory extends BasePanelCategory {
 	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
-		if (PortalPermissionUtil.contains(
+		if (_portalPermission.contains(
 				permissionChecker, ActionKeys.VIEW_CONTROL_PANEL)) {
 
 			return true;
@@ -63,5 +64,8 @@ public class SecurityPanelCategory extends BasePanelCategory {
 
 		return false;
 	}
+
+	@Reference
+	private PortalPermission _portalPermission;
 
 }

--- a/modules/apps/product-navigation/product-navigation-control-panel/src/main/java/com/liferay/product/navigation/control/panel/internal/application/list/SitesPanelCategory.java
+++ b/modules/apps/product-navigation/product-navigation-control-panel/src/main/java/com/liferay/product/navigation/control/panel/internal/application/list/SitesPanelCategory.java
@@ -22,11 +22,12 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
+import com.liferay.portal.kernel.service.permission.PortalPermission;
 
 import java.util.Locale;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Eudaldo Alonso
@@ -55,7 +56,7 @@ public class SitesPanelCategory extends BasePanelCategory {
 	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
-		if (PortalPermissionUtil.contains(
+		if (_portalPermission.contains(
 				permissionChecker, ActionKeys.VIEW_CONTROL_PANEL)) {
 
 			return true;
@@ -63,5 +64,8 @@ public class SitesPanelCategory extends BasePanelCategory {
 
 		return false;
 	}
+
+	@Reference
+	private PortalPermission _portalPermission;
 
 }

--- a/modules/apps/product-navigation/product-navigation-control-panel/src/main/java/com/liferay/product/navigation/control/panel/internal/application/list/SystemPanelCategory.java
+++ b/modules/apps/product-navigation/product-navigation-control-panel/src/main/java/com/liferay/product/navigation/control/panel/internal/application/list/SystemPanelCategory.java
@@ -22,11 +22,12 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
+import com.liferay.portal.kernel.service.permission.PortalPermission;
 
 import java.util.Locale;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Eudaldo Alonso
@@ -55,7 +56,7 @@ public class SystemPanelCategory extends BasePanelCategory {
 	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
-		if (PortalPermissionUtil.contains(
+		if (_portalPermission.contains(
 				permissionChecker, ActionKeys.VIEW_CONTROL_PANEL)) {
 
 			return true;
@@ -63,5 +64,8 @@ public class SystemPanelCategory extends BasePanelCategory {
 
 		return false;
 	}
+
+	@Reference
+	private PortalPermission _portalPermission;
 
 }

--- a/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/portlet/action/SelectSiteInitializerMVCRenderCommand.java
+++ b/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/portlet/action/SelectSiteInitializerMVCRenderCommand.java
@@ -17,7 +17,7 @@ package com.liferay.site.admin.web.internal.portlet.action;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
+import com.liferay.portal.kernel.service.permission.PortalPermission;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -27,6 +27,7 @@ import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Eudaldo Alonso
@@ -48,7 +49,7 @@ public class SelectSiteInitializerMVCRenderCommand implements MVCRenderCommand {
 		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		if (PortalPermissionUtil.contains(
+		if (_portalPermission.contains(
 				themeDisplay.getPermissionChecker(),
 				ActionKeys.ADD_COMMUNITY)) {
 
@@ -59,5 +60,8 @@ public class SelectSiteInitializerMVCRenderCommand implements MVCRenderCommand {
 
 		return "/error.jsp";
 	}
+
+	@Reference
+	private PortalPermission _portalPermission;
 
 }

--- a/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/portlet/configuration/icon/ManageSiteTemplatesConfigurationIcon.java
+++ b/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/portlet/configuration/icon/ManageSiteTemplatesConfigurationIcon.java
@@ -25,7 +25,7 @@ import com.liferay.portal.kernel.portlet.PortletProviderUtil;
 import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
+import com.liferay.portal.kernel.service.permission.PortalPermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.site.admin.web.internal.constants.SiteAdminPortletKeys;
@@ -35,6 +35,7 @@ import javax.portlet.PortletResponse;
 import javax.portlet.PortletURL;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Eudaldo Alonso
@@ -100,7 +101,7 @@ public class ManageSiteTemplatesConfigurationIcon
 		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		if (PortalPermissionUtil.contains(
+		if (_portalPermission.contains(
 				themeDisplay.getPermissionChecker(),
 				ActionKeys.ADD_LAYOUT_SET_PROTOTYPE)) {
 
@@ -112,5 +113,8 @@ public class ManageSiteTemplatesConfigurationIcon
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ManageSiteTemplatesConfigurationIcon.class);
+
+	@Reference
+	private PortalPermission _portalPermission;
 
 }

--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/spi/model/permission/contributor/UserSearchPermissionFilterContributor.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/spi/model/permission/contributor/UserSearchPermissionFilterContributor.java
@@ -27,7 +27,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.UserBag;
 import com.liferay.portal.kernel.service.ContactLocalService;
-import com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil;
+import com.liferay.portal.kernel.service.permission.OrganizationPermission;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.search.spi.model.permission.SearchPermissionFilterContributor;
 
@@ -72,7 +72,7 @@ public class UserSearchPermissionFilterContributor
 			long[] userOrgIds = userBag.getUserOrgIds();
 
 			for (long userOrgId : userOrgIds) {
-				if (OrganizationPermissionUtil.contains(
+				if (_organizationPermission.contains(
 						permissionChecker, userOrgId,
 						ActionKeys.MANAGE_USERS)) {
 
@@ -123,6 +123,9 @@ public class UserSearchPermissionFilterContributor
 
 	@Reference
 	private ContactLocalService _contactLocalService;
+
+	@Reference
+	private OrganizationPermission _organizationPermission;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/MyOrganizationsPortlet.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/MyOrganizationsPortlet.java
@@ -18,7 +18,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
-import com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil;
+import com.liferay.portal.kernel.service.permission.OrganizationPermission;
 import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -32,6 +32,7 @@ import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Jorge Ferrer
@@ -79,7 +80,7 @@ public class MyOrganizationsPortlet extends UsersAdminPortlet {
 						"parentOrganizationSearchContainerPrimaryKeys");
 
 					if (parentOrganizationId > 0) {
-						OrganizationPermissionUtil.check(
+						_organizationPermission.check(
 							PermissionThreadLocal.getPermissionChecker(),
 							parentOrganizationId, ActionKeys.ADD_ORGANIZATION);
 					}
@@ -109,5 +110,8 @@ public class MyOrganizationsPortlet extends UsersAdminPortlet {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		MyOrganizationsPortlet.class);
+
+	@Reference
+	private OrganizationPermission _organizationPermission;
 
 }

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/MyOrganizationsPortlet.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/MyOrganizationsPortlet.java
@@ -19,7 +19,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.permission.OrganizationPermission;
-import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
+import com.liferay.portal.kernel.service.permission.PortalPermission;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.users.admin.constants.UsersAdminPortletKeys;
@@ -85,7 +85,7 @@ public class MyOrganizationsPortlet extends UsersAdminPortlet {
 							parentOrganizationId, ActionKeys.ADD_ORGANIZATION);
 					}
 					else {
-						PortalPermissionUtil.check(
+						_portalPermission.check(
 							PermissionThreadLocal.getPermissionChecker(),
 							ActionKeys.ADD_ORGANIZATION);
 					}
@@ -113,5 +113,8 @@ public class MyOrganizationsPortlet extends UsersAdminPortlet {
 
 	@Reference
 	private OrganizationPermission _organizationPermission;
+
+	@Reference
+	private PortalPermission _portalPermission;
 
 }

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/UsersControlPanelEntry.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/UsersControlPanelEntry.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
-import com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil;
+import com.liferay.portal.kernel.service.permission.OrganizationPermission;
 import com.liferay.users.admin.constants.UsersAdminPortletKeys;
 
 import java.util.List;
@@ -73,16 +73,16 @@ public class UsersControlPanelEntry extends BaseControlPanelEntry {
 				permissionChecker.getUserId());
 
 		for (Organization organization : organizations) {
-			if (OrganizationPermissionUtil.contains(
+			if (_organizationPermission.contains(
 					permissionChecker, organization, ActionKeys.MANAGE_USERS) ||
-				OrganizationPermissionUtil.contains(
+				_organizationPermission.contains(
 					permissionChecker, organization,
 					ActionKeys.MANAGE_SUBORGANIZATIONS)) {
 
 				return true;
 			}
 
-			/*if (OrganizationPermissionUtil.contains(
+			/*if (_organizationPermission.contains(
 					permissionChecker, organization.getOrganizationId(),
 					ActionKeys.VIEW)) {
 
@@ -109,6 +109,10 @@ public class UsersControlPanelEntry extends BaseControlPanelEntry {
 	}
 
 	private OrganizationLocalService _organizationLocalService;
+
+	@Reference
+	private OrganizationPermission _organizationPermission;
+
 	private UserGroupRoleLocalService _userGroupRoleLocalService;
 
 }

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/EditProfileAndDashboardMVCActionCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/EditProfileAndDashboardMVCActionCommand.java
@@ -22,7 +22,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
-import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
+import com.liferay.portal.kernel.service.permission.PortalPermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -68,7 +68,7 @@ public class EditProfileAndDashboardMVCActionCommand
 
 		if (GroupPermissionUtil.contains(
 				permissionChecker, group.getGroupId(), ActionKeys.UPDATE) &&
-			PortalPermissionUtil.contains(
+			_portalPermission.contains(
 				permissionChecker, ActionKeys.UNLINK_LAYOUT_SET_PROTOTYPE)) {
 
 			long publicLayoutSetPrototypeId = ParamUtil.getLong(
@@ -101,6 +101,9 @@ public class EditProfileAndDashboardMVCActionCommand
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private PortalPermission _portalPermission;
 
 	@Reference
 	private Sites _sites;

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/ExportUsersMVCResourceCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/ExportUsersMVCResourceCommand.java
@@ -29,7 +29,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
+import com.liferay.portal.kernel.service.permission.PortalPermission;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.servlet.SessionMessages;
@@ -165,7 +165,7 @@ public class ExportUsersMVCResourceCommand extends BaseMVCResourceCommand {
 		PermissionChecker permissionChecker =
 			themeDisplay.getPermissionChecker();
 
-		boolean exportAllUsers = PortalPermissionUtil.contains(
+		boolean exportAllUsers = _portalPermission.contains(
 			permissionChecker, ActionKeys.EXPORT_USER);
 
 		if (!exportAllUsers &&
@@ -280,6 +280,9 @@ public class ExportUsersMVCResourceCommand extends BaseMVCResourceCommand {
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private PortalPermission _portalPermission;
 
 	private UserLocalService _userLocalService;
 

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/UpdateContactInformationMVCActionCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/UpdateContactInformationMVCActionCommand.java
@@ -50,7 +50,7 @@ import com.liferay.portal.kernel.service.PhoneService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.WebsiteLocalService;
 import com.liferay.portal.kernel.service.WebsiteService;
-import com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil;
+import com.liferay.portal.kernel.service.permission.OrganizationPermission;
 import com.liferay.portal.kernel.service.permission.UserPermissionUtil;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -163,7 +163,7 @@ public class UpdateContactInformationMVCActionCommand
 		throws PortalException {
 
 		if (Objects.equals(className, Organization.class.getName())) {
-			OrganizationPermissionUtil.check(
+			_organizationPermission.check(
 				permissionChecker, classPK, ActionKeys.UPDATE);
 		}
 		else {
@@ -251,6 +251,9 @@ public class UpdateContactInformationMVCActionCommand
 
 	@Reference
 	private EmailAddressService _emailAddressService;
+
+	@Reference
+	private OrganizationPermission _organizationPermission;
 
 	@Reference
 	private OrgLaborLocalService _orgLaborLocalService;

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/UpdateOrganizationAddressesMVCActionCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/UpdateOrganizationAddressesMVCActionCommand.java
@@ -28,7 +28,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.OrganizationService;
-import com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil;
+import com.liferay.portal.kernel.service.permission.OrganizationPermission;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -105,7 +105,7 @@ public class UpdateOrganizationAddressesMVCActionCommand
 		long organizationId = ParamUtil.getLong(
 			actionRequest, "organizationId");
 
-		OrganizationPermissionUtil.check(
+		_organizationPermission.check(
 			themeDisplay.getPermissionChecker(),
 			_organizationService.getOrganization(organizationId),
 			ActionKeys.UPDATE);
@@ -117,6 +117,9 @@ public class UpdateOrganizationAddressesMVCActionCommand
 				Organization.class.getName(), organizationId, addresses);
 		}
 	}
+
+	@Reference
+	private OrganizationPermission _organizationPermission;
 
 	@Reference
 	private OrganizationService _organizationService;

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/UpdateOrganizationReminderQueriesMVCActionCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/UpdateOrganizationReminderQueriesMVCActionCommand.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.OrganizationService;
-import com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil;
+import com.liferay.portal.kernel.service.permission.OrganizationPermission;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -87,7 +87,7 @@ public class UpdateOrganizationReminderQueriesMVCActionCommand
 		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		OrganizationPermissionUtil.check(
+		_organizationPermission.check(
 			themeDisplay.getPermissionChecker(), organization,
 			ActionKeys.UPDATE);
 
@@ -102,6 +102,9 @@ public class UpdateOrganizationReminderQueriesMVCActionCommand
 
 		portletPreferences.store();
 	}
+
+	@Reference
+	private OrganizationPermission _organizationPermission;
 
 	@Reference
 	private OrganizationService _organizationService;

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/UpdateUserRolesMVCActionCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/UpdateUserRolesMVCActionCommand.java
@@ -37,7 +37,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserService;
-import com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil;
+import com.liferay.portal.kernel.service.permission.OrganizationPermission;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -219,7 +219,7 @@ public class UpdateUserRolesMVCActionCommand extends BaseMVCActionCommand {
 			}
 
 			if ((organizationId > 0) &&
-				!OrganizationPermissionUtil.contains(
+				!_organizationPermission.contains(
 					permissionChecker, organizationId, ActionKeys.VIEW)) {
 
 				PortletURL portletURL = _portal.getControlPanelPortletURL(
@@ -260,6 +260,9 @@ public class UpdateUserRolesMVCActionCommand extends BaseMVCActionCommand {
 
 	@Reference
 	private Http _http;
+
+	@Reference
+	private OrganizationPermission _organizationPermission;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/configuration/icon/AssignOrganizationRolesPortletConfigurationIcon.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/configuration/icon/AssignOrganizationRolesPortletConfigurationIcon.java
@@ -29,7 +29,7 @@ import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigura
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil;
+import com.liferay.portal.kernel.service.permission.OrganizationPermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -42,6 +42,7 @@ import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Pei-Jung Lan
@@ -117,7 +118,7 @@ public class AssignOrganizationRolesPortletConfigurationIcon
 			long organizationGroupId = organization.getGroupId();
 
 			if (permissionChecker.isGroupOwner(organizationGroupId) ||
-				OrganizationPermissionUtil.contains(
+				_organizationPermission.contains(
 					permissionChecker, organization,
 					ActionKeys.ASSIGN_USER_ROLES)) {
 
@@ -140,5 +141,8 @@ public class AssignOrganizationRolesPortletConfigurationIcon
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		AssignOrganizationRolesPortletConfigurationIcon.class);
+
+	@Reference
+	private OrganizationPermission _organizationPermission;
 
 }

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/configuration/icon/DeleteOrganizationPortletConfigurationIcon.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/configuration/icon/DeleteOrganizationPortletConfigurationIcon.java
@@ -22,7 +22,7 @@ import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil;
+import com.liferay.portal.kernel.service.permission.OrganizationPermission;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HtmlUtil;
@@ -37,6 +37,7 @@ import javax.portlet.PortletResponse;
 import javax.portlet.RenderResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Pei-Jung Lan
@@ -123,7 +124,7 @@ public class DeleteOrganizationPortletConfigurationIcon
 			WebKeys.THEME_DISPLAY);
 
 		try {
-			if (OrganizationPermissionUtil.contains(
+			if (_organizationPermission.contains(
 					themeDisplay.getPermissionChecker(),
 					ActionUtil.getOrganization(portletRequest),
 					ActionKeys.DELETE)) {
@@ -142,5 +143,8 @@ public class DeleteOrganizationPortletConfigurationIcon
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DeleteOrganizationPortletConfigurationIcon.class);
+
+	@Reference
+	private OrganizationPermission _organizationPermission;
 
 }

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/configuration/icon/EditOrganizationPortletConfigurationIcon.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/configuration/icon/EditOrganizationPortletConfigurationIcon.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil;
+import com.liferay.portal.kernel.service.permission.OrganizationPermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -102,7 +102,7 @@ public class EditOrganizationPortletConfigurationIcon
 			WebKeys.THEME_DISPLAY);
 
 		try {
-			if (OrganizationPermissionUtil.contains(
+			if (_organizationPermission.contains(
 					themeDisplay.getPermissionChecker(),
 					ActionUtil.getOrganization(portletRequest),
 					ActionKeys.UPDATE)) {
@@ -121,6 +121,9 @@ public class EditOrganizationPortletConfigurationIcon
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		EditOrganizationPortletConfigurationIcon.class);
+
+	@Reference
+	private OrganizationPermission _organizationPermission;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/configuration/icon/ExportUsersPortletConfigurationIcon.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/configuration/icon/ExportUsersPortletConfigurationIcon.java
@@ -22,7 +22,7 @@ import com.liferay.portal.kernel.portlet.configuration.icon.BaseJSPPortletConfig
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
+import com.liferay.portal.kernel.service.permission.PortalPermission;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
@@ -83,7 +83,7 @@ public class ExportUsersPortletConfigurationIcon
 		PermissionChecker permissionChecker =
 			themeDisplay.getPermissionChecker();
 
-		if (PortalPermissionUtil.contains(
+		if (_portalPermission.contains(
 				permissionChecker, ActionKeys.EXPORT_USER)) {
 
 			return true;
@@ -117,5 +117,8 @@ public class ExportUsersPortletConfigurationIcon
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ExportUsersPortletConfigurationIcon.class);
+
+	@Reference
+	private PortalPermission _portalPermission;
 
 }

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/configuration/icon/ManageSitePortletConfigurationIcon.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/configuration/icon/ManageSitePortletConfigurationIcon.java
@@ -28,7 +28,7 @@ import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfiguration
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
-import com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil;
+import com.liferay.portal.kernel.service.permission.OrganizationPermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
@@ -117,7 +117,7 @@ public class ManageSitePortletConfigurationIcon
 				(GroupPermissionUtil.contains(
 					permissionChecker, organizationGroup,
 					ActionKeys.MANAGE_STAGING) ||
-				 OrganizationPermissionUtil.contains(
+				 _organizationPermission.contains(
 					 permissionChecker, organization, ActionKeys.UPDATE))) {
 
 				return true;
@@ -134,6 +134,9 @@ public class ManageSitePortletConfigurationIcon
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ManageSitePortletConfigurationIcon.class);
+
+	@Reference
+	private OrganizationPermission _organizationPermission;
 
 	@Reference
 	private Portal _portal;

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -513,6 +513,7 @@
         com.liferay.portal.kernel.dao.jdbc.CurrentConnectionUtil,\
         com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil,\
         com.liferay.portal.kernel.image.GhostscriptUtil,\
+        com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil,\
         com.liferay.portal.kernel.util.HttpUtil,\
         com.liferay.portal.kernel.util.PortalUtil
 

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -515,6 +515,7 @@
         com.liferay.portal.kernel.image.GhostscriptUtil,\
         com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil,\
         com.liferay.portal.kernel.service.permission.PasswordPolicyPermissionUtil,\
+        com.liferay.portal.kernel.service.permission.PortalPermissionUtil,\
         com.liferay.portal.kernel.util.HttpUtil,\
         com.liferay.portal.kernel.util.PortalUtil
 

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -514,6 +514,7 @@
         com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil,\
         com.liferay.portal.kernel.image.GhostscriptUtil,\
         com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil,\
+        com.liferay.portal.kernel.service.permission.PasswordPolicyPermissionUtil,\
         com.liferay.portal.kernel.util.HttpUtil,\
         com.liferay.portal.kernel.util.PortalUtil
 


### PR DESCRIPTION
Hi Tina,

Main Task: [LPS-143403](https://issues.liferay.com/browse/LPS-143403)
Sub Task 8: [LPS-143635](https://issues.liferay.com/browse/LPS-143635)
Removes OrganizationPermissionUtil, PasswordPolicyPermissionUtil, and PortalPermissionUtil from modules components

Note: from sub task 6 and onwards, tasks no longer depend on previous tasks.

Thank you!