### PR TITLE
LPS-143636 Avoid using RolePermissionUtil, UserGroupPermissionUtil directly in modules

### DIFF
--- a/modules/apps/portal-template/portal-template-velocity/src/main/java/com/liferay/portal/template/velocity/internal/helper/VelocityTemplateContextHelper.java
+++ b/modules/apps/portal-template/portal-template-velocity/src/main/java/com/liferay/portal/template/velocity/internal/helper/VelocityTemplateContextHelper.java
@@ -18,7 +18,7 @@ import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Theme;
-import com.liferay.portal.kernel.service.permission.RolePermissionUtil;
+import com.liferay.portal.kernel.service.permission.RolePermission;
 import com.liferay.portal.kernel.template.TemplateContextContributor;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -184,8 +184,7 @@ public class VelocityTemplateContextHelper extends TemplateContextHelper {
 		// Permissions
 
 		try {
-			velocityContext.put(
-				"rolePermission", RolePermissionUtil.getRolePermission());
+			velocityContext.put("rolePermission", _rolePermission);
 		}
 		catch (SecurityException securityException) {
 			_log.error(securityException, securityException);
@@ -215,6 +214,9 @@ public class VelocityTemplateContextHelper extends TemplateContextHelper {
 
 	private static volatile VelocityEngineConfiguration
 		_velocityEngineConfiguration;
+
+	@Reference
+	private RolePermission _rolePermission;
 
 	private final List<TemplateContextContributor>
 		_templateContextContributors = new ArrayList<>();

--- a/modules/apps/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/portlet/configuration/icon/DeleteRolePortletConfigurationIcon.java
+++ b/modules/apps/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/portlet/configuration/icon/DeleteRolePortletConfigurationIcon.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigura
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.RoleService;
-import com.liferay.portal.kernel.service.permission.RolePermissionUtil;
+import com.liferay.portal.kernel.service.permission.RolePermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -109,7 +109,7 @@ public class DeleteRolePortletConfigurationIcon
 					portletRequest);
 
 			if (currentRoleTypeContributor.isAllowDelete(role) &&
-				RolePermissionUtil.contains(
+				_rolePermission.contains(
 					themeDisplay.getPermissionChecker(), roleId,
 					ActionKeys.DELETE)) {
 
@@ -140,6 +140,9 @@ public class DeleteRolePortletConfigurationIcon
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private RolePermission _rolePermission;
 
 	private RoleService _roleService;
 

--- a/modules/apps/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
+++ b/modules/apps/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
@@ -25,7 +25,7 @@ import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigura
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.RoleService;
-import com.liferay.portal.kernel.service.permission.RolePermissionUtil;
+import com.liferay.portal.kernel.service.permission.RolePermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -115,7 +115,7 @@ public class PermissionsPortletConfigurationIcon
 			String roleName = role.getName();
 
 			if (!roleName.equals(RoleConstants.OWNER) &&
-				RolePermissionUtil.contains(
+				_rolePermission.contains(
 					themeDisplay.getPermissionChecker(), roleId,
 					ActionKeys.PERMISSIONS)) {
 
@@ -153,6 +153,9 @@ public class PermissionsPortletConfigurationIcon
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private RolePermission _rolePermission;
 
 	private RoleService _roleService;
 

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/java/com/liferay/user/groups/admin/web/internal/portlet/configuration/icon/AssignMembersPortletConfigurationIcon.java
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/java/com/liferay/user/groups/admin/web/internal/portlet/configuration/icon/AssignMembersPortletConfigurationIcon.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.service.permission.UserGroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.UserGroupPermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -104,7 +104,7 @@ public class AssignMembersPortletConfigurationIcon
 
 			UserGroup userGroup = ActionUtil.getUserGroup(portletRequest);
 
-			return UserGroupPermissionUtil.contains(
+			return _userGroupPermission.contains(
 				themeDisplay.getPermissionChecker(), userGroup.getUserGroupId(),
 				ActionKeys.ASSIGN_MEMBERS);
 		}
@@ -122,5 +122,8 @@ public class AssignMembersPortletConfigurationIcon
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private UserGroupPermission _userGroupPermission;
 
 }

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/java/com/liferay/user/groups/admin/web/internal/portlet/configuration/icon/DeleteUserGroupPortletConfigurationIcon.java
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/java/com/liferay/user/groups/admin/web/internal/portlet/configuration/icon/DeleteUserGroupPortletConfigurationIcon.java
@@ -22,7 +22,7 @@ import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.service.permission.UserGroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.UserGroupPermission;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -33,6 +33,7 @@ import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Pei-Jung Lan
@@ -108,7 +109,7 @@ public class DeleteUserGroupPortletConfigurationIcon
 
 			UserGroup userGroup = ActionUtil.getUserGroup(portletRequest);
 
-			return UserGroupPermissionUtil.contains(
+			return _userGroupPermission.contains(
 				themeDisplay.getPermissionChecker(), userGroup.getUserGroupId(),
 				ActionKeys.DELETE);
 		}
@@ -123,5 +124,8 @@ public class DeleteUserGroupPortletConfigurationIcon
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DeleteUserGroupPortletConfigurationIcon.class);
+
+	@Reference
+	private UserGroupPermission _userGroupPermission;
 
 }

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/java/com/liferay/user/groups/admin/web/internal/portlet/configuration/icon/EditUserGroupPortletConfigurationIcon.java
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/java/com/liferay/user/groups/admin/web/internal/portlet/configuration/icon/EditUserGroupPortletConfigurationIcon.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.service.permission.UserGroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.UserGroupPermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -104,10 +104,10 @@ public class EditUserGroupPortletConfigurationIcon
 
 			UserGroup userGroup = ActionUtil.getUserGroup(portletRequest);
 
-			if (UserGroupPermissionUtil.contains(
+			if (_userGroupPermission.contains(
 					themeDisplay.getPermissionChecker(),
 					userGroup.getUserGroupId(), ActionKeys.UPDATE) &&
-				UserGroupPermissionUtil.contains(
+				_userGroupPermission.contains(
 					themeDisplay.getPermissionChecker(),
 					userGroup.getUserGroupId(), ActionKeys.VIEW)) {
 
@@ -130,5 +130,8 @@ public class EditUserGroupPortletConfigurationIcon
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private UserGroupPermission _userGroupPermission;
 
 }

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/java/com/liferay/user/groups/admin/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/java/com/liferay/user/groups/admin/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
@@ -23,7 +23,7 @@ import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.service.permission.UserGroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.UserGroupPermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.security.PermissionsURLTag;
@@ -34,6 +34,7 @@ import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Pei-Jung Lan
@@ -97,7 +98,7 @@ public class PermissionsPortletConfigurationIcon
 
 			UserGroup userGroup = ActionUtil.getUserGroup(portletRequest);
 
-			return UserGroupPermissionUtil.contains(
+			return _userGroupPermission.contains(
 				themeDisplay.getPermissionChecker(), userGroup.getUserGroupId(),
 				ActionKeys.PERMISSIONS);
 		}
@@ -117,5 +118,8 @@ public class PermissionsPortletConfigurationIcon
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		PermissionsPortletConfigurationIcon.class);
+
+	@Reference
+	private UserGroupPermission _userGroupPermission;
 
 }

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/java/com/liferay/portal/workflow/kaleo/designer/web/internal/portlet/KaleoDesignerPortlet.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/java/com/liferay/portal/workflow/kaleo/designer/web/internal/portlet/KaleoDesignerPortlet.java
@@ -37,7 +37,7 @@ import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.service.permission.RolePermissionUtil;
+import com.liferay.portal.kernel.service.permission.RolePermission;
 import com.liferay.portal.kernel.service.permission.UserPermissionUtil;
 import com.liferay.portal.kernel.servlet.MultiSessionMessages;
 import com.liferay.portal.kernel.servlet.SessionErrors;
@@ -363,7 +363,7 @@ public class KaleoDesignerPortlet extends MVCPortlet {
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
 		for (Role role : roles) {
-			if (!RolePermissionUtil.contains(
+			if (!_rolePermission.contains(
 					themeDisplay.getPermissionChecker(), role.getRoleId(),
 					ActionKeys.VIEW)) {
 
@@ -556,6 +556,9 @@ public class KaleoDesignerPortlet extends MVCPortlet {
 
 	@Reference
 	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private RolePermission _rolePermission;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -513,6 +513,7 @@
         com.liferay.portal.kernel.dao.jdbc.CurrentConnectionUtil,\
         com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil,\
         com.liferay.portal.kernel.image.GhostscriptUtil,\
+        com.liferay.portal.kernel.service.permission.RolePermissionUtil,\
         com.liferay.portal.kernel.util.HttpUtil,\
         com.liferay.portal.kernel.util.PortalUtil
 

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -514,6 +514,7 @@
         com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil,\
         com.liferay.portal.kernel.image.GhostscriptUtil,\
         com.liferay.portal.kernel.service.permission.RolePermissionUtil,\
+        com.liferay.portal.kernel.service.permission.UserGroupPermissionUtil,\
         com.liferay.portal.kernel.util.HttpUtil,\
         com.liferay.portal.kernel.util.PortalUtil
 


### PR DESCRIPTION
Hi Tina,

Main Task: [LPS-143403](https://issues.liferay.com/browse/LPS-143403)
Sub Task 9: [LPS-143636](https://issues.liferay.com/browse/LPS-143636)
Removes RolePermissionUtil and UserGroupPermissionUtil from modules components

Note: from sub task 6 and onwards, tasks no longer depend on previous tasks.

Thank you!