### PR TITLE
LPS-145575 Avoid using FileUtil directly in modules

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/portlet/action/EditAccountEntryMVCActionCommand.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/portlet/action/EditAccountEntryMVCActionCommand.java
@@ -35,7 +35,7 @@ import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.Constants;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -219,7 +219,7 @@ public class EditAccountEntryMVCActionCommand extends BaseMVCActionCommand {
 
 		FileEntry fileEntry = _dlAppLocalService.getFileEntry(fileEntryId);
 
-		return FileUtil.getBytes(fileEntry.getContentStream());
+		return _file.getBytes(fileEntry.getContentStream());
 	}
 
 	private int _getStatus(ActionRequest actionRequest) {
@@ -247,6 +247,9 @@ public class EditAccountEntryMVCActionCommand extends BaseMVCActionCommand {
 
 	@Reference
 	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private Http _http;

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMGIFImageScaler.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/scaler/AMGIFImageScaler.java
@@ -30,7 +30,6 @@ import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.portal.kernel.repository.model.FileVersion;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.awt.image.RenderedImage;
@@ -46,6 +45,7 @@ import java.util.concurrent.Future;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Sergio González
@@ -118,7 +118,7 @@ public class AMGIFImageScaler implements AMImageScaler {
 		throws IOException, PortalException {
 
 		try (InputStream inputStream = fileVersion.getContentStream(false)) {
-			return FileUtil.createTempFile(inputStream);
+			return _file.createTempFile(inputStream);
 		}
 	}
 
@@ -148,5 +148,8 @@ public class AMGIFImageScaler implements AMImageScaler {
 	}
 
 	private volatile AMImageConfiguration _amImageConfiguration;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 }

--- a/modules/apps/analytics/analytics-message-sender-impl/src/main/java/com/liferay/analytics/message/sender/internal/AnalyticsBatchClientImpl.java
+++ b/modules/apps/analytics/analytics-message-sender-impl/src/main/java/com/liferay/analytics/message/sender/internal/AnalyticsBatchClientImpl.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 
 import java.io.File;
 import java.io.InputStream;
@@ -46,6 +45,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.util.EntityUtils;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Riccardo Ferrari
@@ -103,7 +103,7 @@ public class AnalyticsBatchClientImpl
 			HttpEntity httpEntity = closeableHttpResponse.getEntity();
 
 			if (httpEntity != null) {
-				return FileUtil.createTempFile(httpEntity.getContent());
+				return _file.createTempFile(httpEntity.getContent());
 			}
 		}
 		catch (Exception exception) {
@@ -198,5 +198,8 @@ public class AnalyticsBatchClientImpl
 	private static final Format _modifiedSinceHeaderDateFormatter =
 		FastDateFormatFactoryUtil.getSimpleDateFormat(
 			"EEE, dd MMM yyyy HH:mm:ss zzz");
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 }

--- a/modules/apps/archived/html-preview-processor-image/src/main/java/com/liferay/html/preview/processor/image/internal/ImageHtmlPreviewProcessor.java
+++ b/modules/apps/archived/html-preview-processor-image/src/main/java/com/liferay/html/preview/processor/image/internal/ImageHtmlPreviewProcessor.java
@@ -18,7 +18,6 @@ import com.liferay.html.preview.processor.HtmlPreviewProcessor;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
-import com.liferay.portal.kernel.util.FileUtil;
 
 import java.awt.image.BufferedImage;
 
@@ -29,6 +28,7 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Entities;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 import org.xhtmlrenderer.swing.Java2DRenderer;
 import org.xhtmlrenderer.util.FSImageWriter;
@@ -48,7 +48,7 @@ public class ImageHtmlPreviewProcessor implements HtmlPreviewProcessor {
 	@Override
 	public File generateContentHtmlPreview(String content, int width) {
 		try {
-			File tempFile = FileUtil.createTempFile();
+			File tempFile = _file.createTempFile();
 
 			Document document = Jsoup.parse(content);
 
@@ -57,7 +57,7 @@ public class ImageHtmlPreviewProcessor implements HtmlPreviewProcessor {
 			outputSettings.syntax(Document.OutputSettings.Syntax.xml);
 			outputSettings.escapeMode(Entities.EscapeMode.xhtml);
 
-			FileUtil.write(tempFile, document.html());
+			_file.write(tempFile, document.html());
 
 			return _getFile(new Java2DRenderer(tempFile, width));
 		}
@@ -97,7 +97,7 @@ public class ImageHtmlPreviewProcessor implements HtmlPreviewProcessor {
 	private File _getFile(Java2DRenderer renderer) throws Exception {
 		renderer.setBufferedImageType(BufferedImage.TYPE_INT_RGB);
 
-		File outputFile = FileUtil.createTempFile("png");
+		File outputFile = _file.createTempFile("png");
 
 		FSImageWriter imageWriter = new FSImageWriter();
 
@@ -108,5 +108,8 @@ public class ImageHtmlPreviewProcessor implements HtmlPreviewProcessor {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ImageHtmlPreviewProcessor.class);
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 }

--- a/modules/apps/archived/mail-reader-service/src/main/java/com/liferay/mail/reader/service/impl/AttachmentLocalServiceImpl.java
+++ b/modules/apps/archived/mail-reader-service/src/main/java/com/liferay/mail/reader/service/impl/AttachmentLocalServiceImpl.java
@@ -27,7 +27,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.util.FileUtil;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -37,6 +36,7 @@ import java.io.InputStream;
 import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Scott Lee
@@ -145,9 +145,9 @@ public class AttachmentLocalServiceImpl extends AttachmentLocalServiceBaseImpl {
 	@Override
 	public File getFile(long attachmentId) throws PortalException {
 		try {
-			File file = FileUtil.createTempFile();
+			File file = _file.createTempFile();
 
-			FileUtil.write(file, getInputStream(attachmentId));
+			_file.write(file, getInputStream(attachmentId));
 
 			return file;
 		}
@@ -185,5 +185,8 @@ public class AttachmentLocalServiceImpl extends AttachmentLocalServiceBaseImpl {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		AttachmentLocalServiceImpl.class);
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 }

--- a/modules/apps/archived/sync-service/src/main/java/com/liferay/sync/internal/servlet/SyncDownloadServlet.java
+++ b/modules/apps/archived/sync-service/src/main/java/com/liferay/sync/internal/servlet/SyncDownloadServlet.java
@@ -43,7 +43,6 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.servlet.PortalSessionThreadLocal;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
@@ -282,14 +281,14 @@ public class SyncDownloadServlet extends HttpServlet {
 		DLFileVersion sourceDLFileVersion =
 			_dlFileVersionLocalService.getDLFileVersion(sourceVersionId);
 
-		File sourceFile = FileUtil.createTempFile(
+		File sourceFile = _file.createTempFile(
 			_dlFileEntryLocalService.getFileAsStream(
 				fileEntryId, sourceDLFileVersion.getVersion(), false));
 
 		DLFileVersion targetDLFileVersion =
 			_dlFileVersionLocalService.getDLFileVersion(targetVersionId);
 
-		File targetFile = FileUtil.createTempFile(
+		File targetFile = _file.createTempFile(
 			_dlFileEntryLocalService.getFileAsStream(
 				fileEntryId, targetDLFileVersion.getVersion(), false));
 
@@ -364,7 +363,7 @@ public class SyncDownloadServlet extends HttpServlet {
 					new FileInputStream(deltaFile), deltaFile.length());
 			}
 			finally {
-				FileUtil.delete(deltaFile);
+				_file.delete(deltaFile);
 			}
 		}
 
@@ -398,7 +397,7 @@ public class SyncDownloadServlet extends HttpServlet {
 				new FileInputStream(deltaFile), deltaFile.length());
 		}
 		finally {
-			FileUtil.delete(deltaFile);
+			_file.delete(deltaFile);
 		}
 	}
 
@@ -575,6 +574,10 @@ public class SyncDownloadServlet extends HttpServlet {
 	private DLAppService _dlAppService;
 	private DLFileEntryLocalService _dlFileEntryLocalService;
 	private DLFileVersionLocalService _dlFileVersionLocalService;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
+
 	private GroupLocalService _groupLocalService;
 
 	@Reference

--- a/modules/apps/archived/sync-service/src/main/java/com/liferay/sync/internal/util/SyncHelperImpl.java
+++ b/modules/apps/archived/sync-service/src/main/java/com/liferay/sync/internal/util/SyncHelperImpl.java
@@ -46,7 +46,6 @@ import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.ClassUtil;
 import com.liferay.portal.kernel.util.Digester;
 import com.liferay.portal.kernel.util.DigesterUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PrefsPropsUtil;
 import com.liferay.portal.kernel.util.PwdGenerator;
@@ -344,7 +343,7 @@ public class SyncHelperImpl implements SyncHelper {
 	public File getFileDelta(File sourceFile, File targetFile)
 		throws PortalException {
 
-		File checksumsFile = FileUtil.createTempFile();
+		File checksumsFile = _file.createTempFile();
 
 		try (FileInputStream sourceFileInputStream = new FileInputStream(
 				sourceFile);
@@ -365,7 +364,7 @@ public class SyncHelperImpl implements SyncHelper {
 			throw new PortalException(exception);
 		}
 
-		File deltaFile = FileUtil.createTempFile();
+		File deltaFile = _file.createTempFile();
 
 		try (FileInputStream targetFileInputStream = new FileInputStream(
 				targetFile);
@@ -395,7 +394,7 @@ public class SyncHelperImpl implements SyncHelper {
 			throw new PortalException(exception);
 		}
 		finally {
-			FileUtil.delete(checksumsFile);
+			_file.delete(checksumsFile);
 		}
 
 		return deltaFile;
@@ -730,6 +729,10 @@ public class SyncHelperImpl implements SyncHelper {
 
 	private final Map<String, String> _checksums = new ConcurrentHashMap<>();
 	private DLFileVersionLocalService _dlFileVersionLocalService;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
+
 	private GroupLocalService _groupLocalService;
 	private final Map<String, String> _lanTokenKeys = new ConcurrentHashMap<>();
 	private final Provider _provider = new BouncyCastleProvider();

--- a/modules/apps/archived/sync-service/src/main/java/com/liferay/sync/service/impl/SyncDLObjectLocalServiceImpl.java
+++ b/modules/apps/archived/sync-service/src/main/java/com/liferay/sync/service/impl/SyncDLObjectLocalServiceImpl.java
@@ -33,7 +33,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.sync.constants.SyncDLObjectConstants;
@@ -176,7 +176,7 @@ public class SyncDLObjectLocalServiceImpl
 					SyncDLObjectConstants.TYPE_FOLDER,
 					syncDLObject.getParentFolderId());
 
-			String parentFolderExtension = FileUtil.getExtension(
+			String parentFolderExtension = _file.getExtension(
 				parentFolderSyncDLObject.getName());
 
 			if (ArrayUtil.contains(
@@ -415,6 +415,9 @@ public class SyncDLObjectLocalServiceImpl
 
 	@Reference
 	private DLFolderLocalService _dlFolderLocalService;
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private SyncDLFileVersionDiffLocalService

--- a/modules/apps/archived/sync-service/src/main/java/com/liferay/sync/service/impl/SyncDLObjectServiceImpl.java
+++ b/modules/apps/archived/sync-service/src/main/java/com/liferay/sync/service/impl/SyncDLObjectServiceImpl.java
@@ -68,7 +68,6 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Constants;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
@@ -1001,11 +1000,11 @@ public class SyncDLObjectServiceImpl extends SyncDLObjectServiceBaseImpl {
 			DLFileVersion dlFileVersion =
 				_dlFileVersionLocalService.getDLFileVersion(sourceVersionId);
 
-			sourceFile = FileUtil.createTempFile(
+			sourceFile = _file.createTempFile(
 				_dlFileEntryLocalService.getFileAsStream(
 					fileEntryId, dlFileVersion.getVersion(), false));
 
-			patchedFile = FileUtil.createTempFile();
+			patchedFile = _file.createTempFile();
 
 			_syncHelper.patchFile(sourceFile, deltaFile, patchedFile);
 
@@ -1032,9 +1031,9 @@ public class SyncDLObjectServiceImpl extends SyncDLObjectServiceBaseImpl {
 				_syncHelper.buildExceptionMessage(exception), exception);
 		}
 		finally {
-			FileUtil.delete(sourceFile);
+			_file.delete(sourceFile);
 
-			FileUtil.delete(patchedFile);
+			_file.delete(patchedFile);
 		}
 	}
 
@@ -1651,7 +1650,7 @@ public class SyncDLObjectServiceImpl extends SyncDLObjectServiceBaseImpl {
 			File tempFile = null;
 
 			try {
-				tempFile = FileUtil.createTempFile(inputStream);
+				tempFile = _file.createTempFile(inputStream);
 
 				String checksum = MapUtil.getString(
 					jsonWebServiceActionParametersMap, "checksum");
@@ -1661,7 +1660,7 @@ public class SyncDLObjectServiceImpl extends SyncDLObjectServiceBaseImpl {
 					description, changeLog, tempFile, checksum, serviceContext);
 			}
 			finally {
-				FileUtil.delete(tempFile);
+				_file.delete(tempFile);
 			}
 		}
 		else if (urlPath.endsWith("/add-folder")) {
@@ -1748,7 +1747,7 @@ public class SyncDLObjectServiceImpl extends SyncDLObjectServiceBaseImpl {
 			File tempFile = null;
 
 			try {
-				tempFile = FileUtil.createTempFile(inputStream);
+				tempFile = _file.createTempFile(inputStream);
 
 				String checksum = MapUtil.getString(
 					jsonWebServiceActionParametersMap, "checksum");
@@ -1759,7 +1758,7 @@ public class SyncDLObjectServiceImpl extends SyncDLObjectServiceBaseImpl {
 					checksum, serviceContext);
 			}
 			finally {
-				FileUtil.delete(tempFile);
+				_file.delete(tempFile);
 			}
 		}
 		else if (urlPath.endsWith("/update-file-entry")) {
@@ -1785,7 +1784,7 @@ public class SyncDLObjectServiceImpl extends SyncDLObjectServiceBaseImpl {
 					zipFileId);
 
 				if (inputStream != null) {
-					tempFile = FileUtil.createTempFile(inputStream);
+					tempFile = _file.createTempFile(inputStream);
 				}
 
 				String checksum = MapUtil.getString(
@@ -1797,7 +1796,7 @@ public class SyncDLObjectServiceImpl extends SyncDLObjectServiceBaseImpl {
 					serviceContext);
 			}
 			finally {
-				FileUtil.delete(tempFile);
+				_file.delete(tempFile);
 			}
 		}
 		else if (urlPath.endsWith("/update-folder")) {
@@ -1847,6 +1846,9 @@ public class SyncDLObjectServiceImpl extends SyncDLObjectServiceBaseImpl {
 
 	@Reference
 	private DLTrashService _dlTrashService;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/archived/web-form-web/src/main/java/com/liferay/web/form/web/internal/portlet/WebFormPortlet.java
+++ b/modules/apps/archived/web-form-web/src/main/java/com/liferay/web/form/web/internal/portlet/WebFormPortlet.java
@@ -41,7 +41,7 @@ import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -513,14 +513,14 @@ public class WebFormPortlet extends MVCPortlet {
 
 		StringBundler sb = new StringBundler();
 
-		if (!FileUtil.exists(fileName)) {
+		if (!_file.exists(fileName)) {
 			_appendFieldLabels(fieldsMap, csvSeparator, sb);
 		}
 
 		_appendFieldValues(fieldsMap, csvSeparator, sb);
 
 		try {
-			FileUtil.write(fileName, sb.toString(), false, true);
+			_file.write(fileName, sb.toString(), false, true);
 
 			return true;
 		}
@@ -641,6 +641,9 @@ public class WebFormPortlet extends MVCPortlet {
 
 	@Reference
 	private ConfigurationProvider _configurationProvider;
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/internal/batch/engine/broker/BatchEngineBrokerImpl.java
+++ b/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/internal/batch/engine/broker/BatchEngineBrokerImpl.java
@@ -35,7 +35,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.multipart.BinaryFile;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
@@ -197,7 +196,7 @@ public class BatchEngineBrokerImpl implements BatchEngineBroker {
 				BatchPlannerLogConstants.STATUS_QUEUED);
 		}
 		finally {
-			FileUtil.delete(file);
+			_file.delete(file);
 		}
 	}
 
@@ -218,6 +217,9 @@ public class BatchEngineBrokerImpl implements BatchEngineBroker {
 
 	@Reference
 	private ExportTaskResource _exportTaskResource;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private ImportTaskResource _importTaskResource;

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/portlet/action/SubmitBatchPlannerPlanMVCResourceCommand.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/portlet/action/SubmitBatchPlannerPlanMVCResourceCommand.java
@@ -25,7 +25,6 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.BaseTransactionalMVCResourc
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.Constants;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 
@@ -127,7 +126,7 @@ public class SubmitBatchPlannerPlanMVCResourceCommand
 					batchPlannerLog.getBatchEngineImportTaskERC()));
 		}
 		finally {
-			FileUtil.delete(importFile);
+			_file.delete(importFile);
 		}
 	}
 
@@ -137,7 +136,7 @@ public class SubmitBatchPlannerPlanMVCResourceCommand
 
 		UUID uuid = UUID.randomUUID();
 
-		File file = FileUtil.createTempFile(uuid.toString(), externalType);
+		File file = _file.createTempFile(uuid.toString(), externalType);
 
 		try {
 			Files.copy(inputStream, file.toPath());
@@ -158,6 +157,9 @@ public class SubmitBatchPlannerPlanMVCResourceCommand
 
 	@Reference
 	private BatchPlannerPlanHelper _batchPlannerPlanHelper;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
+++ b/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
@@ -103,7 +103,7 @@ import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.JavaConstants;
@@ -217,7 +217,7 @@ public class CalendarPortlet extends MVCPortlet {
 		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		String data = FileUtil.read(uploadPortletRequest.getFile("file"));
+		String data = _file.read(uploadPortletRequest.getFile("file"));
 
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
 
@@ -1857,6 +1857,9 @@ public class CalendarPortlet extends MVCPortlet {
 
 	@Reference
 	private CustomSQL _customSQL;
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/commerce/commerce-catalog-web/src/main/java/com/liferay/commerce/catalog/web/internal/upload/CommerceMediaDefaultImageUploadFileEntryHandler.java
+++ b/modules/apps/commerce/commerce-catalog-web/src/main/java/com/liferay/commerce/catalog/web/internal/upload/CommerceMediaDefaultImageUploadFileEntryHandler.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.upload.UniqueFileNameProvider;
@@ -127,7 +127,7 @@ public class CommerceMediaDefaultImageUploadFileEntryHandler
 			throw new CPAttachmentFileEntrySizeException();
 		}
 
-		String extension = FileUtil.getExtension(fileName);
+		String extension = _file.getExtension(fileName);
 
 		String[] imageExtensions = _attachmentsConfiguration.imageExtensions();
 
@@ -152,6 +152,9 @@ public class CommerceMediaDefaultImageUploadFileEntryHandler
 		CommerceMediaDefaultImageUploadFileEntryHandler.class);
 
 	private volatile AttachmentsConfiguration _attachmentsConfiguration;
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private UniqueFileNameProvider _uniqueFileNameProvider;

--- a/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/BlogsImporter.java
+++ b/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/BlogsImporter.java
@@ -29,7 +29,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
 
 import java.io.InputStream;
@@ -143,7 +143,7 @@ public class BlogsImporter {
 			imageDependenciesPath + fileName);
 
 		ImageSelector imageSelector = new ImageSelector(
-			FileUtil.getBytes(inputStream), fileName,
+			_file.getBytes(inputStream), fileName,
 			MimeTypesUtil.getContentType(fileName), StringPool.BLANK);
 
 		_blogsEntryLocalService.addCoverImage(
@@ -164,6 +164,9 @@ public class BlogsImporter {
 
 	@Reference
 	private BlogsEntryLocalService _blogsEntryLocalService;
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private ResourcePermissionLocalService _resourcePermissionLocalService;

--- a/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/CPAttachmentFileEntryCreator.java
+++ b/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/CPAttachmentFileEntryCreator.java
@@ -29,7 +29,6 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -124,7 +123,7 @@ public class CPAttachmentFileEntryCreator {
 			Repository repository = _repositoryProvider.getRepository(
 				serviceContext.getScopeGroupId());
 
-			file = FileUtil.createTempFile(inputStream);
+			file = _file.createTempFile(inputStream);
 
 			fileEntry = _dlAppService.addFileEntry(
 				repository.getRepositoryId(),
@@ -134,7 +133,7 @@ public class CPAttachmentFileEntryCreator {
 		}
 		finally {
 			if (file != null) {
-				FileUtil.delete(file);
+				_file.delete(file);
 			}
 
 			inputStream.close();
@@ -194,6 +193,9 @@ public class CPAttachmentFileEntryCreator {
 
 	@Reference
 	private DLAppService _dlAppService;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private FriendlyURLNormalizer _friendlyURLNormalizer;

--- a/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/CommerceAccountsImporter.java
+++ b/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/CommerceAccountsImporter.java
@@ -51,7 +51,7 @@ import com.liferay.portal.kernel.service.OrganizationLocalService;
 import com.liferay.portal.kernel.service.RegionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -194,7 +194,7 @@ public class CommerceAccountsImporter {
 				_commerceAccountLocalService.updateCommerceAccount(
 					commerceAccount.getCommerceAccountId(),
 					commerceAccount.getName(), true,
-					FileUtil.getBytes(inputStream), commerceAccount.getEmail(),
+					_file.getBytes(inputStream), commerceAccount.getEmail(),
 					commerceAccount.getTaxId(), true, serviceContext);
 			}
 		}
@@ -357,6 +357,9 @@ public class CommerceAccountsImporter {
 
 	@Reference
 	private CountryLocalService _countryLocalService;
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private OrganizationLocalService _organizationLocalService;

--- a/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/CommerceUsersImporter.java
+++ b/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/CommerceUsersImporter.java
@@ -43,7 +43,6 @@ import com.liferay.portal.kernel.service.UserIdMapperLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -254,7 +253,7 @@ public class CommerceUsersImporter {
 						dependenciesPath + portrait);
 				}
 
-				portraitBytes = FileUtil.getBytes(inputStream);
+				portraitBytes = _file.getBytes(inputStream);
 
 				hasPortrait = true;
 			}
@@ -475,6 +474,9 @@ public class CommerceUsersImporter {
 	@Reference
 	private CommerceAccountUserRelLocalService
 		_commerceAccountUserRelLocalService;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private OrganizationLocalService _organizationLocalService;

--- a/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/DLImporter.java
+++ b/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/DLImporter.java
@@ -35,7 +35,6 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -151,7 +150,7 @@ public class DLImporter {
 			InputStream inputStream = classLoader.getResourceAsStream(
 				documentsDependencyPath + fileName);
 
-			File file = FileUtil.createTempFile(inputStream);
+			File file = _file.createTempFile(inputStream);
 
 			FileEntry fileEntry = _dlAppLocalService.addFileEntry(
 				null, userId, repository.getRepositoryId(),
@@ -235,6 +234,9 @@ public class DLImporter {
 
 	@Reference
 	private DLFolderLocalService _dlFolderLocalService;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private RepositoryLocalService _repositoryLocalService;

--- a/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/PortletSettingsImporter.java
+++ b/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/PortletSettingsImporter.java
@@ -41,7 +41,6 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.template.TemplateConstants;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -133,7 +132,7 @@ public class PortletSettingsImporter {
 			InputStream inputStream = classLoader.getResourceAsStream(
 				displayTemplateDependenciesPath + fileName);
 
-			file = FileUtil.createTempFile(inputStream);
+			file = _file.createTempFile(inputStream);
 		}
 
 		DDMTemplate ddmTemplate = _cpFileImporter.getDDMTemplate(
@@ -308,6 +307,9 @@ public class PortletSettingsImporter {
 
 	@Reference
 	private DDMFormInstanceLocalService _ddmFormInstanceLocalService;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private JournalArticleLocalService _journalArticleLocalService;

--- a/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/importer/type/CSVCommerceOrderImporterTypeImpl.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/importer/type/CSVCommerceOrderImporterTypeImpl.java
@@ -47,7 +47,7 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.settings.GroupServiceSettingsLocator;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
@@ -223,7 +223,7 @@ public class CSVCommerceOrderImporterTypeImpl
 
 		try {
 			return CSVParser.parse(
-				FileUtil.createTempFile(fileEntry.getContentStream()),
+				_file.createTempFile(fileEntry.getContentStream()),
 				Charset.defaultCharset(), csvFormat);
 		}
 		catch (IOException ioException) {
@@ -349,6 +349,9 @@ public class CSVCommerceOrderImporterTypeImpl
 
 	@Reference
 	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private JSPRenderer _jspRenderer;

--- a/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/portlet/action/ImportCSVMVCActionCommand.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/portlet/action/ImportCSVMVCActionCommand.java
@@ -34,7 +34,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.servlet.SessionErrors;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -146,7 +146,7 @@ public class ImportCSVMVCActionCommand extends BaseMVCActionCommand {
 			FileEntry fileEntry = _dlAppLocalService.getFileEntry(fileEntryId);
 
 			return CSVParser.parse(
-				FileUtil.createTempFile(fileEntry.getContentStream()),
+				_file.createTempFile(fileEntry.getContentStream()),
 				Charset.defaultCharset(), csvFormat);
 		}
 		catch (IOException ioException) {
@@ -200,6 +200,9 @@ public class ImportCSVMVCActionCommand extends BaseMVCActionCommand {
 
 	@Reference
 	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/upload/CSVUploadFileEntryHandler.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/upload/CSVUploadFileEntryHandler.java
@@ -23,7 +23,7 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.upload.UniqueFileNameProvider;
@@ -50,7 +50,7 @@ public class CSVUploadFileEntryHandler implements UploadFileEntryHandler {
 		_dlValidator.validateFileSize(
 			fileName, uploadPortletRequest.getSize(_PARAMETER_NAME));
 
-		String extension = FileUtil.getExtension(fileName);
+		String extension = _file.getExtension(fileName);
 
 		if (!extension.equals("csv")) {
 			throw new FileExtensionException(
@@ -114,6 +114,9 @@ public class CSVUploadFileEntryHandler implements UploadFileEntryHandler {
 
 	@Reference
 	private DLValidator _dlValidator;
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private UniqueFileNameProvider _uniqueFileNameProvider;

--- a/modules/apps/commerce/commerce-product-asset-categories-web/src/main/java/com/liferay/commerce/product/asset/categories/web/internal/upload/TempAssetCategoryAttachmentsUploadFileEntryHandler.java
+++ b/modules/apps/commerce/commerce-product-asset-categories-web/src/main/java/com/liferay/commerce/product/asset/categories/web/internal/upload/TempAssetCategoryAttachmentsUploadFileEntryHandler.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.upload.UniqueFileNameProvider;
@@ -128,7 +128,7 @@ public class TempAssetCategoryAttachmentsUploadFileEntryHandler
 			throw new CPAttachmentFileEntrySizeException();
 		}
 
-		String extension = FileUtil.getExtension(fileName);
+		String extension = _file.getExtension(fileName);
 
 		String[] imageExtensions = _attachmentsConfiguration.imageExtensions();
 
@@ -153,6 +153,9 @@ public class TempAssetCategoryAttachmentsUploadFileEntryHandler
 		TempAssetCategoryAttachmentsUploadFileEntryHandler.class);
 
 	private volatile AttachmentsConfiguration _attachmentsConfiguration;
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private UniqueFileNameProvider _uniqueFileNameProvider;

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/java/com/liferay/commerce/product/definitions/web/internal/upload/TempAttachmentsUploadFileEntryHandler.java
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/java/com/liferay/commerce/product/definitions/web/internal/upload/TempAttachmentsUploadFileEntryHandler.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.upload.UniqueFileNameProvider;
@@ -128,7 +128,7 @@ public class TempAttachmentsUploadFileEntryHandler
 			throw new CPAttachmentFileEntrySizeException();
 		}
 
-		String extension = FileUtil.getExtension(fileName);
+		String extension = _file.getExtension(fileName);
 
 		String[] imageExtensions = _attachmentsConfiguration.imageExtensions();
 
@@ -153,6 +153,9 @@ public class TempAttachmentsUploadFileEntryHandler
 		TempAttachmentsUploadFileEntryHandler.class);
 
 	private volatile AttachmentsConfiguration _attachmentsConfiguration;
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private UniqueFileNameProvider _uniqueFileNameProvider;

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/importer/CPFileImporterImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/importer/CPFileImporterImpl.java
@@ -74,7 +74,6 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ThemeLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -438,7 +437,7 @@ public class CPFileImporterImpl implements CPFileImporter {
 
 			InputStream inputStream = classLoader.getResourceAsStream(filePath);
 
-			byte[] byteArray = FileUtil.getBytes(inputStream);
+			byte[] byteArray = _file.getBytes(inputStream);
 
 			layout = _layoutLocalService.updateIconImage(
 				layout.getPlid(), byteArray);
@@ -612,7 +611,7 @@ public class CPFileImporterImpl implements CPFileImporter {
 
 		String mimeType = MimeTypesUtil.getContentType(fileName);
 
-		byte[] byteArray = FileUtil.getBytes(inputStream);
+		byte[] byteArray = _file.getBytes(inputStream);
 
 		return _dlAppLocalService.addFileEntry(
 			null, serviceContext.getUserId(), serviceContext.getScopeGroupId(),
@@ -1031,6 +1030,9 @@ public class CPFileImporterImpl implements CPFileImporter {
 
 	@Reference
 	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private JournalArticleLocalService _journalArticleLocalService;

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/model/listener/PortalInstanceLifecycleListenerImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/model/listener/PortalInstanceLifecycleListenerImpl.java
@@ -35,7 +35,6 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.RepositoryLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PropsKeys;
@@ -109,7 +108,7 @@ public class PortalInstanceLifecycleListenerImpl
 
 				Image image = ImageToolUtil.getDefaultCompanyLogo();
 
-				File file = FileUtil.createTempFile(image.getTextObj());
+				File file = _file.createTempFile(image.getTextObj());
 
 				try {
 					String mimeType = MimeTypesUtil.getContentType(file);
@@ -122,7 +121,7 @@ public class PortalInstanceLifecycleListenerImpl
 						null, serviceContext);
 				}
 				finally {
-					FileUtil.delete(file);
+					_file.delete(file);
 				}
 			}
 		}
@@ -139,6 +138,9 @@ public class PortalInstanceLifecycleListenerImpl
 
 	@Reference
 	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium-site-initializer/src/main/java/com/liferay/commerce/theme/minium/site/initializer/internal/MiniumSiteInitializer.java
+++ b/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium-site-initializer/src/main/java/com/liferay/commerce/theme/minium/site/initializer/internal/MiniumSiteInitializer.java
@@ -92,7 +92,6 @@ import com.liferay.portal.kernel.settings.ModifiableSettings;
 import com.liferay.portal.kernel.settings.Settings;
 import com.liferay.portal.kernel.settings.SettingsFactory;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -912,7 +911,7 @@ public class MiniumSiteInitializer implements SiteInitializer {
 		File file = null;
 
 		try {
-			file = FileUtil.createTempFile(inputStream);
+			file = _file.createTempFile(inputStream);
 
 			String mimeType = MimeTypesUtil.getContentType(file);
 
@@ -926,7 +925,7 @@ public class MiniumSiteInitializer implements SiteInitializer {
 		}
 		finally {
 			if (file != null) {
-				FileUtil.delete(file);
+				_file.delete(file);
 			}
 		}
 	}
@@ -956,7 +955,7 @@ public class MiniumSiteInitializer implements SiteInitializer {
 			_siteInitializerDependencyResolver.getImageDependencyPath() +
 				"minium_logo.png");
 
-		File file = FileUtil.createTempFile(inputStream);
+		File file = _file.createTempFile(inputStream);
 
 		_cpFileImporter.updateLogo(file, true, true, serviceContext);
 		_cpFileImporter.updateLogo(file, false, true, serviceContext);
@@ -1111,6 +1110,9 @@ public class MiniumSiteInitializer implements SiteInitializer {
 
 	@Reference
 	private DLImporter _dlImporter;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/commerce/commerce-theme-speedwell/commerce-theme-speedwell-site-initializer/src/main/java/com/liferay/commerce/theme/speedwell/site/initializer/internal/SpeedwellSiteInitializer.java
+++ b/modules/apps/commerce/commerce-theme-speedwell/commerce-theme-speedwell-site-initializer/src/main/java/com/liferay/commerce/theme/speedwell/site/initializer/internal/SpeedwellSiteInitializer.java
@@ -95,7 +95,6 @@ import com.liferay.portal.kernel.settings.ModifiableSettings;
 import com.liferay.portal.kernel.settings.Settings;
 import com.liferay.portal.kernel.settings.SettingsFactory;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
@@ -908,7 +907,7 @@ public class SpeedwellSiteInitializer implements SiteInitializer {
 		File file = null;
 
 		try {
-			file = FileUtil.createTempFile(inputStream);
+			file = _file.createTempFile(inputStream);
 
 			String mimeType = MimeTypesUtil.getContentType(file);
 
@@ -922,7 +921,7 @@ public class SpeedwellSiteInitializer implements SiteInitializer {
 		}
 		finally {
 			if (file != null) {
-				FileUtil.delete(file);
+				_file.delete(file);
 			}
 		}
 	}
@@ -952,7 +951,7 @@ public class SpeedwellSiteInitializer implements SiteInitializer {
 			_speedwellDependencyResolver.getImageDependencyPath() +
 				"Speedwell_Logo.png");
 
-		File file = FileUtil.createTempFile(inputStream);
+		File file = _file.createTempFile(inputStream);
 
 		_cpFileImporter.updateLogo(file, false, true, serviceContext);
 		_cpFileImporter.updateLogo(file, true, true, serviceContext);
@@ -1089,6 +1088,9 @@ public class SpeedwellSiteInitializer implements SiteInitializer {
 
 	@Reference
 	private DLImporter _dlImporter;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/contacts/contacts-web/src/main/java/com/liferay/contacts/web/internal/portlet/ContactsCenterPortlet.java
+++ b/modules/apps/contacts/contacts-web/src/main/java/com/liferay/contacts/web/internal/portlet/ContactsCenterPortlet.java
@@ -75,7 +75,7 @@ import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -1238,7 +1238,7 @@ public class ContactsCenterPortlet extends MVCPortlet {
 			FileEntry fileEntry = dlAppLocalService.getFileEntry(fileEntryId);
 
 			try (InputStream inputStream = fileEntry.getContentStream()) {
-				portraitBytes = FileUtil.getBytes(inputStream);
+				portraitBytes = _file.getBytes(inputStream);
 			}
 		}
 
@@ -1310,6 +1310,9 @@ public class ContactsCenterPortlet extends MVCPortlet {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ContactsCenterPortlet.class);
+
+	@Reference
+	private File _file;
 
 	private volatile UserFileUploadsConfiguration _userFileUploadsConfiguration;
 

--- a/modules/apps/diff/diff-impl/src/main/java/com/liferay/diff/internal/DiffImpl.java
+++ b/modules/apps/diff/diff-impl/src/main/java/com/liferay/diff/internal/DiffImpl.java
@@ -17,7 +17,7 @@ package com.liferay.diff.internal;
 import com.liferay.diff.DiffResult;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 
 import java.io.Reader;
 
@@ -28,6 +28,7 @@ import org.incava.util.diff.Diff;
 import org.incava.util.diff.Difference;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * This class can compare two different versions of a text. Source refers to the
@@ -93,8 +94,8 @@ public class DiffImpl implements com.liferay.diff.Diff {
 
 		// Convert the texts to Lists where each element are lines of the texts.
 
-		List<String> sourceStringList = FileUtil.toList(source);
-		List<String> targetStringList = FileUtil.toList(target);
+		List<String> sourceStringList = _file.toList(source);
+		List<String> targetStringList = _file.toList(target);
 
 		// Make a a Diff of these lines and iterate over their Differences.
 
@@ -584,5 +585,8 @@ public class DiffImpl implements com.liferay.diff.Diff {
 	}
 
 	private static final int _DIFF_MAX_LINE_LENGTH = 5000;
+
+	@Reference
+	private File _file;
 
 }

--- a/modules/apps/diff/diff-impl/src/test/java/com/liferay/diff/internal/DiffImplTest.java
+++ b/modules/apps/diff/diff-impl/src/test/java/com/liferay/diff/internal/DiffImplTest.java
@@ -18,6 +18,8 @@ import com.liferay.diff.Diff;
 import com.liferay.diff.DiffResult;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.io.unsync.UnsyncStringReader;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.io.Reader;
@@ -26,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -37,6 +40,12 @@ public class DiffImplTest {
 	@ClassRule
 	public static LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		ReflectionTestUtil.setFieldValue(
+			_diffImpl, "_file", FileUtil.getFile());
+	}
 
 	@Test
 	public void testEight() {

--- a/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/DSEnvelopeResourceImpl.java
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/DSEnvelopeResourceImpl.java
@@ -22,7 +22,7 @@ import com.liferay.digital.signature.rest.resource.v1_0.DSEnvelopeResource;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.portal.kernel.util.Base64;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.Validator;
 
 import org.osgi.service.component.annotations.Component;
@@ -77,8 +77,7 @@ public class DSEnvelopeResourceImpl extends BaseDSEnvelopeResourceImpl {
 			}
 
 			document.setData(
-				Base64.encode(
-					FileUtil.getBytes(dlFileEntry.getContentStream())));
+				Base64.encode(_file.getBytes(dlFileEntry.getContentStream())));
 		}
 
 		return DSEnvelopeUtil.toDSEnvelope(dsEnvelope);
@@ -89,5 +88,8 @@ public class DSEnvelopeResourceImpl extends BaseDSEnvelopeResourceImpl {
 
 	@Reference
 	private DSEnvelopeManager _dsEnvelopeManager;
+
+	@Reference
+	private File _file;
 
 }

--- a/modules/apps/digital-signature/digital-signature-web/src/main/java/com/liferay/digital/signature/web/internal/portlet/action/AddDSEnvelopeMVCResourceCommand.java
+++ b/modules/apps/digital-signature/digital-signature-web/src/main/java/com/liferay/digital/signature/web/internal/portlet/action/AddDSEnvelopeMVCResourceCommand.java
@@ -30,7 +30,7 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Base64;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.IntegerWrapper;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -102,7 +102,7 @@ public class AddDSEnvelopeMVCResourceCommand extends BaseMVCResourceCommand {
 				return new DSDocument() {
 					{
 						data = Base64.encode(
-							FileUtil.getBytes(fileEntry.getContentStream()));
+							_file.getBytes(fileEntry.getContentStream()));
 						dsDocumentId = String.valueOf(fileEntryId);
 						fileExtension = fileEntry.getExtension();
 						name = fileEntry.getFileName();
@@ -133,5 +133,8 @@ public class AddDSEnvelopeMVCResourceCommand extends BaseMVCResourceCommand {
 
 	@Reference
 	private DSEnvelopeManager _dsEnvelopeManager;
+
+	@Reference
+	private File _file;
 
 }

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/repository/DefaultDispatchFileValidator.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/repository/DefaultDispatchFileValidator.java
@@ -21,12 +21,13 @@ import com.liferay.dispatch.repository.DispatchFileValidator;
 import com.liferay.dispatch.repository.exception.DispatchRepositoryException;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Igor Beslic
@@ -44,7 +45,7 @@ public class DefaultDispatchFileValidator extends BaseDispatchFileValidator {
 		throws DispatchRepositoryException {
 
 		if (isValidExtension(
-				StringPool.PERIOD + FileUtil.getExtension(fileName),
+				StringPool.PERIOD + _file.getExtension(fileName),
 				_dispatchConfiguration.fileExtensions())) {
 
 			return;
@@ -73,5 +74,8 @@ public class DefaultDispatchFileValidator extends BaseDispatchFileValidator {
 	}
 
 	private volatile DispatchConfiguration _dispatchConfiguration;
+
+	@Reference
+	private File _file;
 
 }

--- a/modules/apps/dispatch/dispatch-talend-web/src/main/java/com/liferay/dispatch/talend/web/internal/executor/TalendDispatchTaskExecutor.java
+++ b/modules/apps/dispatch/dispatch-talend-web/src/main/java/com/liferay/dispatch/talend/web/internal/executor/TalendDispatchTaskExecutor.java
@@ -34,7 +34,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 
 import java.io.File;
@@ -107,7 +106,7 @@ public class TalendDispatchTaskExecutor extends BaseDispatchTaskExecutor {
 			throw new PortalException(exception);
 		}
 		finally {
-			FileUtil.deltree(new File(talendArchive.getJobDirectory()));
+			_file.deltree(new File(talendArchive.getJobDirectory()));
 		}
 	}
 
@@ -185,6 +184,9 @@ public class TalendDispatchTaskExecutor extends BaseDispatchTaskExecutor {
 
 	@Reference
 	private DispatchTriggerLocalService _dispatchTriggerLocalService;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private ProcessExecutor _processExecutor;

--- a/modules/apps/dispatch/dispatch-talend-web/src/main/java/com/liferay/dispatch/talend/web/internal/portlet/action/EditDispatchTalendJobArchiveMVCActionCommand.java
+++ b/modules/apps/dispatch/dispatch-talend-web/src/main/java/com/liferay/dispatch/talend/web/internal/portlet/action/EditDispatchTalendJobArchiveMVCActionCommand.java
@@ -31,7 +31,6 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.UnicodeProperties;
@@ -77,7 +76,7 @@ public class EditDispatchTalendJobArchiveMVCActionCommand
 			long dispatchTriggerId = ParamUtil.getLong(
 				uploadPortletRequest, "dispatchTriggerId");
 
-			File jobArchiveFile = FileUtil.createTempFile(
+			File jobArchiveFile = _file.createTempFile(
 				uploadPortletRequest.getFileAsStream("jobArchive"));
 
 			try (FileInputStream fileInputStream = new FileInputStream(
@@ -104,7 +103,7 @@ public class EditDispatchTalendJobArchiveMVCActionCommand
 					uploadPortletRequest.getFileName("jobArchive"));
 			}
 			finally {
-				FileUtil.delete(jobArchiveFile);
+				_file.delete(jobArchiveFile);
 			}
 		}
 		catch (Exception exception) {
@@ -176,6 +175,9 @@ public class EditDispatchTalendJobArchiveMVCActionCommand
 
 	@Reference
 	private ExpandoValueLocalService _expandoValueLocalService;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/dispatch/dispatch-talend-web/src/main/java/com/liferay/dispatch/talend/web/internal/repository/TalendDispatchFileValidator.java
+++ b/modules/apps/dispatch/dispatch-talend-web/src/main/java/com/liferay/dispatch/talend/web/internal/repository/TalendDispatchFileValidator.java
@@ -20,12 +20,13 @@ import com.liferay.dispatch.repository.exception.DispatchRepositoryException;
 import com.liferay.dispatch.talend.web.internal.configuration.DispatchTalendConfiguration;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Igor Beslic
@@ -45,7 +46,7 @@ public class TalendDispatchFileValidator extends BaseDispatchFileValidator {
 		throws DispatchRepositoryException {
 
 		if (isValidExtension(
-				StringPool.PERIOD + FileUtil.getExtension(fileName),
+				StringPool.PERIOD + _file.getExtension(fileName),
 				_dispatchTalendConfiguration.fileExtensions())) {
 
 			return;
@@ -74,5 +75,8 @@ public class TalendDispatchFileValidator extends BaseDispatchFileValidator {
 	}
 
 	private volatile DispatchTalendConfiguration _dispatchTalendConfiguration;
+
+	@Reference
+	private File _file;
 
 }

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/DLOpenerGoogleDriveManager.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/DLOpenerGoogleDriveManager.java
@@ -38,7 +38,6 @@ import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.InetAddressUtil;
@@ -311,7 +310,7 @@ public class DLOpenerGoogleDriveManager
 				"Authorization", "Bearer " + credential.getAccessToken());
 
 			try (InputStream inputStream = urlConnection.getInputStream()) {
-				return FileUtil.createTempFile(inputStream);
+				return _file.createTempFile(inputStream);
 			}
 		}
 		catch (IOException | PortalException exception) {
@@ -374,6 +373,9 @@ public class DLOpenerGoogleDriveManager
 	@Reference
 	private DLOpenerFileEntryReferenceLocalService
 		_dlOpenerFileEntryReferenceLocalService;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	private JsonFactory _jsonFactory;
 	private NetHttpTransport _netHttpTransport;

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/background/task/UploadGoogleDriveDocumentBackgroundTaskExecutor.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/background/task/UploadGoogleDriveDocumentBackgroundTaskExecutor.java
@@ -44,7 +44,6 @@ import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.io.File;
@@ -165,7 +164,7 @@ public class UploadGoogleDriveDocumentBackgroundTaskExecutor
 
 	private File _getFileEntryFile(FileVersion fileVersion) throws Exception {
 		try (InputStream inputStream = fileVersion.getContentStream(false)) {
-			return FileUtil.createTempFile(inputStream);
+			return _file.createTempFile(inputStream);
 		}
 	}
 
@@ -270,6 +269,9 @@ public class UploadGoogleDriveDocumentBackgroundTaskExecutor
 	@Reference
 	private DLOpenerFileEntryReferenceLocalService
 		_dlOpenerFileEntryReferenceLocalService;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private OAuth2Manager _oAuth2Manager;

--- a/modules/apps/document-library/document-library-asset-auto-tagger-microsoft-cognitive-services/src/main/java/com/liferay/document/library/asset/auto/tagger/microsoft/cognitive/services/internal/MSCognitiveServicesImageAssetAutoTagProvider.java
+++ b/modules/apps/document-library/document-library-asset-auto-tagger-microsoft-cognitive-services/src/main/java/com/liferay/document/library/asset/auto/tagger/microsoft/cognitive/services/internal/MSCognitiveServicesImageAssetAutoTagProvider.java
@@ -30,7 +30,7 @@ import com.liferay.portal.kernel.repository.capabilities.TemporaryFileEntriesCap
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.util.ContentTypes;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.InetAddressUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -150,7 +150,7 @@ public class MSCognitiveServicesImageAssetAutoTagProvider
 
 		try (OutputStream outputStream = httpURLConnection.getOutputStream()) {
 			outputStream.write(
-				FileUtil.getBytes(fileVersion.getContentStream(false)));
+				_file.getBytes(fileVersion.getContentStream(false)));
 		}
 
 		httpURLConnection.getResponseMessage();
@@ -181,6 +181,9 @@ public class MSCognitiveServicesImageAssetAutoTagProvider
 
 	@Reference
 	private ConfigurationProvider _configurationProvider;
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private Http _http;

--- a/modules/apps/document-library/document-library-asset-auto-tagger-tensorflow/src/main/java/com/liferay/document/library/asset/auto/tagger/tensorflow/internal/TensorFlowImageAssetAutoTagProvider.java
+++ b/modules/apps/document-library/document-library-asset-auto-tagger-tensorflow/src/main/java/com/liferay/document/library/asset/auto/tagger/tensorflow/internal/TensorFlowImageAssetAutoTagProvider.java
@@ -29,7 +29,7 @@ import com.liferay.portal.kernel.repository.capabilities.TemporaryFileEntriesCap
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.util.ContentTypes;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -83,7 +83,7 @@ public class TensorFlowImageAssetAutoTagProvider
 
 				if (_isSupportedMimeType(fileVersion.getMimeType())) {
 					return _label(
-						FileUtil.getBytes(fileVersion.getContentStream(false)),
+						_file.getBytes(fileVersion.getContentStream(false)),
 						fileVersion.getMimeType(),
 						tensorFlowImageAssetAutoTagProviderCompanyConfiguration.
 							confidenceThreshold());
@@ -182,6 +182,9 @@ public class TensorFlowImageAssetAutoTagProvider
 
 	@Reference
 	private ConfigurationProvider _configurationProvider;
+
+	@Reference
+	private File _file;
 
 	private String[] _labels;
 

--- a/modules/apps/document-library/document-library-demo-data-creator-impl/src/main/java/com/liferay/document/library/demo/data/creator/internal/UnsplashFileEntryDemoDataCreatorImpl.java
+++ b/modules/apps/document-library/document-library-demo-data-creator-impl/src/main/java/com/liferay/document/library/demo/data/creator/internal/UnsplashFileEntryDemoDataCreatorImpl.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.security.RandomUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -95,7 +95,7 @@ public class UnsplashFileEntryDemoDataCreatorImpl
 		URL url = _getNextUrl();
 
 		try (InputStream inputStream = url.openStream()) {
-			return FileUtil.getBytes(inputStream);
+			return _file.getBytes(inputStream);
 		}
 		catch (IOException ioException) {
 			if (_log.isWarnEnabled()) {
@@ -106,7 +106,7 @@ public class UnsplashFileEntryDemoDataCreatorImpl
 				"dependencies/%d.jpg", RandomUtil.nextInt(5));
 
 			try {
-				return FileUtil.getBytes(getClass(), fileName);
+				return _file.getBytes(getClass(), fileName);
 			}
 			catch (Exception exception) {
 				throw new PortalException(exception);
@@ -138,6 +138,9 @@ public class UnsplashFileEntryDemoDataCreatorImpl
 
 	@Reference
 	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
+	private File _file;
 
 	private final List<Long> _fileEntryIds = new CopyOnWriteArrayList<>();
 

--- a/modules/apps/document-library/document-library-document-conversion/src/main/java/com/liferay/document/library/document/conversion/internal/DocumentConversionImpl.java
+++ b/modules/apps/document-library/document-library-document-conversion/src/main/java/com/liferay/document/library/document/conversion/internal/DocumentConversionImpl.java
@@ -33,7 +33,6 @@ import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.SortedArrayList;
 import com.liferay.portal.kernel.util.SystemProperties;
@@ -53,6 +52,7 @@ import java.util.Map;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Bruno Farache
@@ -135,7 +135,7 @@ public class DocumentConversionImpl implements DocumentConversion {
 			inputStream, inputDocumentFormat, unsyncByteArrayOutputStream,
 			outputDocumentFormat);
 
-		FileUtil.write(
+		_file.write(
 			file, unsyncByteArrayOutputStream.unsafeGetByteArray(), 0,
 			unsyncByteArrayOutputStream.size());
 
@@ -316,6 +316,10 @@ public class DocumentConversionImpl implements DocumentConversion {
 		DocumentConversionImpl.class);
 
 	private DocumentConverter _documentConverter;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
+
 	private volatile OpenOfficeConfiguration _openOfficeConfiguration;
 	private OpenOfficeConnection _openOfficeConnection;
 

--- a/modules/apps/document-library/document-library-preview-audio/src/main/java/com/liferay/document/library/preview/audio/internal/DLAudioFFMPEGAudioConverter.java
+++ b/modules/apps/document-library/document-library-preview-audio/src/main/java/com/liferay/document/library/preview/audio/internal/DLAudioFFMPEGAudioConverter.java
@@ -22,7 +22,6 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -43,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Adolfo Pérez
@@ -57,7 +57,7 @@ public class DLAudioFFMPEGAudioConverter implements AudioConverter {
 	public InputStream generateAudioPreview(File file, String format)
 		throws Exception {
 
-		File destinationFile = FileUtil.createTempFile(format);
+		File destinationFile = _file.createTempFile(format);
 
 		Properties audioProperties = PropsUtil.getProperties(
 			PropsKeys.DL_FILE_ENTRY_PREVIEW_AUDIO, false);
@@ -163,5 +163,8 @@ public class DLAudioFFMPEGAudioConverter implements AudioConverter {
 
 	private volatile DLAudioFFMPEGAudioConverterConfiguration
 		_dlAudioFFMPEGAudioConverterConfiguration;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 }

--- a/modules/apps/document-library/document-library-repository-portlet-file-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/file/repository/internal/PortletFileRepositoryImpl.java
+++ b/modules/apps/document-library/document-library-repository-portlet-file-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/file/repository/internal/PortletFileRepositoryImpl.java
@@ -48,7 +48,6 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEventHierarchyEntryThreadLocal;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ContentTypes;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
@@ -111,7 +110,7 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 		File file = null;
 
 		try {
-			file = FileUtil.createTempFile(bytes);
+			file = _file.createTempFile(bytes);
 
 			return addPortletFileEntry(
 				groupId, userId, className, classPK, portletId, folderId, file,
@@ -122,7 +121,7 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 				"Unable to write temporary file", ioException);
 		}
 		finally {
-			FileUtil.delete(file);
+			_file.delete(file);
 		}
 	}
 
@@ -191,7 +190,7 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 		File file = null;
 
 		try {
-			file = FileUtil.createTempFile(inputStream);
+			file = _file.createTempFile(inputStream);
 
 			return addPortletFileEntry(
 				groupId, userId, className, classPK, portletId, folderId, file,
@@ -202,7 +201,7 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 				"Unable to write temporary file", ioException);
 		}
 		finally {
-			FileUtil.delete(file);
+			_file.delete(file);
 		}
 	}
 
@@ -651,7 +650,7 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 			try {
 				getPortletFileEntry(groupId, folderId, uniqueFileName);
 
-				uniqueFileName = FileUtil.appendParentheticalSuffix(
+				uniqueFileName = _file.appendParentheticalSuffix(
 					fileName, String.valueOf(i));
 			}
 			catch (Exception exception) {
@@ -800,6 +799,9 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 
 	@Reference
 	private DLTrashLocalService _dlTrashLocalService;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/asset/auto/tagger/text/extractor/FileEntryTextExtractor.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/asset/auto/tagger/text/extractor/FileEntryTextExtractor.java
@@ -20,13 +20,14 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 
 import java.io.InputStream;
 
 import java.util.Locale;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Alicia García
@@ -43,7 +44,7 @@ public class FileEntryTextExtractor implements TextExtractor<FileEntry> {
 			try (InputStream inputStream = fileVersion.getContentStream(
 					false)) {
 
-				return FileUtil.extractText(
+				return _file.extractText(
 					inputStream, fileVersion.getFileName());
 			}
 		}
@@ -61,5 +62,8 @@ public class FileEntryTextExtractor implements TextExtractor<FileEntry> {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		FileEntryTextExtractor.class);
+
+	@Reference
+	private File _file;
 
 }

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/util/DLValidatorImpl.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/util/DLValidatorImpl.java
@@ -29,7 +29,6 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.upload.UploadServletRequestConfigurationHelper;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeFormatter;
 import com.liferay.portal.kernel.util.Validator;
@@ -114,7 +113,7 @@ public final class DLValidatorImpl implements DLValidator {
 			}
 		}
 
-		String nameWithoutExtension = FileUtil.stripExtension(name);
+		String nameWithoutExtension = _file.stripExtension(name);
 
 		for (String blacklistName : PropsValues.DL_NAME_BLACKLIST) {
 			if (StringUtil.equalsIgnoreCase(
@@ -149,7 +148,7 @@ public final class DLValidatorImpl implements DLValidator {
 
 		for (String fileExtension : _dlConfiguration.fileExtensions()) {
 			String fileNameExtension = StringUtil.toLowerCase(
-				FileUtil.getExtension(fileName));
+				_file.getExtension(fileName));
 
 			if (StringPool.STAR.equals(fileExtension) ||
 				StringUtil.equals(
@@ -241,7 +240,7 @@ public final class DLValidatorImpl implements DLValidator {
 			String fileExtension, String sourceFileName)
 		throws SourceFileNameException {
 
-		String sourceFileExtension = FileUtil.getExtension(sourceFileName);
+		String sourceFileExtension = _file.getExtension(sourceFileName);
 
 		if (Validator.isNotNull(sourceFileName) &&
 			PropsValues.DL_FILE_EXTENSIONS_STRICT_CHECK &&
@@ -306,8 +305,8 @@ public final class DLValidatorImpl implements DLValidator {
 	}
 
 	private String _replaceDLNameBlacklist(String title) {
-		String extension = FileUtil.getExtension(title);
-		String nameWithoutExtension = FileUtil.stripExtension(title);
+		String extension = _file.getExtension(title);
+		String nameWithoutExtension = _file.stripExtension(title);
 
 		for (String blacklistName : PropsValues.DL_NAME_BLACKLIST) {
 			if (StringUtil.equalsIgnoreCase(
@@ -333,6 +332,9 @@ public final class DLValidatorImpl implements DLValidator {
 	}
 
 	private volatile DLConfiguration _dlConfiguration;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private UploadServletRequestConfigurationHelper

--- a/modules/apps/document-library/document-library-service/src/test/java/com/liferay/document/library/internal/util/DLValidatorImplTest.java
+++ b/modules/apps/document-library/document-library-service/src/test/java/com/liferay/document/library/internal/util/DLValidatorImplTest.java
@@ -17,7 +17,9 @@ package com.liferay.document.library.internal.util;
 import com.liferay.document.library.configuration.DLConfiguration;
 import com.liferay.document.library.kernel.exception.FileExtensionException;
 import com.liferay.document.library.kernel.util.DLValidator;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.util.FileImpl;
 
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -43,6 +45,8 @@ public class DLValidatorImplTest {
 		dlValidatorImpl.setDLConfiguration(_dlConfiguration);
 
 		_dlValidator = dlValidatorImpl;
+
+		ReflectionTestUtil.setFieldValue(_dlValidator, "_file", new FileImpl());
 	}
 
 	@Test(expected = FileExtensionException.class)

--- a/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/converter/DLVideoFFMPEGVideoConverter.java
+++ b/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/converter/DLVideoFFMPEGVideoConverter.java
@@ -24,7 +24,6 @@ import com.liferay.portal.kernel.image.ImageToolUtil;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -49,6 +48,7 @@ import java.util.concurrent.TimeUnit;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Alejandro Tardín
@@ -63,7 +63,7 @@ public class DLVideoFFMPEGVideoConverter implements VideoConverter {
 	public InputStream generateVideoPreview(File file, String containerType)
 		throws Exception {
 
-		File destinationFile = FileUtil.createTempFile(containerType);
+		File destinationFile = _file.createTempFile(containerType);
 
 		Properties videoProperties = PropsUtil.getProperties(
 			PropsKeys.DL_FILE_ENTRY_PREVIEW_VIDEO, false);
@@ -91,7 +91,7 @@ public class DLVideoFFMPEGVideoConverter implements VideoConverter {
 		throws Exception {
 
 		try {
-			File destinationFile = FileUtil.createTempFile(format);
+			File destinationFile = _file.createTempFile(format);
 
 			_runFFMPEGCommand(
 				Arrays.asList(
@@ -239,5 +239,8 @@ public class DLVideoFFMPEGVideoConverter implements VideoConverter {
 
 	private volatile DLVideoFFMPEGVideoConverterConfiguration
 		_dlVideoFFMPEGVideoConverterConfiguration;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 }

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/change/tracking/spi/display/DLFileVersionCTDisplayRenderer.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/change/tracking/spi/display/DLFileVersionCTDisplayRenderer.java
@@ -37,7 +37,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.repository.model.FileVersion;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.util.PropsValues;
@@ -127,12 +127,12 @@ public class DLFileVersionCTDisplayRenderer
 				displayContext.getDownloadURL(
 					_AUDIO_PREVIEW + ",mp3",
 					_audioProcessor.getPreviewFileSize(fileVersion, "mp3"),
-					FileUtil.stripExtension(fileName) + ".mp3"),
+					_file.stripExtension(fileName) + ".mp3"),
 				"\" type=\"audio/mp3\"/><source src=\"",
 				displayContext.getDownloadURL(
 					_AUDIO_PREVIEW + ",ogg",
 					_audioProcessor.getPreviewFileSize(fileVersion, "ogg"),
-					FileUtil.stripExtension(fileName) + ".ogg"),
+					_file.stripExtension(fileName) + ".ogg"),
 				"\" type=\"audio/ogg\"/></audio>");
 		}
 
@@ -162,7 +162,7 @@ public class DLFileVersionCTDisplayRenderer
 			}
 
 			fileName = StringBundler.concat(
-				FileUtil.stripExtension(fileName), StringPool.PERIOD,
+				_file.stripExtension(fileName), StringPool.PERIOD,
 				PDFProcessor.PREVIEW_TYPE);
 
 			return StringBundler.concat(
@@ -186,7 +186,7 @@ public class DLFileVersionCTDisplayRenderer
 			}
 
 			fileName = StringBundler.concat(
-				FileUtil.stripExtension(fileName), StringPool.PERIOD,
+				_file.stripExtension(fileName), StringPool.PERIOD,
 				_imageProcessor.getPreviewType(fileVersion));
 
 			return StringBundler.concat(
@@ -216,12 +216,12 @@ public class DLFileVersionCTDisplayRenderer
 				displayContext.getDownloadURL(
 					_VIDEO_PREVIEW + ",mp4",
 					_audioProcessor.getPreviewFileSize(fileVersion, "mp4"),
-					FileUtil.stripExtension(fileName) + ".mp4"),
+					_file.stripExtension(fileName) + ".mp4"),
 				"\" type=\"video/mp4\"/><source src=\"",
 				displayContext.getDownloadURL(
 					_VIDEO_PREVIEW + ",ogv",
 					_audioProcessor.getPreviewFileSize(fileVersion, "ogv"),
-					FileUtil.stripExtension(fileName) + ".ogv"),
+					_file.stripExtension(fileName) + ".ogv"),
 				"\" type=\"video/ogv\"/></audio>");
 		}
 
@@ -352,6 +352,9 @@ public class DLFileVersionCTDisplayRenderer
 		target = "(component.name=com.liferay.document.library.preview.document.internal.DocumentPreviewRendererProvider)"
 	)
 	private DLPreviewRendererProvider _dlPreviewRendererProvider;
+
+	@Reference
+	private File _file;
 
 	@Reference(policyOption = ReferencePolicyOption.GREEDY)
 	private ImageProcessor _imageProcessor;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
@@ -95,7 +95,7 @@ import com.liferay.portal.kernel.upload.UploadException;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.upload.UploadRequestSizeException;
 import com.liferay.portal.kernel.util.Constants;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.KeyValuePair;
@@ -463,7 +463,7 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 
 			String uniqueFileTitle = DLUtil.getUniqueTitle(
 				tempFileEntry.getGroupId(), folderId,
-				FileUtil.stripExtension(originalSelectedFileName));
+				_file.stripExtension(originalSelectedFileName));
 
 			FileEntry fileEntry = _dlAppService.addFileEntry(
 				null, repositoryId, folderId, uniqueFileName,
@@ -1233,7 +1233,7 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 
 				_validateFileName(
 					sourceFileName,
-					FileUtil.getExtension(
+					_file.getExtension(
 						uploadPortletRequest.getFileName("file")));
 
 				fileEntry = _dlAppService.addFileEntry(
@@ -1251,7 +1251,7 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 
 				String uniqueFileTitle = DLUtil.getUniqueTitle(
 					themeDisplay.getScopeGroupId(), folderId,
-					FileUtil.stripExtension(sourceFileName));
+					_file.stripExtension(sourceFileName));
 
 				fileEntry = _dlAppService.addFileEntry(
 					null, repositoryId, folderId, uniqueFileName, contentType,
@@ -1312,7 +1312,7 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 
 		if (Validator.isNotNull(extension) &&
 			(Validator.isNull(sourceFileName) ||
-			 Validator.isNull(FileUtil.getExtension(sourceFileName)))) {
+			 Validator.isNull(_file.getExtension(sourceFileName)))) {
 
 			throw new FileNameExtensionException(
 				"The file name cannot be empty or without extension");
@@ -1353,6 +1353,9 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 
 	@Reference
 	private DLValidator _dlValidator;
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private Http _http;

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/webdav/DLWebDAVStorageImpl.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/webdav/DLWebDAVStorageImpl.java
@@ -63,7 +63,6 @@ import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
@@ -206,7 +205,7 @@ public class DLWebDAVStorageImpl extends BaseWebDAVStorageImpl {
 
 			InputStream inputStream = fileEntry.getContentStream();
 
-			file = FileUtil.createTempFile(inputStream);
+			file = _file.createTempFile(inputStream);
 
 			ServiceContext serviceContext = _getServiceContext(
 				DLFileEntry.class.getName(), webDAVRequest);
@@ -223,7 +222,7 @@ public class DLWebDAVStorageImpl extends BaseWebDAVStorageImpl {
 
 			_dlAppService.addFileEntry(
 				null, groupId, parentFolderId, fileName,
-				fileEntry.getMimeType(), FileUtil.stripExtension(fileName),
+				fileEntry.getMimeType(), _file.stripExtension(fileName),
 				fileEntry.getDescription(), StringPool.BLANK, file, null, null,
 				serviceContext);
 
@@ -263,7 +262,7 @@ public class DLWebDAVStorageImpl extends BaseWebDAVStorageImpl {
 			throw new WebDAVException(exception);
 		}
 		finally {
-			FileUtil.delete(file);
+			_file.delete(file);
 		}
 	}
 
@@ -450,8 +449,7 @@ public class DLWebDAVStorageImpl extends BaseWebDAVStorageImpl {
 				String contentType = _getContentType(
 					webDAVRequest.getHttpServletRequest(), null, fileName);
 
-				File file = FileUtil.createTempFile(
-					FileUtil.getExtension(fileName));
+				File file = _file.createTempFile(_file.getExtension(fileName));
 
 				file.createNewFile();
 
@@ -460,7 +458,7 @@ public class DLWebDAVStorageImpl extends BaseWebDAVStorageImpl {
 
 				FileEntry fileEntry = _dlAppService.addFileEntry(
 					null, webDAVRequest.getGroupId(), parentFolderId, fileName,
-					contentType, FileUtil.stripExtension(fileName),
+					contentType, _file.stripExtension(fileName),
 					StringPool.BLANK, StringPool.BLANK, file, null, null,
 					serviceContext);
 
@@ -690,7 +688,7 @@ public class DLWebDAVStorageImpl extends BaseWebDAVStorageImpl {
 
 					InputStream inputStream = fileEntry.getContentStream();
 
-					file = FileUtil.createTempFile(inputStream);
+					file = _file.createTempFile(inputStream);
 
 					_populateServiceContext(serviceContext, destFileEntry);
 
@@ -759,7 +757,7 @@ public class DLWebDAVStorageImpl extends BaseWebDAVStorageImpl {
 			throw new WebDAVException(exception);
 		}
 		finally {
-			FileUtil.delete(file);
+			_file.delete(file);
 		}
 	}
 
@@ -780,9 +778,9 @@ public class DLWebDAVStorageImpl extends BaseWebDAVStorageImpl {
 			ServiceContext serviceContext = _getServiceContext(
 				DLFileEntry.class.getName(), webDAVRequest);
 
-			file = FileUtil.createTempFile(FileUtil.getExtension(fileName));
+			file = _file.createTempFile(_file.getExtension(fileName));
 
-			FileUtil.write(file, httpServletRequest.getInputStream());
+			_file.write(file, httpServletRequest.getInputStream());
 
 			String contentType = _getContentType(
 				httpServletRequest, file, fileName);
@@ -818,7 +816,7 @@ public class DLWebDAVStorageImpl extends BaseWebDAVStorageImpl {
 
 				_dlAppService.addFileEntry(
 					null, webDAVRequest.getGroupId(), parentFolderId, fileName,
-					contentType, FileUtil.stripExtension(fileName),
+					contentType, _file.stripExtension(fileName),
 					StringPool.BLANK, StringPool.BLANK, file, null, null,
 					serviceContext);
 			}
@@ -862,7 +860,7 @@ public class DLWebDAVStorageImpl extends BaseWebDAVStorageImpl {
 			throw new WebDAVException(exception);
 		}
 		finally {
-			FileUtil.delete(file);
+			_file.delete(file);
 		}
 	}
 
@@ -1287,5 +1285,8 @@ public class DLWebDAVStorageImpl extends BaseWebDAVStorageImpl {
 
 	@Reference
 	private DLTrashService _dlTrashService;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/upload/DDMFormUploadFileEntryHandler.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/upload/DDMFormUploadFileEntryHandler.java
@@ -29,7 +29,6 @@ import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -62,7 +61,7 @@ public class DDMFormUploadFileEntryHandler implements UploadFileEntryHandler {
 			long groupId = ParamUtil.getLong(uploadPortletRequest, "groupId");
 			long folderId = ParamUtil.getLong(uploadPortletRequest, "folderId");
 
-			file = FileUtil.createTempFile(inputStream);
+			file = _file.createTempFile(inputStream);
 
 			String fileName = uploadPortletRequest.getFileName("file");
 
@@ -79,7 +78,7 @@ public class DDMFormUploadFileEntryHandler implements UploadFileEntryHandler {
 				MimeTypesUtil.getContentType(file, fileName), themeDisplay);
 		}
 		finally {
-			FileUtil.delete(file);
+			_file.delete(file);
 		}
 	}
 
@@ -126,6 +125,9 @@ public class DDMFormUploadFileEntryHandler implements UploadFileEntryHandler {
 
 	@Reference
 	private DDMFormUploadValidator _ddmFormUploadValidator;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/upload/DDMFormUploadValidator.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/upload/DDMFormUploadValidator.java
@@ -20,7 +20,6 @@ import com.liferay.document.library.kernel.exception.InvalidFileException;
 import com.liferay.dynamic.data.mapping.form.web.internal.configuration.DDMFormWebConfiguration;
 import com.liferay.dynamic.data.mapping.form.web.internal.configuration.activator.DDMFormWebConfigurationActivator;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.File;
@@ -70,7 +69,7 @@ public class DDMFormUploadValidator {
 		Optional<String> guestUploadFileExtensionOptional =
 			guestUploadFileExtensionsStream.filter(
 				guestUploadFileExtension -> StringUtil.equalsIgnoreCase(
-					FileUtil.getExtension(fileName),
+					_file.getExtension(fileName),
 					StringUtil.trim(guestUploadFileExtension))
 			).findFirst();
 
@@ -115,5 +114,8 @@ public class DDMFormUploadValidator {
 	)
 	private volatile DDMFormWebConfigurationActivator
 		_ddmFormWebConfigurationActivator;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/upload/DDMFormUploadValidatorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/upload/DDMFormUploadValidatorTest.java
@@ -20,8 +20,10 @@ import com.liferay.document.library.kernel.exception.InvalidFileException;
 import com.liferay.dynamic.data.mapping.form.web.internal.configuration.DDMFormWebConfiguration;
 import com.liferay.dynamic.data.mapping.form.web.internal.configuration.activator.DDMFormWebConfigurationActivator;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.util.FileImpl;
 
 import java.io.File;
 
@@ -46,6 +48,8 @@ public class DDMFormUploadValidatorTest {
 	@Before
 	public void setUp() throws Exception {
 		_setUpDDMFormWebConfigurationActivator();
+		ReflectionTestUtil.setFieldValue(
+			_ddmFormUploadValidator, "_file", new FileImpl());
 	}
 
 	@Test(expected = InvalidFileException.class)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMImpl.java
@@ -74,7 +74,7 @@ import com.liferay.portal.kernel.upload.UploadRequest;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.DateUtil;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -1152,7 +1152,7 @@ public class DDMImpl implements DDM {
 			UploadRequest uploadRequest, String fieldNameValue)
 		throws Exception {
 
-		byte[] bytes = FileUtil.getBytes(
+		byte[] bytes = _file.getBytes(
 			uploadRequest.getFile(fieldNameValue + "File"));
 
 		if (ArrayUtil.isNotEmpty(bytes)) {
@@ -1340,6 +1340,9 @@ public class DDMImpl implements DDM {
 	private DLURLHelper _dlURLHelper;
 
 	private FieldsToDDMFormValuesConverter _fieldsToDDMFormValuesConverter;
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private Http _http;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DefaultDDMStructureHelperImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DefaultDDMStructureHelperImpl.java
@@ -39,7 +39,7 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.template.TemplateConstants;
 import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
@@ -141,8 +141,7 @@ public class DefaultDDMStructureHelperImpl
 
 			String script = StringUtil.read(
 				classLoader,
-				FileUtil.getPath(fileName) + StringPool.SLASH +
-					templateFileName);
+				_file.getPath(fileName) + StringPool.SLASH + templateFileName);
 
 			boolean cacheable = GetterUtil.getBoolean(
 				templateElement.elementText("cacheable"));
@@ -351,6 +350,9 @@ public class DefaultDDMStructureHelperImpl
 	private DDM _ddm;
 	private DDMStructureLocalService _ddmStructureLocalService;
 	private DDMTemplateLocalService _ddmTemplateLocalService;
+
+	@Reference
+	private File _file;
 
 	@Reference(target = "(ddm.form.deserializer.type=json)")
 	private DDMFormDeserializer _jsonDDMFormDeserializer;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMTemplateLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMTemplateLocalServiceImpl.java
@@ -65,7 +65,6 @@ import com.liferay.portal.kernel.service.permission.ModelPermissions;
 import com.liferay.portal.kernel.settings.GroupServiceSettingsLocator;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.Constants;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -223,7 +222,7 @@ public class DDMTemplateLocalServiceImpl
 
 		if (smallImage) {
 			try {
-				smallImageBytes = FileUtil.getBytes(smallImageFile);
+				smallImageBytes = _file.getBytes(smallImageFile);
 			}
 			catch (IOException ioException) {
 				if (_log.isDebugEnabled()) {
@@ -1453,7 +1452,7 @@ public class DDMTemplateLocalServiceImpl
 
 		if (smallImage) {
 			try {
-				smallImageBytes = FileUtil.getBytes(smallImageFile);
+				smallImageBytes = _file.getBytes(smallImageFile);
 			}
 			catch (IOException ioException) {
 				if (_log.isDebugEnabled()) {
@@ -1673,7 +1672,7 @@ public class DDMTemplateLocalServiceImpl
 
 		if (template.isSmallImage()) {
 			try {
-				smallImageBytes = FileUtil.getBytes(smallImageFile);
+				smallImageBytes = _file.getBytes(smallImageFile);
 			}
 			catch (IOException ioException) {
 				if (_log.isDebugEnabled()) {
@@ -1761,10 +1760,10 @@ public class DDMTemplateLocalServiceImpl
 				template.getSmallImageId());
 
 			if (smallImage != null) {
-				smallImageFile = FileUtil.createTempFile(smallImage.getType());
+				smallImageFile = _file.createTempFile(smallImage.getType());
 
 				try {
-					FileUtil.write(smallImageFile, smallImage.getTextObj());
+					_file.write(smallImageFile, smallImage.getTextObj());
 				}
 				catch (IOException ioException) {
 					_log.error(ioException, ioException);
@@ -1945,6 +1944,9 @@ public class DDMTemplateLocalServiceImpl
 		policyOption = ReferencePolicyOption.GREEDY
 	)
 	private volatile DepotEntryLocalService _depotEntryLocalService;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private ImageLocalService _imageLocalService;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/DDMTemplateStagedModelDataHandler.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/DDMTemplateStagedModelDataHandler.java
@@ -43,7 +43,6 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ImageLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -381,10 +380,10 @@ public class DDMTemplateStagedModelDataHandler
 						smallImagePath);
 
 					if (bytes != null) {
-						smallFile = FileUtil.createTempFile(
+						smallFile = _file.createTempFile(
 							template.getSmallImageType());
 
-						FileUtil.write(smallFile, bytes);
+						_file.write(smallFile, bytes);
 					}
 				}
 			}
@@ -630,6 +629,9 @@ public class DDMTemplateStagedModelDataHandler
 		_ddmTemplateExportImportContentProcessor;
 	private DDMTemplateLocalService _ddmTemplateLocalService;
 	private DDMTemplateVersionLocalService _ddmTemplateVersionLocalService;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/portlet/action/AddTemplateMVCActionCommand.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/portlet/action/AddTemplateMVCActionCommand.java
@@ -24,7 +24,6 @@ import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.template.TemplateConstants;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.ContentTypes;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -93,6 +92,9 @@ public class AddTemplateMVCActionCommand extends BaseDDMMVCActionCommand {
 	protected DDMTemplateService ddmTemplateService;
 
 	@Reference
+	protected com.liferay.portal.kernel.util.File file;
+
+	@Reference
 	protected Portal portal;
 
 	private DDMTemplate _addTemplate(ActionRequest actionRequest)
@@ -142,15 +144,15 @@ public class AddTemplateMVCActionCommand extends BaseDDMMVCActionCommand {
 			UploadPortletRequest uploadPortletRequest)
 		throws Exception {
 
-		File file = uploadPortletRequest.getFile("script");
+		File scriptFile = uploadPortletRequest.getFile("script");
 
-		if (file == null) {
+		if (scriptFile == null) {
 			return null;
 		}
 
-		String fileScriptContent = FileUtil.read(file);
+		String fileScriptContent = file.read(scriptFile);
 
-		String contentType = MimeTypesUtil.getContentType(file);
+		String contentType = MimeTypesUtil.getContentType(scriptFile);
 
 		if (Validator.isNotNull(fileScriptContent) &&
 			!_isValidContentType(contentType)) {

--- a/modules/apps/export-import/export-import-resources-importer/src/main/java/com/liferay/exportimport/resources/importer/internal/portlet/preferences/JournalPortletPreferencesTranslator.java
+++ b/modules/apps/export-import/export-import-resources-importer/src/main/java/com/liferay/exportimport/resources/importer/internal/portlet/preferences/JournalPortletPreferencesTranslator.java
@@ -17,13 +17,14 @@ package com.liferay.exportimport.resources.importer.internal.portlet.preferences
 import com.liferay.exportimport.resources.importer.portlet.preferences.PortletPreferencesTranslator;
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import javax.portlet.PortletException;
 import javax.portlet.PortletPreferences;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Michael C. Han
@@ -45,7 +46,7 @@ public class JournalPortletPreferencesTranslator
 		String value = portletPreferencesJSONObject.getString(key);
 
 		if (key.equals("articleId")) {
-			String articleId = FileUtil.stripExtension(value);
+			String articleId = _file.stripExtension(value);
 
 			articleId = StringUtil.toUpperCase(articleId);
 
@@ -55,5 +56,8 @@ public class JournalPortletPreferencesTranslator
 
 		portletPreferences.setValue(key, value);
 	}
+
+	@Reference
+	private File _file;
 
 }

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/ExportImportHelperImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/ExportImportHelperImpl.java
@@ -78,7 +78,6 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.Digester;
 import com.liferay.portal.kernel.util.DigesterUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -467,7 +466,7 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 			FileEntry fileEntry)
 		throws Exception {
 
-		File file = FileUtil.createTempFile("lar");
+		File file = _file.createTempFile("lar");
 
 		ZipReader zipReader = null;
 
@@ -476,7 +475,7 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 		try (InputStream inputStream = _dlFileEntryLocalService.getFileAsStream(
 				fileEntry.getFileEntryId(), fileEntry.getVersion(), false)) {
 
-			FileUtil.write(file, inputStream);
+			_file.write(file, inputStream);
 
 			Group group = _groupLocalService.getGroup(groupId);
 			String userIdStrategy = MapUtil.getString(
@@ -496,7 +495,7 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 				zipReader.close();
 			}
 
-			FileUtil.delete(file);
+			_file.delete(file);
 		}
 
 		return manifestSummary;
@@ -1530,6 +1529,10 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 	private ConfigurationProvider _configurationProvider;
 
 	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
+
 	private GroupLocalService _groupLocalService;
 	private LayoutLocalService _layoutLocalService;
 	private LayoutRevisionLocalService _layoutRevisionLocalService;

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
@@ -51,7 +51,6 @@ import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -600,7 +599,7 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 		FileEntry fileEntry = PortletFileRepositoryUtil.addPortletFileEntry(
 			groupId, userId, className, classPK, FragmentPortletKeys.FRAGMENT,
 			repository.getDlFolderId(), inputStream,
-			classPK + "_preview." + FileUtil.getExtension(contentPath),
+			classPK + "_preview." + _file.getExtension(contentPath),
 			MimeTypesUtil.getContentType(contentPath), false);
 
 		return fileEntry.getFileEntryId();
@@ -893,6 +892,9 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 
 	@Reference
 	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private FragmentCollectionLocalService _fragmentCollectionLocalService;

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/CopyContributedEntryMVCActionCommand.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/CopyContributedEntryMVCActionCommand.java
@@ -36,7 +36,7 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -191,10 +191,10 @@ public class CopyContributedEntryMVCActionCommand extends BaseMVCActionCommand {
 			byte[] bytes = null;
 
 			try (InputStream inputStream = url.openStream()) {
-				bytes = FileUtil.getBytes(inputStream);
+				bytes = _file.getBytes(inputStream);
 			}
 
-			String shortFileName = FileUtil.getShortFileName(imagePreviewURL);
+			String shortFileName = _file.getShortFileName(imagePreviewURL);
 
 			Repository repository =
 				PortletFileRepositoryUtil.fetchPortletRepository(
@@ -229,6 +229,9 @@ public class CopyContributedEntryMVCActionCommand extends BaseMVCActionCommand {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		CopyContributedEntryMVCActionCommand.class);
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private FragmentCollectionContributorTracker

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingResourceImpl.java
@@ -46,7 +46,7 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
@@ -374,7 +374,7 @@ public class BlogPostingResourceImpl
 				image.getImageId());
 
 			return new ImageSelector(
-				FileUtil.getBytes(fileEntry.getContentStream()),
+				_file.getBytes(fileEntry.getContentStream()),
 				fileEntry.getFileName(), fileEntry.getMimeType(),
 				"{\"height\": 0, \"width\": 0, \"x\": 0, \"y\": 0}");
 		}
@@ -488,6 +488,9 @@ public class BlogPostingResourceImpl
 
 	@Reference
 	private ExpandoTableLocalService _expandoTableLocalService;
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private InfoItemServiceTracker _infoItemServiceTracker;

--- a/modules/apps/image-uploader/image-uploader-web/src/main/java/com/liferay/image/uploader/web/internal/portlet/action/UploadImageMVCActionCommand.java
+++ b/modules/apps/image-uploader/image-uploader-web/src/main/java/com/liferay/image/uploader/web/internal/portlet/action/UploadImageMVCActionCommand.java
@@ -49,7 +49,6 @@ import com.liferay.portal.kernel.upload.UploadRequestSizeException;
 import com.liferay.portal.kernel.upload.UploadServletRequestConfigurationHelper;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -379,7 +378,7 @@ public class UploadImageMVCActionCommand extends BaseMVCActionCommand {
 					(ThemeDisplay)actionRequest.getAttribute(
 						WebKeys.THEME_DISPLAY);
 
-				File file = FileUtil.createTempFile(bytes);
+				File file = _file.createTempFile(bytes);
 
 				try {
 					TempFileEntryUtil.deleteTempFileEntry(
@@ -413,6 +412,9 @@ public class UploadImageMVCActionCommand extends BaseMVCActionCommand {
 		UploadImageMVCActionCommand.class);
 
 	private volatile DLConfiguration _dlConfiguration;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -84,7 +84,6 @@ import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
 import com.liferay.portal.kernel.settings.GroupServiceSettingsLocator;
 import com.liferay.portal.kernel.trash.TrashHandler;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HtmlEscapableObject;
@@ -796,10 +795,10 @@ public class JournalArticleStagedModelDataHandler
 						smallImagePath);
 
 					if (bytes != null) {
-						smallFile = FileUtil.createTempFile(
+						smallFile = _file.createTempFile(
 							article.getSmallImageType());
 
-						FileUtil.write(smallFile, bytes);
+						_file.write(smallFile, bytes);
 					}
 				}
 			}
@@ -1816,6 +1815,9 @@ public class JournalArticleStagedModelDataHandler
 	@Reference(target = "(content.processor.type=DLReferences)")
 	private ExportImportContentProcessor<String>
 		_dlReferencesExportImportContentProcessor;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private FriendlyURLEntryLocalService _friendlyURLEntryLocalService;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalArticleModelValidator.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalArticleModelValidator.java
@@ -63,7 +63,6 @@ import com.liferay.portal.kernel.service.ImageLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -207,7 +206,7 @@ public class JournalArticleModelValidator
 		if (!validSmallImageExtension) {
 			throw new ArticleSmallImageNameException(
 				"Invalid image extension " +
-					FileUtil.getExtension(smallImageName));
+					_file.getExtension(smallImageName));
 		}
 
 		long smallImageMaxSize =
@@ -369,10 +368,9 @@ public class JournalArticleModelValidator
 
 				if (smallImageBytes != null) {
 					try {
-						smallImageFile = FileUtil.createTempFile(
-							image.getType());
+						smallImageFile = _file.createTempFile(image.getType());
 
-						FileUtil.write(smallImageFile, smallImageBytes, false);
+						_file.write(smallImageFile, smallImageBytes, false);
 					}
 					catch (IOException ioException) {
 						if (_log.isDebugEnabled()) {
@@ -528,6 +526,9 @@ public class JournalArticleModelValidator
 
 	@Reference
 	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private ImageLocalService _imageLocalService;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -178,7 +178,6 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.GroupSubscriptionCheckSubscriptionSender;
@@ -513,7 +512,7 @@ public class JournalArticleLocalServiceImpl
 		byte[] smallImageBytes = null;
 
 		try {
-			smallImageBytes = FileUtil.getBytes(smallImageFile);
+			smallImageBytes = _file.getBytes(smallImageFile);
 		}
 		catch (IOException ioException) {
 			if (_log.isDebugEnabled()) {
@@ -771,7 +770,7 @@ public class JournalArticleLocalServiceImpl
 		byte[] smallImageBytes = null;
 
 		try {
-			smallImageBytes = FileUtil.getBytes(smallImageFile);
+			smallImageBytes = _file.getBytes(smallImageFile);
 		}
 		catch (IOException ioException) {
 			if (_log.isDebugEnabled()) {
@@ -5672,7 +5671,7 @@ public class JournalArticleLocalServiceImpl
 		byte[] smallImageBytes = null;
 
 		try {
-			smallImageBytes = FileUtil.getBytes(smallImageFile);
+			smallImageBytes = _file.getBytes(smallImageFile);
 		}
 		catch (IOException ioException) {
 			if (_log.isDebugEnabled()) {
@@ -6288,7 +6287,7 @@ public class JournalArticleLocalServiceImpl
 		byte[] smallImageBytes = null;
 
 		try {
-			smallImageBytes = FileUtil.getBytes(smallImageFile);
+			smallImageBytes = _file.getBytes(smallImageFile);
 		}
 		catch (IOException ioException) {
 			if (_log.isDebugEnabled()) {
@@ -9301,6 +9300,9 @@ public class JournalArticleLocalServiceImpl
 
 	@Reference
 	private FieldsToDDMFormValuesConverter _fieldsToDDMFormValuesConverter;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ImportDataDefinitionMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ImportDataDefinitionMVCActionCommand.java
@@ -32,7 +32,7 @@ import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -76,7 +76,7 @@ public class ImportDataDefinitionMVCActionCommand extends BaseMVCActionCommand {
 				_getUploadPortletRequest(actionRequest);
 
 			DataDefinition dataDefinition = DataDefinition.toDTO(
-				FileUtil.read(uploadPortletRequest.getFile("jsonFile")));
+				_file.read(uploadPortletRequest.getFile("jsonFile")));
 
 			dataDefinition.setName(
 				HashMapBuilder.<String, Object>put(
@@ -278,6 +278,9 @@ public class ImportDataDefinitionMVCActionCommand extends BaseMVCActionCommand {
 	private DataDefinitionResource.Factory _dataDefinitionResourceFactory;
 
 	private final Set<String> _fieldNames = new HashSet<>();
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/upload/ImageJournalUploadFileEntryHandler.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/upload/ImageJournalUploadFileEntryHandler.java
@@ -32,7 +32,7 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -197,7 +197,7 @@ public class ImageJournalUploadFileEntryHandler
 
 		_dlValidator.validateFileSize(fileName, size);
 
-		String extension = FileUtil.getExtension(fileName);
+		String extension = _file.getExtension(fileName);
 
 		for (String imageExtension :
 				_journalFileUploadsConfiguration.imageExtensions()) {
@@ -224,6 +224,9 @@ public class ImageJournalUploadFileEntryHandler
 
 	@Reference
 	private DLValidator _dlValidator;
+
+	@Reference
+	private File _file;
 
 	private ModelResourcePermission<JournalArticle>
 		_journalArticleModelResourcePermission;

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutMVCActionCommand.java
@@ -33,7 +33,7 @@ import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.servlet.MultiSessionMessages;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -108,7 +108,7 @@ public class EditLayoutMVCActionCommand extends BaseMVCActionCommand {
 				FileEntry fileEntry = _dlAppLocalService.getFileEntry(
 					fileEntryId);
 
-				iconBytes = FileUtil.getBytes(fileEntry.getContentStream());
+				iconBytes = _file.getBytes(fileEntry.getContentStream());
 			}
 
 			Layout layout = _layoutLocalService.getLayout(
@@ -255,6 +255,9 @@ public class EditLayoutMVCActionCommand extends BaseMVCActionCommand {
 
 	@Reference
 	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutSetMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutSetMVCActionCommand.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.service.GroupService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.service.LayoutSetService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PropertiesParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -136,7 +136,7 @@ public class EditLayoutSetMVCActionCommand extends BaseMVCActionCommand {
 		if (fileEntryId > 0) {
 			FileEntry fileEntry = _dlAppLocalService.getFileEntry(fileEntryId);
 
-			logoBytes = FileUtil.getBytes(fileEntry.getContentStream());
+			logoBytes = _file.getBytes(fileEntry.getContentStream());
 		}
 
 		long groupId = liveGroupId;
@@ -190,6 +190,9 @@ public class EditLayoutSetMVCActionCommand extends BaseMVCActionCommand {
 
 	@Reference
 	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddFragmentCompositionMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddFragmentCompositionMVCActionCommand.java
@@ -42,7 +42,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Base64;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -185,7 +185,7 @@ public class AddFragmentCompositionMVCActionCommand
 
 				URL imageURL = new URL(url);
 
-				bytes = FileUtil.getBytes(imageURL.openStream());
+				bytes = _file.getBytes(imageURL.openStream());
 			}
 
 			if (bytes.length == 0) {
@@ -227,6 +227,9 @@ public class AddFragmentCompositionMVCActionCommand
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		AddFragmentCompositionMVCActionCommand.class);
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private FragmentCollectionContributorTracker

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/importer/LayoutPageTemplatesImporterImpl.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/importer/LayoutPageTemplatesImporterImpl.java
@@ -80,7 +80,6 @@ import com.liferay.portal.kernel.service.ThemeLocalService;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -747,12 +746,12 @@ public class LayoutPageTemplatesImporterImpl
 
 		String imageFileName =
 			layoutPageTemplateEntryId + "_preview." +
-				FileUtil.getExtension(zipEntry.getName());
+				_file.getExtension(zipEntry.getName());
 
 		byte[] bytes = null;
 
 		try (InputStream inputStream = zipFile.getInputStream(zipEntry)) {
-			bytes = FileUtil.getBytes(inputStream);
+			bytes = _file.getBytes(inputStream);
 		}
 
 		FileEntry fileEntry = _portletFileRepository.fetchPortletFileEntry(
@@ -1415,6 +1414,9 @@ public class LayoutPageTemplatesImporterImpl
 	private static final TransactionConfig _transactionConfig =
 		TransactionConfig.Factory.create(
 			Propagation.REQUIRED, new Class<?>[] {Exception.class});
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/portlet/MarketplaceAppManagerPortlet.java
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/portlet/MarketplaceAppManagerPortlet.java
@@ -45,7 +45,6 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadException;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -159,7 +158,7 @@ public class MarketplaceAppManagerPortlet extends MVCPortlet {
 
 		File file = uploadPortletRequest.getFile("file");
 
-		if (ArrayUtil.isEmpty(FileUtil.getBytes(file))) {
+		if (ArrayUtil.isEmpty(_file.getBytes(file))) {
 			SessionErrors.add(actionRequest, UploadException.class.getName());
 		}
 		else if (!fileName.endsWith(".jar") && !fileName.endsWith(".lpkg") &&
@@ -170,7 +169,7 @@ public class MarketplaceAppManagerPortlet extends MVCPortlet {
 		else {
 			String deployDir = PropsUtil.get(PropsKeys.AUTO_DEPLOY_DEPLOY_DIR);
 
-			FileUtil.copyFile(
+			_file.copyFile(
 				file.toString(), deployDir + StringPool.SLASH + fileName);
 
 			SessionMessages.add(actionRequest, "pluginUploaded");
@@ -469,7 +468,7 @@ public class MarketplaceAppManagerPortlet extends MVCPortlet {
 
 				File destinationFile = new File(destination);
 
-				FileUtil.write(destinationFile, bytes);
+				_file.write(destinationFile, bytes);
 
 				SessionMessages.add(actionRequest, "pluginDownloaded");
 			}
@@ -532,6 +531,9 @@ public class MarketplaceAppManagerPortlet extends MVCPortlet {
 
 	@Reference
 	private BundleManager _bundleManager;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private Http _http;

--- a/modules/apps/marketplace/marketplace-service/src/main/java/com/liferay/marketplace/service/impl/AppLocalServiceImpl.java
+++ b/modules/apps/marketplace/marketplace-service/src/main/java/com/liferay/marketplace/service/impl/AppLocalServiceImpl.java
@@ -37,7 +37,6 @@ import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.plugin.PluginPackage;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -277,10 +276,9 @@ public class AppLocalServiceImpl extends AppLocalServiceBaseImpl {
 				StringBundler.concat(
 					SystemProperties.get(SystemProperties.TMP_DIR),
 					StringPool.SLASH, encodeSafeFileName(app.getTitle()),
-					StringPool.PERIOD,
-					FileUtil.getExtension(app.getFileName())));
+					StringPool.PERIOD, _file.getExtension(app.getFileName())));
 
-			FileUtil.write(file, inputStream);
+			_file.write(file, inputStream);
 
 			BundleManagerUtil.installLPKG(file);
 		}
@@ -413,7 +411,7 @@ public class AppLocalServiceImpl extends AppLocalServiceBaseImpl {
 			return StringPool.BLANK;
 		}
 
-		fileName = FileUtil.encodeSafeFileName(fileName);
+		fileName = _file.encodeSafeFileName(fileName);
 
 		return StringUtil.replace(
 			fileName, _SAFE_FILE_NAME_1, _SAFE_FILE_NAME_2);
@@ -435,12 +433,12 @@ public class AppLocalServiceImpl extends AppLocalServiceBaseImpl {
 					try (InputStream subsystemInputStream =
 							zipFile.getInputStream(subsystemZipEntry)) {
 
-						file = FileUtil.createTempFile(subsystemInputStream);
+						file = _file.createTempFile(subsystemInputStream);
 
 						return getMarketplaceProperties(file);
 					}
 					finally {
-						FileUtil.delete(file);
+						_file.delete(file);
 					}
 				}
 
@@ -493,6 +491,9 @@ public class AppLocalServiceImpl extends AppLocalServiceBaseImpl {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		AppLocalServiceImpl.class);
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	private List<App> _installedApps;
 

--- a/modules/apps/marketplace/marketplace-store-web/src/main/java/com/liferay/marketplace/store/web/internal/portlet/MarketplaceStorePortlet.java
+++ b/modules/apps/marketplace/marketplace-store-web/src/main/java/com/liferay/marketplace/store/web/internal/portlet/MarketplaceStorePortlet.java
@@ -33,7 +33,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.patcher.PatcherUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.ReleaseInfo;
 import com.liferay.portal.kernel.util.Validator;
@@ -104,7 +103,7 @@ public class MarketplaceStorePortlet extends RemoteMVCPortlet {
 		File file = null;
 
 		try {
-			file = FileUtil.createTempFile();
+			file = _file.createTempFile();
 
 			downloadApp(
 				actionRequest, actionResponse, appPackageId, unlicensed, file);
@@ -276,7 +275,7 @@ public class MarketplaceStorePortlet extends RemoteMVCPortlet {
 		File file = null;
 
 		try {
-			file = FileUtil.createTempFile();
+			file = _file.createTempFile();
 
 			downloadApp(
 				actionRequest, actionResponse, appPackageId, unlicensed, file);
@@ -362,7 +361,7 @@ public class MarketplaceStorePortlet extends RemoteMVCPortlet {
 					File file = null;
 
 					try {
-						file = FileUtil.createTempFile();
+						file = _file.createTempFile();
 
 						downloadApp(
 							actionRequest, actionResponse, appPackageId, false,
@@ -460,7 +459,7 @@ public class MarketplaceStorePortlet extends RemoteMVCPortlet {
 
 		Response response = getResponse(themeDisplay.getUser(), oAuthRequest);
 
-		FileUtil.write(file, response.getStream());
+		_file.write(file, response.getStream());
 	}
 
 	@Override
@@ -564,6 +563,10 @@ public class MarketplaceStorePortlet extends RemoteMVCPortlet {
 
 	private AppLocalService _appLocalService;
 	private AppService _appService;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
+
 	private final ReentrantLock _reentrantLock = new ReentrantLock();
 
 }

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/portlet/action/ImportObjectDefinitionMVCActionCommand.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/definitions/portlet/action/ImportObjectDefinitionMVCActionCommand.java
@@ -38,7 +38,7 @@ import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -152,7 +152,7 @@ public class ImportObjectDefinitionMVCActionCommand
 		UploadPortletRequest uploadPortletRequest = _getUploadPortletRequest(
 			actionRequest);
 
-		String objectDefinitionJSON = FileUtil.read(
+		String objectDefinitionJSON = _file.read(
 			uploadPortletRequest.getFile("objectDefinitionJSON"));
 
 		JSONObject objectDefinitionJSONObject =
@@ -273,6 +273,9 @@ public class ImportObjectDefinitionMVCActionCommand
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ImportObjectDefinitionMVCActionCommand.class);
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private ObjectActionResource.Factory _objectActionResourceFactory;

--- a/modules/apps/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/internal/portlet/action/EditCompanyMVCActionCommand.java
+++ b/modules/apps/portal-settings/portal-settings-web/src/main/java/com/liferay/portal/settings/web/internal/portlet/action/EditCompanyMVCActionCommand.java
@@ -59,7 +59,7 @@ import com.liferay.portal.kernel.service.WebsiteLocalService;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Constants;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -201,7 +201,7 @@ public class EditCompanyMVCActionCommand extends BaseFormMVCActionCommand {
 		if (fileEntryId > 0) {
 			FileEntry fileEntry = _dlAppLocalService.getFileEntry(fileEntryId);
 
-			logoBytes = FileUtil.getBytes(fileEntry.getContentStream());
+			logoBytes = _file.getBytes(fileEntry.getContentStream());
 		}
 
 		User defaultUser = _userLocalService.getDefaultUser(companyId);
@@ -401,6 +401,9 @@ public class EditCompanyMVCActionCommand extends BaseFormMVCActionCommand {
 
 	@Reference
 	private EmailAddressLocalService _emailAddressLocalService;
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/portal-store/portal-store-azure/src/main/java/com/liferay/portal/store/azure/AzureStore.java
+++ b/modules/apps/portal-store/portal-store-azure/src/main/java/com/liferay/portal/store/azure/AzureStore.java
@@ -46,7 +46,6 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -68,6 +67,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Josef Sustacek
@@ -92,7 +92,7 @@ public class AzureStore implements Store {
 		File tempFile = null;
 
 		try {
-			tempFile = FileUtil.createTempFile(inputStream);
+			tempFile = _file.createTempFile(inputStream);
 
 			blobClient.uploadFromFile(tempFile.getAbsolutePath(), true);
 		}
@@ -105,7 +105,7 @@ public class AzureStore implements Store {
 				"Unable to add file", uncheckedIOException);
 		}
 		finally {
-			FileUtil.delete(tempFile);
+			_file.delete(tempFile);
 		}
 	}
 
@@ -449,5 +449,8 @@ public class AzureStore implements Store {
 	private static final Log _log = LogFactoryUtil.getLog(AzureStore.class);
 
 	private volatile BlobContainerClient _blobContainerClient;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 }

--- a/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/IBMS3Store.java
+++ b/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/IBMS3Store.java
@@ -54,7 +54,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.store.s3.configuration.S3StoreConfiguration;
 
@@ -107,7 +106,7 @@ public class IBMS3Store implements Store {
 		File file = null;
 
 		try {
-			file = FileUtil.createTempFile(inputStream);
+			file = _file.createTempFile(inputStream);
 
 			putObject(companyId, repositoryId, fileName, versionLabel, file);
 		}
@@ -115,7 +114,7 @@ public class IBMS3Store implements Store {
 			throw new SystemException(ioException);
 		}
 		finally {
-			FileUtil.delete(file);
+			_file.delete(file);
 		}
 	}
 
@@ -731,6 +730,9 @@ public class IBMS3Store implements Store {
 	private AmazonS3 _amazonS3;
 	private AWSCredentialsProvider _awsCredentialsProvider;
 	private String _bucketName;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private S3FileCache _s3FileCache;

--- a/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3FileCache.java
+++ b/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3FileCache.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.backgroundtask.BackgroundTaskThreadLocal;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.DateUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StreamUtil;
 import com.liferay.portal.kernel.util.SystemProperties;
@@ -140,7 +139,7 @@ public class S3FileCache {
 				throw new IOException("S3 object input stream is null");
 			}
 
-			FileUtil.mkdirs(cacheFile.getParentFile());
+			_file.mkdirs(cacheFile.getParentFile());
 
 			try (OutputStream outputStream = new FileOutputStream(cacheFile)) {
 				StreamUtil.transfer(inputStream, outputStream);
@@ -249,6 +248,10 @@ public class S3FileCache {
 	private volatile AtomicInteger _cacheDirCleanUpExpunge;
 	private volatile AtomicInteger _cacheDirCleanUpFrequency;
 	private int _calledCleanUpCacheFilesCount;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
+
 	private S3KeyTransformer _s3KeyTransformer;
 	private volatile S3StoreConfiguration _s3StoreConfiguration;
 

--- a/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java
+++ b/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java
@@ -54,7 +54,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.store.s3.configuration.S3StoreConfiguration;
 
@@ -104,7 +103,7 @@ public class S3Store implements Store {
 		File file = null;
 
 		try {
-			file = FileUtil.createTempFile(inputStream);
+			file = _file.createTempFile(inputStream);
 
 			putObject(companyId, repositoryId, fileName, versionLabel, file);
 		}
@@ -112,7 +111,7 @@ public class S3Store implements Store {
 			throw new SystemException(ioException);
 		}
 		finally {
-			FileUtil.delete(file);
+			_file.delete(file);
 		}
 	}
 
@@ -728,6 +727,9 @@ public class S3Store implements Store {
 	private AmazonS3 _amazonS3;
 	private AWSCredentialsProvider _awsCredentialsProvider;
 	private String _bucketName;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private S3FileCache _s3FileCache;

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/manager/DefaultPortalKaleoManager.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/manager/DefaultPortalKaleoManager.java
@@ -33,7 +33,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.settings.LocalizedValuesMap;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
@@ -189,7 +189,7 @@ public class DefaultPortalKaleoManager
 			_workflowDefinitionManager.deployWorkflowDefinition(
 				serviceContext.getCompanyId(), defaultUser.getUserId(),
 				_getLocalizedTitle(companyId, definitionName), definitionName,
-				FileUtil.getBytes(inputStream));
+				_file.getBytes(inputStream));
 		}
 	}
 
@@ -344,6 +344,9 @@ public class DefaultPortalKaleoManager
 		_DEFINITION_NAME,
 		"META-INF/definitions/single-approver-workflow-definition.xml"
 	).build();
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private Language _language;

--- a/modules/apps/portal/portal-license-deployer/src/main/java/com/liferay/portal/license/deployer/internal/installer/LicenseInstaller.java
+++ b/modules/apps/portal/portal-license-deployer/src/main/java/com/liferay/portal/license/deployer/internal/installer/LicenseInstaller.java
@@ -20,7 +20,6 @@ import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
@@ -40,14 +39,14 @@ public class LicenseInstaller implements FileInstaller {
 
 	@Override
 	public boolean canTransformURL(File artifact) {
-		String extension = FileUtil.getExtension(artifact.getName());
+		String extension = _file.getExtension(artifact.getName());
 
 		if (!extension.equals("xml")) {
 			return false;
 		}
 
 		try {
-			String content = FileUtil.read(artifact);
+			String content = _file.read(artifact);
 
 			Document document = SAXReaderUtil.read(content);
 
@@ -73,7 +72,7 @@ public class LicenseInstaller implements FileInstaller {
 	@Override
 	public URL transformURL(File file) throws Exception {
 		LicenseManagerUtil.registerLicense(
-			JSONUtil.put("licenseXML", FileUtil.read(file)));
+			JSONUtil.put("licenseXML", _file.read(file)));
 
 		return null;
 	}
@@ -84,6 +83,9 @@ public class LicenseInstaller implements FileInstaller {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		LicenseInstaller.class);
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference(target = ModuleServiceLifecycle.LICENSE_INSTALL)
 	private ModuleServiceLifecycle _moduleServiceLifecycle;

--- a/modules/apps/site/site-welcome-site-initializer/src/main/java/com/liferay/site/welcome/site/initializer/internal/WelcomeSiteInitializer.java
+++ b/modules/apps/site/site-welcome-site-initializer/src/main/java/com/liferay/site/welcome/site/initializer/internal/WelcomeSiteInitializer.java
@@ -46,7 +46,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -250,7 +250,7 @@ public class WelcomeSiteInitializer implements SiteInitializer {
 		byte[] bytes = null;
 
 		try (InputStream inputStream = url.openStream()) {
-			bytes = FileUtil.getBytes(inputStream);
+			bytes = _file.getBytes(inputStream);
 		}
 
 		fileEntry = _portletFileRepository.addPortletFileEntry(
@@ -369,6 +369,9 @@ public class WelcomeSiteInitializer implements SiteInitializer {
 		WelcomeSiteInitializer.class);
 
 	private Bundle _bundle;
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JspReloader.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-servlet-jsp-compiler/src/main/java/com/liferay/portal/osgi/web/servlet/jsp/compiler/internal/JspReloader.java
@@ -18,7 +18,6 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.util.PropsValues;
 
 import java.io.File;
@@ -30,6 +29,7 @@ import org.osgi.framework.BundleListener;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Matthew Tambara
@@ -75,6 +75,9 @@ public class JspReloader {
 
 	private BundleContext _bundleContext;
 
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
+
 	private final BundleListener _jspReloadBundleListener =
 		new BundleListener() {
 
@@ -96,7 +99,7 @@ public class JspReloader {
 						bundle.getVersion());
 
 				if (file.exists()) {
-					FileUtil.deltree(file);
+					_file.deltree(file);
 
 					if (PropsValues.WORK_DIR_OVERRIDE_ENABLED &&
 						_log.isInfoEnabled()) {

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-reference-support/src/main/java/com/liferay/portal/osgi/web/wab/reference/support/internal/WabDirURLStreamHandlerService.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-reference-support/src/main/java/com/liferay/portal/osgi/web/wab/reference/support/internal/WabDirURLStreamHandlerService.java
@@ -17,7 +17,6 @@ package com.liferay.portal.osgi.web.wab.reference.support.internal;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.xml.Document;
@@ -204,7 +203,7 @@ public class WabDirURLStreamHandlerService
 	}
 
 	private Document _readDocument(File file) throws IOException {
-		String content = FileUtil.read(file);
+		String content = _file.read(file);
 
 		try {
 			return UnsecureSAXReaderUtil.read(content);

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/zip/processor/StyleBookEntryZipProcessorImpl.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/zip/processor/StyleBookEntryZipProcessorImpl.java
@@ -27,7 +27,6 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -259,7 +258,7 @@ public class StyleBookEntryZipProcessorImpl
 			groupId, userId, className, classPK,
 			StyleBookPortletKeys.STYLE_BOOK, repository.getDlFolderId(),
 			inputStream,
-			classPK + "_preview." + FileUtil.getExtension(contentPath),
+			classPK + "_preview." + _file.getExtension(contentPath),
 			MimeTypesUtil.getContentType(contentPath), false);
 
 		return fileEntry.getFileEntryId();
@@ -369,6 +368,9 @@ public class StyleBookEntryZipProcessorImpl
 
 	@Reference
 	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	private List<StyleBookEntryZipProcessorImportResultEntry>
 		_importResultEntries;

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/importer/XLIFFInfoFormTranslationImporter.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/importer/XLIFFInfoFormTranslationImporter.java
@@ -25,7 +25,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.LayoutLocalService;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -297,7 +296,7 @@ public class XLIFFInfoFormTranslationImporter
 			XLIFFInfoFormTranslationImporter.class.getClassLoader());
 
 		try (AutoXLIFFFilter autoXLIFFFilter = new AutoXLIFFFilter()) {
-			File tempFile = FileUtil.createTempFile(inputStream);
+			File tempFile = _file.createTempFile(inputStream);
 
 			Document document = _saxReader.read(tempFile);
 
@@ -658,6 +657,9 @@ public class XLIFFInfoFormTranslationImporter
 	}
 
 	private static final Pattern _pattern = Pattern.compile("([^:]+):(.+)");
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private Language _language;

--- a/modules/apps/upload/upload-web/src/main/java/com/liferay/upload/web/internal/DefaultUniqueFileNameProvider.java
+++ b/modules/apps/upload/upload-web/src/main/java/com/liferay/upload/web/internal/DefaultUniqueFileNameProvider.java
@@ -17,7 +17,6 @@ package com.liferay.upload.web.internal;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.upload.UploadServletRequestConfigurationHelper;
 import com.liferay.portal.kernel.util.File;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.upload.UniqueFileNameProvider;
 
 import java.util.function.Predicate;
@@ -51,7 +50,7 @@ public class DefaultUniqueFileNameProvider implements UniqueFileNameProvider {
 
 			tries++;
 
-			uniqueFileName = FileUtil.appendParentheticalSuffix(
+			uniqueFileName = _file.appendParentheticalSuffix(
 				baseFileName, String.valueOf(tries));
 		}
 

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/EditOrganizationMVCActionCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/EditOrganizationMVCActionCommand.java
@@ -37,7 +37,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.Constants;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -202,7 +202,7 @@ public class EditOrganizationMVCActionCommand extends BaseMVCActionCommand {
 		if (fileEntryId > 0) {
 			FileEntry fileEntry = _dlAppLocalService.getFileEntry(fileEntryId);
 
-			logoBytes = FileUtil.getBytes(fileEntry.getContentStream());
+			logoBytes = _file.getBytes(fileEntry.getContentStream());
 		}
 
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
@@ -244,6 +244,9 @@ public class EditOrganizationMVCActionCommand extends BaseMVCActionCommand {
 
 	@Reference
 	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private Http _http;

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/EditUserMVCActionCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/EditUserMVCActionCommand.java
@@ -63,7 +63,7 @@ import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.Constants;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -375,7 +375,7 @@ public class EditUserMVCActionCommand extends BaseMVCActionCommand {
 		if (fileEntryId > 0) {
 			FileEntry fileEntry = _dlAppLocalService.getFileEntry(fileEntryId);
 
-			portraitBytes = FileUtil.getBytes(fileEntry.getContentStream());
+			portraitBytes = _file.getBytes(fileEntry.getContentStream());
 		}
 
 		String languageId = BeanParamUtil.getString(
@@ -569,6 +569,10 @@ public class EditUserMVCActionCommand extends BaseMVCActionCommand {
 	}
 
 	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
+	private File _file;
+
 	private ListTypeLocalService _listTypeLocalService;
 
 	@Reference

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -74,7 +74,6 @@ import com.liferay.portal.kernel.systemevent.SystemEventHierarchyEntryThreadLoca
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -442,7 +441,7 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 			File file = null;
 
 			try {
-				file = FileUtil.createTempFile(inputStream);
+				file = _file.createTempFile(inputStream);
 
 				String mimeType = _mimeTypes.getContentType(file, fileName);
 
@@ -456,7 +455,7 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 					"Unable to write temporary file", ioException);
 			}
 			finally {
-				FileUtil.delete(file);
+				_file.delete(file);
 			}
 		}
 
@@ -3459,6 +3458,9 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 
 	@Reference
 	private ExpandoRowLocalService _expandoRowLocalService;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private IndexerRegistry _indexerRegistry;

--- a/modules/dxp/apps/antivirus/antivirus-async-store/src/main/java/com/liferay/antivirus/async/store/internal/AntivirusAsyncDLStore.java
+++ b/modules/dxp/apps/antivirus/antivirus-async-store/src/main/java/com/liferay/antivirus/async/store/internal/AntivirusAsyncDLStore.java
@@ -35,7 +35,6 @@ import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portlet.documentlibrary.store.StoreFactory;
 
 import java.io.File;
@@ -132,9 +131,9 @@ public class AntivirusAsyncDLStore implements DLStore {
 		File tempFile = null;
 
 		try {
-			tempFile = FileUtil.createTempFile();
+			tempFile = _file.createTempFile();
 
-			FileUtil.write(tempFile, inputStream1);
+			_file.write(tempFile, inputStream1);
 
 			try (InputStream inputStream2 = new FileInputStream(tempFile)) {
 				store.addFile(
@@ -716,6 +715,9 @@ public class AntivirusAsyncDLStore implements DLStore {
 
 	@Reference
 	private DLValidator _dlValidator;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	private final StoreFactory _storeFactory;
 

--- a/modules/dxp/apps/antivirus/antivirus-async-store/src/main/java/com/liferay/antivirus/async/store/internal/messaging/AntivirusAsyncFileStoreMessageListener.java
+++ b/modules/dxp/apps/antivirus/antivirus-async-store/src/main/java/com/liferay/antivirus/async/store/internal/messaging/AntivirusAsyncFileStoreMessageListener.java
@@ -40,7 +40,6 @@ import com.liferay.portal.kernel.scheduler.StorageType;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
 import com.liferay.portal.kernel.scheduler.messaging.SchedulerResponse;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 
@@ -263,11 +262,11 @@ public class AntivirusAsyncFileStoreMessageListener implements MessageListener {
 				relativePath.subpath(0, relativePath.getNameCount() - 1));
 		}
 
-		String fileExtension = FileUtil.getExtension(fileName);
+		String fileExtension = _file.getExtension(fileName);
 
 		if (fileExtension.equals("afsh")) {
 			fileExtension = StringPool.BLANK;
-			fileName = FileUtil.stripExtension(fileName);
+			fileName = _file.stripExtension(fileName);
 		}
 
 		if (!fileNameFragment.isEmpty()) {
@@ -332,6 +331,9 @@ public class AntivirusAsyncFileStoreMessageListener implements MessageListener {
 
 	@Reference
 	private DestinationFactory _destinationFactory;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private MessageBus _messageBus;

--- a/modules/dxp/apps/commerce-salesforce-connector/commerce-salesforce-connector/src/main/java/com/liferay/commerce/salesforce/connector/internal/instance/lifecycle/AddCommerceSalesforceConnectorPortalInstanceLifecycleListener.java
+++ b/modules/dxp/apps/commerce-salesforce-connector/commerce-salesforce-connector/src/main/java/com/liferay/commerce/salesforce/connector/internal/instance/lifecycle/AddCommerceSalesforceConnectorPortalInstanceLifecycleListener.java
@@ -23,7 +23,6 @@ import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener
 import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portlet.documentlibrary.store.StoreFactory;
 
@@ -68,7 +67,7 @@ public class AddCommerceSalesforceConnectorPortalInstanceLifecycleListener
 
 		Class<?> clazz = getClass();
 
-		File connectorArchiveFile = FileUtil.createTempFile(
+		File connectorArchiveFile = _file.createTempFile(
 			clazz.getResourceAsStream("/" + name));
 
 		try (FileInputStream fileInputStream = new FileInputStream(
@@ -90,7 +89,7 @@ public class AddCommerceSalesforceConnectorPortalInstanceLifecycleListener
 				"application/zip", new FileInputStream(connectorArchiveFile));
 		}
 		finally {
-			FileUtil.delete(connectorArchiveFile);
+			_file.delete(connectorArchiveFile);
 		}
 	}
 
@@ -102,6 +101,9 @@ public class AddCommerceSalesforceConnectorPortalInstanceLifecycleListener
 
 	@Reference
 	private DLFileVersionPreviewLocalService _dlFileVersionPreviewLocalService;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference(target = "(dl.store.impl.enabled=true)")
 	private StoreFactory _storeFactory;

--- a/modules/dxp/apps/commerce/commerce-shop-by-diagram-web/src/main/java/com/liferay/commerce/shop/by/diagram/admin/web/internal/upload/CSDiagramSettingImageUploadFileEntryHandler.java
+++ b/modules/dxp/apps/commerce/commerce-shop-by-diagram-web/src/main/java/com/liferay/commerce/shop/by/diagram/admin/web/internal/upload/CSDiagramSettingImageUploadFileEntryHandler.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.upload.UniqueFileNameProvider;
@@ -128,7 +128,7 @@ public class CSDiagramSettingImageUploadFileEntryHandler
 			throw new CPAttachmentFileEntrySizeException();
 		}
 
-		String extension = FileUtil.getExtension(fileName);
+		String extension = _file.getExtension(fileName);
 
 		String[] imageExtensions =
 			_csDiagramSettingImageConfiguration.imageExtensions();
@@ -155,6 +155,9 @@ public class CSDiagramSettingImageUploadFileEntryHandler
 
 	private volatile CSDiagramSettingImageConfiguration
 		_csDiagramSettingImageConfiguration;
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private UniqueFileNameProvider _uniqueFileNameProvider;

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/DLOpenerOneDriveManager.java
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/DLOpenerOneDriveManager.java
@@ -38,7 +38,6 @@ import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -317,7 +316,7 @@ public class DLOpenerOneDriveManager {
 				).buildRequest();
 
 			try (InputStream inputStream = iDriveItemStreamRequest.get()) {
-				return FileUtil.createTempFile(inputStream);
+				return _file.createTempFile(inputStream);
 			}
 		}
 		catch (GraphServiceException graphServiceException) {
@@ -390,6 +389,9 @@ public class DLOpenerOneDriveManager {
 	@Reference
 	private DLOpenerFileEntryReferenceLocalService
 		_dlOpenerFileEntryReferenceLocalService;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private OAuth2Manager _oAuth2Manager;

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/service/DLOpenerOneDriveDLAppServiceWrapper.java
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/service/DLOpenerOneDriveDLAppServiceWrapper.java
@@ -35,7 +35,6 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceWrapper;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.io.File;
@@ -209,7 +208,7 @@ public class DLOpenerOneDriveDLAppServiceWrapper extends DLAppServiceWrapper {
 				fileEntry.getGroupId(), fileEntry.getFolderId(),
 				mimeTypeExtension,
 				_dlValidator.fixName(
-					FileUtil.stripExtension(
+					_file.stripExtension(
 						dLOpenerOneDriveFileReference.getTitle())));
 
 			sourceFileName = title.concat(mimeTypeExtension);
@@ -245,6 +244,9 @@ public class DLOpenerOneDriveDLAppServiceWrapper extends DLAppServiceWrapper {
 
 	@Reference
 	private DLValidator _dlValidator;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private UniqueFileEntryTitleProvider _uniqueFileEntryTitleProvider;

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-service/src/main/java/com/liferay/portal/reports/engine/console/service/impl/EntryLocalServiceImpl.java
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-service/src/main/java/com/liferay/portal/reports/engine/console/service/impl/EntryLocalServiceImpl.java
@@ -43,7 +43,6 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.settings.GroupServiceSettingsLocator;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.Portal;
@@ -456,7 +455,7 @@ public class EntryLocalServiceImpl extends EntryLocalServiceBaseImpl {
 				throw new IOException("Unable to open file " + fileName);
 			}
 
-			return FileUtil.createTempFile(inputStream);
+			return _file.createTempFile(inputStream);
 		}
 	}
 
@@ -589,6 +588,9 @@ public class EntryLocalServiceImpl extends EntryLocalServiceBaseImpl {
 
 	@Reference
 	private ConfigurationProvider _configurationProvider;
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 	@Reference
 	private JSONFactory _jsonFactory;

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/java/com/liferay/portal/reports/engine/console/web/internal/admin/lar/DefinitionStagedModelDataHandler.java
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/java/com/liferay/portal/reports/engine/console/web/internal/admin/lar/DefinitionStagedModelDataHandler.java
@@ -25,7 +25,7 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.reports.engine.console.model.Definition;
@@ -167,7 +167,7 @@ public class DefinitionStagedModelDataHandler
 			String fullFileName = attachmentElement.attributeValue(
 				"full-file-name");
 
-			fileName = FileUtil.getShortFileName(fullFileName);
+			fileName = _file.getShortFileName(fullFileName);
 		}
 
 		try (InputStream inputStream =
@@ -215,6 +215,9 @@ public class DefinitionStagedModelDataHandler
 
 	@Reference
 	private DefinitionLocalService _definitionLocalService;
+
+	@Reference
+	private File _file;
 
 	@Reference
 	private SourceLocalService _sourceLocalService;

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/credential/DLKeyStoreManagerImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/credential/DLKeyStoreManagerImpl.java
@@ -21,7 +21,6 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.saml.runtime.credential.KeyStoreManager;
 
 import java.io.File;
@@ -39,6 +38,7 @@ import java.util.Map;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Mika Koivisto
@@ -95,7 +95,7 @@ public class DLKeyStoreManagerImpl extends BaseKeyStoreManagerImpl {
 
 	@Override
 	public void saveKeyStore(KeyStore keyStore) throws Exception {
-		File tempFile = FileUtil.createTempFile("jks");
+		File tempFile = _file.createTempFile("jks");
 
 		try {
 			String samlKeyStorePassword = getSamlKeyStorePassword();
@@ -138,5 +138,8 @@ public class DLKeyStoreManagerImpl extends BaseKeyStoreManagerImpl {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DLKeyStoreManagerImpl.class);
+
+	@Reference
+	private com.liferay.portal.kernel.util.File _file;
 
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/power/tools/portlet/action/ImportGooglePlacesMVCActionCommand.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/power/tools/portlet/action/ImportGooglePlacesMVCActionCommand.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -36,6 +36,7 @@ import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Petteri Karttunen
@@ -140,7 +141,7 @@ public class ImportGooglePlacesMVCActionCommand extends BaseMVCActionCommand {
 	private JSONObject _read(String fileName) throws Exception {
 		return jsonFactory.createJSONObject(
 			new String(
-				FileUtil.getBytes(
+				_file.getBytes(
 					getClass(),
 					"dependencies/google/places/" + fileName + ".json")));
 	}
@@ -187,5 +188,8 @@ public class ImportGooglePlacesMVCActionCommand extends BaseMVCActionCommand {
 		CharPool.QUESTION, CharPool.QUOTE, CharPool.RETURN, CharPool.SEMICOLON,
 		CharPool.SLASH, CharPool.STAR, CharPool.TILDE
 	};
+
+	@Reference
+	private File _file;
 
 }

--- a/modules/util/source-formatter/source-formatter-suppressions.xml
+++ b/modules/util/source-formatter/source-formatter-suppressions.xml
@@ -12,6 +12,7 @@
 		<suppress checks="JavaInterfaceCheck" files="src/main/java/com/liferay/source/formatter/check/JavaInterfaceCheck\.java" />
 		<suppress checks="JavaModuleIllegalImportsCheck" files="src/main/java/com/liferay/source/formatter/check/JavaModuleIllegalImportsCheck\.java" />
 		<suppress checks="JavaModuleServiceProxyFactoryCheck" files="src/main/java/com/liferay/source/formatter/check/JavaModuleServiceProxyFactoryCheck\.java" />
+		<suppress checks="JavaOSGiReferenceCheck" files="src/main/java/com/liferay/source/formatter/check/JavaOSGiReferenceCheck\.java" />
 		<suppress checks="JavaStopWatchCheck" files="src/main/java/com/liferay/source/formatter/check/JavaStopWatchCheck\.java" />
 		<suppress checks="JavaStylingCheck" files="src/main/java/com/liferay/source/formatter/check/BaseStylingCheck\.java" />
 		<suppress checks="JavaStylingCheck" files="src/main/java/com/liferay/source/formatter/check/JavaStylingCheck\.java" />

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaOSGiReferenceCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaOSGiReferenceCheck.java
@@ -17,6 +17,7 @@ package com.liferay.source.formatter.check;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.source.formatter.BNDSettings;
@@ -25,7 +26,6 @@ import com.liferay.source.formatter.parser.JavaClass;
 import com.liferay.source.formatter.parser.JavaClassParser;
 import com.liferay.source.formatter.parser.JavaTerm;
 import com.liferay.source.formatter.parser.ParseException;
-import com.liferay.source.formatter.util.FileUtil;
 
 import java.io.File;
 import java.io.IOException;


### PR DESCRIPTION
Hi Tina,

Main Task: [LPS-143403](https://issues.liferay.com/browse/LPS-143403)
Sub Task 13: [LPS-145575](https://issues.liferay.com/browse/LPS-145575)
Removes FileUtil from modules components

Note: 
 - this Util was used in public static method, so did not add it to SF.
 - from sub task 6 and onwards, tasks no longer depend on previous tasks.

Thank you!