### PR TITLE
LPS-143630 Avoid using TransferHeadersHelperUtil, CalendarFactoryUtil, ColorSchemeFactoryUtil directly in modules

### DIFF
--- a/modules/apps/archived/portal-security-sso-google-impl/src/main/java/com/liferay/portal/security/sso/google/internal/GoogleAuthorizationImpl.java
+++ b/modules/apps/archived/portal-security-sso-google-impl/src/main/java/com/liferay/portal/security/sso/google/internal/GoogleAuthorizationImpl.java
@@ -43,7 +43,7 @@ import com.liferay.portal.kernel.settings.CompanyServiceSettingsLocator;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -353,7 +353,7 @@ public class GoogleAuthorizationImpl implements GoogleAuthorization {
 
 		Contact contact = user.getContact();
 
-		Calendar birthdayCal = CalendarFactoryUtil.getCalendar();
+		Calendar birthdayCal = _calendarFactory.getCalendar();
 
 		birthdayCal.setTime(contact.getBirthday());
 
@@ -406,6 +406,9 @@ public class GoogleAuthorizationImpl implements GoogleAuthorization {
 	private static final TransactionConfig _transactionConfig =
 		TransactionConfig.Factory.create(
 			Propagation.REQUIRED, new Class<?>[] {Exception.class});
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private CompanyLocalService _companyLocalService;

--- a/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
+++ b/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
@@ -101,7 +101,7 @@ import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -935,7 +935,7 @@ public class CalendarPortlet extends MVCPortlet {
 
 		List<Integer> daysOfWeek = _getDaysOfWeek(recurrenceObj);
 
-		java.util.Calendar startTimeJCalendar = CalendarFactoryUtil.getCalendar(
+		java.util.Calendar startTimeJCalendar = _calendarFactory.getCalendar(
 			calendarBooking.getStartTime(), timeZone);
 
 		int startTimeDayOfWeek = startTimeJCalendar.get(
@@ -1027,17 +1027,17 @@ public class CalendarPortlet extends MVCPortlet {
 			TimeZone timeZone = editedCalendarBookingInstance.getTimeZone();
 
 			java.util.Calendar oldStartTimeJCalendar =
-				CalendarFactoryUtil.getCalendar(oldStartTime, timeZone);
+				_calendarFactory.getCalendar(oldStartTime, timeZone);
 
 			java.util.Calendar firstInstanceJCalendar =
-				CalendarFactoryUtil.getCalendar(
+				_calendarFactory.getCalendar(
 					firstInstance.getStartTime(), timeZone);
 
 			if (!JCalendarUtil.isSameDayOfWeek(
 					oldStartTimeJCalendar, firstInstanceJCalendar)) {
 
 				java.util.Calendar newStartTimeJCalendar =
-					CalendarFactoryUtil.getCalendar(newStartTime, timeZone);
+					_calendarFactory.getCalendar(newStartTime, timeZone);
 
 				newStartTimeJCalendar = JCalendarUtil.mergeJCalendar(
 					oldStartTimeJCalendar, newStartTimeJCalendar, timeZone);
@@ -1574,7 +1574,7 @@ public class CalendarPortlet extends MVCPortlet {
 			timeZoneId = user.getTimeZoneId();
 		}
 
-		java.util.Calendar nowCalendar = CalendarFactoryUtil.getCalendar(
+		java.util.Calendar nowCalendar = _calendarFactory.getCalendar(
 			TimeZone.getTimeZone(timeZoneId));
 
 		writeJSON(
@@ -1830,6 +1830,9 @@ public class CalendarPortlet extends MVCPortlet {
 
 	@Reference
 	private CalendarBookingService _calendarBookingService;
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private CalendarLocalService _calendarLocalService;

--- a/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/CPAttachmentFileEntryCreator.java
+++ b/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/CPAttachmentFileEntryCreator.java
@@ -28,7 +28,7 @@ import com.liferay.portal.kernel.repository.RepositoryProvider;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -140,7 +140,7 @@ public class CPAttachmentFileEntryCreator {
 			inputStream.close();
 		}
 
-		Calendar displayCalendar = CalendarFactoryUtil.getCalendar(
+		Calendar displayCalendar = _calendarFactory.getCalendar(
 			user.getTimeZone());
 
 		displayCalendar.add(Calendar.YEAR, -1);
@@ -156,7 +156,7 @@ public class CPAttachmentFileEntryCreator {
 			displayDateHour += 12;
 		}
 
-		Calendar expirationCalendar = CalendarFactoryUtil.getCalendar(
+		Calendar expirationCalendar = _calendarFactory.getCalendar(
 			user.getTimeZone());
 
 		expirationCalendar.add(Calendar.MONTH, 1);
@@ -187,6 +187,9 @@ public class CPAttachmentFileEntryCreator {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		CPAttachmentFileEntryCreator.class);
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private CPAttachmentFileEntryLocalService

--- a/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/CPDefinitionsImporter.java
+++ b/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/CPDefinitionsImporter.java
@@ -73,7 +73,7 @@ import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -204,7 +204,7 @@ public class CPDefinitionsImporter {
 
 		User user = _userLocalService.getUser(serviceContext.getUserId());
 
-		Calendar displayCalendar = CalendarFactoryUtil.getCalendar(
+		Calendar displayCalendar = _calendarFactory.getCalendar(
 			user.getTimeZone());
 
 		displayCalendar.add(Calendar.YEAR, -1);
@@ -220,7 +220,7 @@ public class CPDefinitionsImporter {
 			displayDateHour += 12;
 		}
 
-		Calendar expirationCalendar = CalendarFactoryUtil.getCalendar(
+		Calendar expirationCalendar = _calendarFactory.getCalendar(
 			user.getTimeZone());
 
 		expirationCalendar.add(Calendar.MONTH, 1);
@@ -977,6 +977,9 @@ public class CPDefinitionsImporter {
 
 	@Reference
 	private AssetTagsImporter _assetTagsImporter;
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private CommerceAccountGroupLocalService _commerceAccountGroupLocalService;

--- a/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/CommercePriceListsImporter.java
+++ b/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/CommercePriceListsImporter.java
@@ -32,7 +32,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -107,7 +107,7 @@ public class CommercePriceListsImporter {
 
 		User user = _userLocalService.getUser(serviceContext.getUserId());
 
-		Calendar displayCalendar = CalendarFactoryUtil.getCalendar(
+		Calendar displayCalendar = _calendarFactory.getCalendar(
 			user.getTimeZone());
 
 		int displayDateMonth = displayCalendar.get(
@@ -127,7 +127,7 @@ public class CommercePriceListsImporter {
 			displayDateHour += 12;
 		}
 
-		Calendar expirationCalendar = CalendarFactoryUtil.getCalendar(
+		Calendar expirationCalendar = _calendarFactory.getCalendar(
 			user.getTimeZone());
 
 		expirationCalendar.add(Calendar.MONTH, 1);
@@ -224,6 +224,9 @@ public class CommercePriceListsImporter {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		CommercePriceListsImporter.class);
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private CommerceAccountGroupLocalService _commerceAccountGroupLocalService;

--- a/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/CommerceShipmentGenerator.java
+++ b/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/CommerceShipmentGenerator.java
@@ -44,7 +44,7 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -79,7 +79,7 @@ public class CommerceShipmentGenerator {
 			date = new Date();
 		}
 
-		Calendar calendar = CalendarFactoryUtil.getCalendar();
+		Calendar calendar = _calendarFactory.getCalendar();
 
 		calendar.setTime(date);
 
@@ -317,6 +317,9 @@ public class CommerceShipmentGenerator {
 	private static final TransactionConfig _transactionConfig =
 		TransactionConfig.Factory.create(
 			Propagation.REQUIRED, new Class<?>[] {Exception.class});
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private CommerceChannelLocalService _commerceChannelLocalService;

--- a/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/CommerceUsersImporter.java
+++ b/modules/apps/commerce/commerce-initializer-util/src/main/java/com/liferay/commerce/initializer/util/CommerceUsersImporter.java
@@ -42,7 +42,7 @@ import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserIdMapperLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -298,7 +298,7 @@ public class CommerceUsersImporter {
 			male = gender.equals("male");
 		}
 
-		Calendar calendar = CalendarFactoryUtil.getCalendar(timeZone);
+		Calendar calendar = _calendarFactory.getCalendar(timeZone);
 
 		int birthdayMonth = calendar.get(
 			jsonObject.getInt("birthdayMonth", Calendar.MONTH));
@@ -468,6 +468,9 @@ public class CommerceUsersImporter {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		CommerceUsersImporter.class);
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private CommerceAccountLocalService _commerceAccountLocalService;

--- a/modules/apps/commerce/commerce-pricing-web/src/main/java/com/liferay/commerce/pricing/web/internal/portlet/action/EditCommercePriceListMVCActionCommand.java
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/java/com/liferay/commerce/pricing/web/internal/portlet/action/EditCommercePriceListMVCActionCommand.java
@@ -33,7 +33,7 @@ import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -195,7 +195,7 @@ public class EditCommercePriceListMVCActionCommand
 
 		Date date = new Date();
 
-		Calendar calendar = CalendarFactoryUtil.getCalendar(date.getTime());
+		Calendar calendar = _calendarFactory.getCalendar(date.getTime());
 
 		int displayDateMonth = ParamUtil.getInteger(
 			actionRequest, "displayDateMonth", calendar.get(Calendar.MONTH));
@@ -266,6 +266,9 @@ public class EditCommercePriceListMVCActionCommand
 
 		return commercePriceList;
 	}
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private CommercePriceListAccountRelService

--- a/modules/apps/commerce/commerce-pricing-web/src/main/java/com/liferay/commerce/pricing/web/internal/portlet/action/EditCommercePriceModifierMVCActionCommand.java
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/java/com/liferay/commerce/pricing/web/internal/portlet/action/EditCommercePriceModifierMVCActionCommand.java
@@ -25,7 +25,7 @@ import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.servlet.SessionErrors;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -135,7 +135,7 @@ public class EditCommercePriceModifierMVCActionCommand
 
 		Date date = new Date();
 
-		Calendar calendar = CalendarFactoryUtil.getCalendar(date.getTime());
+		Calendar calendar = _calendarFactory.getCalendar(date.getTime());
 
 		int displayDateMonth = ParamUtil.getInteger(
 			actionRequest, "displayDateMonth", calendar.get(Calendar.MONTH));
@@ -199,6 +199,9 @@ public class EditCommercePriceModifierMVCActionCommand
 			expirationDateDay, expirationDateYear, expirationDateHour,
 			expirationDateMinute, neverExpire, serviceContext);
 	}
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private CommercePriceModifierService _commercePriceModifierService;

--- a/modules/apps/commerce/commerce-pricing-web/src/main/java/com/liferay/commerce/pricing/web/internal/portlet/action/EditCommerceTierPriceEntryMVCActionCommand.java
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/java/com/liferay/commerce/pricing/web/internal/portlet/action/EditCommerceTierPriceEntryMVCActionCommand.java
@@ -32,7 +32,7 @@ import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.servlet.SessionErrors;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -227,7 +227,7 @@ public class EditCommerceTierPriceEntryMVCActionCommand
 
 		Date date = new Date();
 
-		Calendar calendar = CalendarFactoryUtil.getCalendar(date.getTime());
+		Calendar calendar = _calendarFactory.getCalendar(date.getTime());
 
 		int displayDateMonth = ParamUtil.getInteger(
 			actionRequest, "displayDateMonth", calendar.get(Calendar.MONTH));
@@ -302,6 +302,9 @@ public class EditCommerceTierPriceEntryMVCActionCommand
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		EditCommerceTierPriceEntryMVCActionCommand.class);
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private CommercePriceEntryService _commercePriceEntryService;

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/java/com/liferay/commerce/product/definitions/web/internal/portlet/action/EditCPInstanceMVCActionCommand.java
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/java/com/liferay/commerce/product/definitions/web/internal/portlet/action/EditCPInstanceMVCActionCommand.java
@@ -49,7 +49,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -380,7 +380,7 @@ public class EditCPInstanceMVCActionCommand extends BaseMVCActionCommand {
 				DateFormatFactoryUtil.getSimpleDateFormat("MM/dd/yyyy"), null);
 
 			if (discontinuedDate != null) {
-				Calendar calendar = CalendarFactoryUtil.getCalendar(
+				Calendar calendar = _calendarFactory.getCalendar(
 					discontinuedDate.getTime());
 
 				discontinuedDateDay = calendar.get(Calendar.DAY_OF_MONTH);
@@ -463,6 +463,9 @@ public class EditCPInstanceMVCActionCommand extends BaseMVCActionCommand {
 	private static final TransactionConfig _transactionConfig =
 		TransactionConfig.Factory.create(
 			Propagation.REQUIRED, new Class<?>[] {Exception.class});
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private CommercePriceEntryLocalService _commercePriceEntryLocalService;

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/importer/CPFileImporterImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/importer/CPFileImporterImpl.java
@@ -73,7 +73,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ThemeLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -355,7 +355,7 @@ public class CPFileImporterImpl implements CPFileImporter {
 		content = _getNormalizedContent(
 			content, classLoader, dependenciesFilePath, serviceContext);
 
-		Calendar displayCalendar = CalendarFactoryUtil.getCalendar(
+		Calendar displayCalendar = _calendarFactory.getCalendar(
 			serviceContext.getTimeZone());
 
 		int displayDateMonth = displayCalendar.get(Calendar.MONTH);
@@ -1016,6 +1016,9 @@ public class CPFileImporterImpl implements CPFileImporter {
 
 	@Reference
 	private AssetEntryLocalService _assetEntryLocalService;
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private DDM _ddm;

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/osgi/commands/CPOSGiCommands.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/osgi/commands/CPOSGiCommands.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.LocaleUtil;
 
 import java.util.Calendar;
@@ -70,7 +70,7 @@ public class CPOSGiCommands {
 		serviceContext.setTimeZone(user.getTimeZone());
 		serviceContext.setUserId(user.getUserId());
 
-		Calendar displayCalendar = CalendarFactoryUtil.getCalendar(
+		Calendar displayCalendar = _calendarFactory.getCalendar(
 			serviceContext.getTimeZone());
 
 		displayCalendar.add(Calendar.YEAR, -1);
@@ -103,6 +103,9 @@ public class CPOSGiCommands {
 				serviceContext);
 		}
 	}
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private CommerceCatalogLocalService _commerceCatalogLocalService;

--- a/modules/apps/commerce/commerce-product-subscription-type-web/src/main/java/com/liferay/commerce/product/subscription/type/web/internal/DailyCPSubscriptionTypeImpl.java
+++ b/modules/apps/commerce/commerce-product-subscription-type-web/src/main/java/com/liferay/commerce/product/subscription/type/web/internal/DailyCPSubscriptionTypeImpl.java
@@ -17,7 +17,7 @@ package com.liferay.commerce.product.subscription.type.web.internal;
 import com.liferay.commerce.product.constants.CPConstants;
 import com.liferay.commerce.product.util.CPSubscriptionType;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 
 import java.util.Calendar;
@@ -26,6 +26,7 @@ import java.util.Locale;
 import java.util.TimeZone;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Alessio Antonio Rendina
@@ -56,7 +57,7 @@ public class DailyCPSubscriptionTypeImpl implements CPSubscriptionType {
 		UnicodeProperties subscriptionTypeSettingsUnicodeProperties,
 		Date lastIterationDate) {
 
-		Calendar calendar = CalendarFactoryUtil.getCalendar(timeZone);
+		Calendar calendar = _calendarFactory.getCalendar(timeZone);
 
 		if (lastIterationDate == null) {
 			lastIterationDate = getSubscriptionStartDate(
@@ -77,5 +78,8 @@ public class DailyCPSubscriptionTypeImpl implements CPSubscriptionType {
 
 		return new Date();
 	}
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 }

--- a/modules/apps/commerce/commerce-product-subscription-type-web/src/main/java/com/liferay/commerce/product/subscription/type/web/internal/MonthlyCPSubscriptionTypeImpl.java
+++ b/modules/apps/commerce/commerce-product-subscription-type-web/src/main/java/com/liferay/commerce/product/subscription/type/web/internal/MonthlyCPSubscriptionTypeImpl.java
@@ -18,7 +18,7 @@ import com.liferay.commerce.product.constants.CPConstants;
 import com.liferay.commerce.product.subscription.type.web.internal.constants.CPSubscriptionTypeConstants;
 import com.liferay.commerce.product.util.CPSubscriptionType;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 
@@ -28,6 +28,7 @@ import java.util.Locale;
 import java.util.TimeZone;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Alessio Antonio Rendina
@@ -58,7 +59,7 @@ public class MonthlyCPSubscriptionTypeImpl implements CPSubscriptionType {
 		UnicodeProperties subscriptionTypeSettingsUnicodeProperties,
 		Date lastIterationDate) {
 
-		Calendar calendar = CalendarFactoryUtil.getCalendar(timeZone);
+		Calendar calendar = _calendarFactory.getCalendar(timeZone);
 
 		if (lastIterationDate == null) {
 			lastIterationDate = getSubscriptionStartDate(
@@ -106,7 +107,7 @@ public class MonthlyCPSubscriptionTypeImpl implements CPSubscriptionType {
 			return date;
 		}
 
-		Calendar calendar = CalendarFactoryUtil.getCalendar(
+		Calendar calendar = _calendarFactory.getCalendar(
 			date.getTime(), timeZone);
 
 		int dayOfMonthActualMaximum = calendar.getActualMaximum(
@@ -141,5 +142,8 @@ public class MonthlyCPSubscriptionTypeImpl implements CPSubscriptionType {
 
 		return calendar.getTime();
 	}
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 }

--- a/modules/apps/commerce/commerce-product-subscription-type-web/src/main/java/com/liferay/commerce/product/subscription/type/web/internal/WeeklyCPSubscriptionTypeImpl.java
+++ b/modules/apps/commerce/commerce-product-subscription-type-web/src/main/java/com/liferay/commerce/product/subscription/type/web/internal/WeeklyCPSubscriptionTypeImpl.java
@@ -17,7 +17,7 @@ package com.liferay.commerce.product.subscription.type.web.internal;
 import com.liferay.commerce.product.constants.CPConstants;
 import com.liferay.commerce.product.util.CPSubscriptionType;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 
@@ -27,6 +27,7 @@ import java.util.Locale;
 import java.util.TimeZone;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Alessio Antonio Rendina
@@ -57,7 +58,7 @@ public class WeeklyCPSubscriptionTypeImpl implements CPSubscriptionType {
 		UnicodeProperties subscriptionTypeSettingsUnicodeProperties,
 		Date lastIterationDate) {
 
-		Calendar calendar = CalendarFactoryUtil.getCalendar(timeZone);
+		Calendar calendar = _calendarFactory.getCalendar(timeZone);
 
 		if (lastIterationDate == null) {
 			lastIterationDate = getSubscriptionStartDate(
@@ -91,7 +92,7 @@ public class WeeklyCPSubscriptionTypeImpl implements CPSubscriptionType {
 			return date;
 		}
 
-		Calendar calendar = CalendarFactoryUtil.getCalendar(
+		Calendar calendar = _calendarFactory.getCalendar(
 			date.getTime(), timeZone);
 
 		int today = calendar.get(Calendar.DAY_OF_WEEK);
@@ -108,5 +109,8 @@ public class WeeklyCPSubscriptionTypeImpl implements CPSubscriptionType {
 
 		return calendar.getTime();
 	}
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 }

--- a/modules/apps/commerce/commerce-product-subscription-type-web/src/main/java/com/liferay/commerce/product/subscription/type/web/internal/YearlyCPSubscriptionTypeImpl.java
+++ b/modules/apps/commerce/commerce-product-subscription-type-web/src/main/java/com/liferay/commerce/product/subscription/type/web/internal/YearlyCPSubscriptionTypeImpl.java
@@ -18,7 +18,7 @@ import com.liferay.commerce.product.constants.CPConstants;
 import com.liferay.commerce.product.subscription.type.web.internal.constants.CPSubscriptionTypeConstants;
 import com.liferay.commerce.product.util.CPSubscriptionType;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 
@@ -28,6 +28,7 @@ import java.util.Locale;
 import java.util.TimeZone;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Alessio Antonio Rendina
@@ -58,7 +59,7 @@ public class YearlyCPSubscriptionTypeImpl implements CPSubscriptionType {
 		UnicodeProperties subscriptionTypeSettingsUnicodeProperties,
 		Date lastIterationDate) {
 
-		Calendar calendar = CalendarFactoryUtil.getCalendar(timeZone);
+		Calendar calendar = _calendarFactory.getCalendar(timeZone);
 
 		if (lastIterationDate == null) {
 			lastIterationDate = getSubscriptionStartDate(
@@ -101,7 +102,7 @@ public class YearlyCPSubscriptionTypeImpl implements CPSubscriptionType {
 			return date;
 		}
 
-		Calendar calendar = CalendarFactoryUtil.getCalendar(
+		Calendar calendar = _calendarFactory.getCalendar(
 			date.getTime(), timeZone);
 
 		int today = calendar.get(Calendar.DAY_OF_YEAR);
@@ -143,5 +144,8 @@ public class YearlyCPSubscriptionTypeImpl implements CPSubscriptionType {
 
 		return calendar.get(Calendar.DAY_OF_YEAR);
 	}
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 }

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/UserResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/UserResourceImpl.java
@@ -28,7 +28,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -91,7 +91,7 @@ public class UserResourceImpl extends BaseUserResourceImpl {
 		else {
 			Date birthday = invitedUser.getBirthday();
 
-			Calendar birthdayCalendar = CalendarFactoryUtil.getCalendar(
+			Calendar birthdayCalendar = _calendarFactory.getCalendar(
 				birthday.getTime(), invitedUser.getTimeZone());
 
 			invitedUser = _userService.updateUser(
@@ -151,6 +151,9 @@ public class UserResourceImpl extends BaseUserResourceImpl {
 				invitedUser.getUserId(),
 				contextAcceptLanguage.getPreferredLocale()));
 	}
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private CommerceAccountService _commerceAccountService;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/ProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/ProductResourceImpl.java
@@ -97,7 +97,7 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Validator;
@@ -992,12 +992,12 @@ public class ProductResourceImpl
 			serviceContext.setExpandoBridgeAttributes(expandoBridgeAttributes);
 		}
 
-		Calendar displayCalendar = CalendarFactoryUtil.getCalendar(
+		Calendar displayCalendar = _calendarFactory.getCalendar(
 			serviceContext.getTimeZone());
 
 		DateConfig displayDateConfig = new DateConfig(displayCalendar);
 
-		Calendar expirationCalendar = CalendarFactoryUtil.getCalendar(
+		Calendar expirationCalendar = _calendarFactory.getCalendar(
 			serviceContext.getTimeZone());
 
 		expirationCalendar.add(Calendar.MONTH, 1);
@@ -1092,6 +1092,9 @@ public class ProductResourceImpl
 
 	@Reference
 	private AssetTagService _assetTagService;
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private ClassNameLocalService _classNameLocalService;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/SkuResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/SkuResourceImpl.java
@@ -34,7 +34,7 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -293,7 +293,7 @@ public class SkuResourceImpl
 			}
 		}
 
-		Calendar discontinuedCalendar = CalendarFactoryUtil.getCalendar(
+		Calendar discontinuedCalendar = _calendarFactory.getCalendar(
 			serviceContext.getTimeZone());
 
 		if (sku.getDiscontinuedDate() != null) {
@@ -304,7 +304,7 @@ public class SkuResourceImpl
 		DateConfig discontinuedDateConfig = new DateConfig(
 			discontinuedCalendar);
 
-		Calendar displayCalendar = CalendarFactoryUtil.getCalendar(
+		Calendar displayCalendar = _calendarFactory.getCalendar(
 			serviceContext.getTimeZone());
 
 		if (sku.getDisplayDate() != null) {
@@ -314,7 +314,7 @@ public class SkuResourceImpl
 
 		DateConfig displayDateConfig = new DateConfig(displayCalendar);
 
-		Calendar expirationCalendar = CalendarFactoryUtil.getCalendar(
+		Calendar expirationCalendar = _calendarFactory.getCalendar(
 			serviceContext.getTimeZone());
 
 		expirationCalendar.add(Calendar.MONTH, 1);
@@ -348,6 +348,9 @@ public class SkuResourceImpl
 	}
 
 	private static final EntityModel _entityModel = new SkuEntityModel();
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private CPDefinitionService _cpDefinitionService;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OrderResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OrderResourceImpl.java
@@ -56,7 +56,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Validator;
@@ -328,7 +328,7 @@ public class OrderResourceImpl
 		// Order date
 
 		if (order.getOrderDate() != null) {
-			Calendar orderDateCalendar = CalendarFactoryUtil.getCalendar(
+			Calendar orderDateCalendar = _calendarFactory.getCalendar(
 				serviceContext.getTimeZone());
 
 			orderDateCalendar.setTime(order.getOrderDate());
@@ -345,7 +345,7 @@ public class OrderResourceImpl
 
 		if (order.getRequestedDeliveryDate() != null) {
 			Calendar requestedDeliveryDateCalendar =
-				CalendarFactoryUtil.getCalendar(serviceContext.getTimeZone());
+				_calendarFactory.getCalendar(serviceContext.getTimeZone());
 
 			requestedDeliveryDateCalendar.setTime(
 				order.getRequestedDeliveryDate());
@@ -616,7 +616,7 @@ public class OrderResourceImpl
 					commerceOrder.getGroupId());
 
 			Calendar requestedDeliveryDateCalendar =
-				CalendarFactoryUtil.getCalendar(serviceContext.getTimeZone());
+				_calendarFactory.getCalendar(serviceContext.getTimeZone());
 
 			requestedDeliveryDateCalendar.setTime(
 				order.getRequestedDeliveryDate());
@@ -671,6 +671,9 @@ public class OrderResourceImpl
 	}
 
 	private static final EntityModel _entityModel = new OrderEntityModel();
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private CommerceAccountService _commerceAccountService;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/DiscountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/DiscountResourceImpl.java
@@ -47,7 +47,7 @@ import com.liferay.headless.commerce.core.util.ServiceContextHelper;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.search.BaseModelSearchResult;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
@@ -196,12 +196,12 @@ public class DiscountResourceImpl extends BaseDiscountResourceImpl {
 		ServiceContext serviceContext =
 			_serviceContextHelper.getServiceContext();
 
-		Calendar displayCalendar = CalendarFactoryUtil.getCalendar(
+		Calendar displayCalendar = _calendarFactory.getCalendar(
 			serviceContext.getTimeZone());
 
 		DateConfig displayDateConfig = new DateConfig(displayCalendar);
 
-		Calendar expirationCalendar = CalendarFactoryUtil.getCalendar(
+		Calendar expirationCalendar = _calendarFactory.getCalendar(
 			serviceContext.getTimeZone());
 
 		expirationCalendar.add(Calendar.MONTH, 1);
@@ -275,12 +275,12 @@ public class DiscountResourceImpl extends BaseDiscountResourceImpl {
 		ServiceContext serviceContext =
 			_serviceContextHelper.getServiceContext();
 
-		Calendar displayCalendar = CalendarFactoryUtil.getCalendar(
+		Calendar displayCalendar = _calendarFactory.getCalendar(
 			serviceContext.getTimeZone());
 
 		DateConfig displayDateConfig = new DateConfig(displayCalendar);
 
-		Calendar expirationCalendar = CalendarFactoryUtil.getCalendar(
+		Calendar expirationCalendar = _calendarFactory.getCalendar(
 			serviceContext.getTimeZone());
 
 		expirationCalendar.add(Calendar.MONTH, 1);
@@ -457,6 +457,9 @@ public class DiscountResourceImpl extends BaseDiscountResourceImpl {
 
 	@Reference
 	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private CommerceAccountGroupService _commerceAccountGroupService;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/PriceListResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/PriceListResourceImpl.java
@@ -47,7 +47,7 @@ import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
@@ -223,12 +223,12 @@ public class PriceListResourceImpl
 		ServiceContext serviceContext =
 			_serviceContextHelper.getServiceContext();
 
-		Calendar displayCalendar = CalendarFactoryUtil.getCalendar(
+		Calendar displayCalendar = _calendarFactory.getCalendar(
 			serviceContext.getTimeZone());
 
 		DateConfig displayDateConfig = new DateConfig(displayCalendar);
 
-		Calendar expirationCalendar = CalendarFactoryUtil.getCalendar(
+		Calendar expirationCalendar = _calendarFactory.getCalendar(
 			serviceContext.getTimeZone());
 
 		expirationCalendar.add(Calendar.MONTH, 1);
@@ -353,12 +353,12 @@ public class PriceListResourceImpl
 		ServiceContext serviceContext = _serviceContextHelper.getServiceContext(
 			commercePriceList.getGroupId());
 
-		Calendar displayCalendar = CalendarFactoryUtil.getCalendar(
+		Calendar displayCalendar = _calendarFactory.getCalendar(
 			serviceContext.getTimeZone());
 
 		DateConfig displayDateConfig = new DateConfig(displayCalendar);
 
-		Calendar expirationCalendar = CalendarFactoryUtil.getCalendar(
+		Calendar expirationCalendar = _calendarFactory.getCalendar(
 			serviceContext.getTimeZone());
 
 		expirationCalendar.add(Calendar.MONTH, 1);
@@ -396,6 +396,9 @@ public class PriceListResourceImpl
 	}
 
 	private static final EntityModel _entityModel = new PriceListEntityModel();
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private CommerceAccountGroupService _commerceAccountGroupService;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/ShipmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/ShipmentResourceImpl.java
@@ -33,7 +33,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.CountryService;
 import com.liferay.portal.kernel.service.RegionService;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -116,7 +116,7 @@ public class ShipmentResourceImpl extends BaseShipmentResourceImpl {
 		Date expectedDate = shipment.getExpectedDate();
 
 		if (expectedDate != null) {
-			Calendar calendar = CalendarFactoryUtil.getCalendar(
+			Calendar calendar = _calendarFactory.getCalendar(
 				expectedDate.getTime());
 
 			int expectedDay = calendar.get(Calendar.DAY_OF_MONTH);
@@ -142,7 +142,7 @@ public class ShipmentResourceImpl extends BaseShipmentResourceImpl {
 		Date shippingDate = shipment.getShippingDate();
 
 		if (shippingDate != null) {
-			Calendar calendar = CalendarFactoryUtil.getCalendar(
+			Calendar calendar = _calendarFactory.getCalendar(
 				shippingDate.getTime());
 
 			int shippingDay = calendar.get(Calendar.DAY_OF_MONTH);
@@ -249,6 +249,9 @@ public class ShipmentResourceImpl extends BaseShipmentResourceImpl {
 				commerceShipmentId, contextAcceptLanguage.getPreferredLocale(),
 				contextUriInfo, contextUser));
 	}
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private CommerceAddressService _commerceAddressService;

--- a/modules/apps/contacts/contacts-web/src/main/java/com/liferay/contacts/web/internal/portlet/ContactsCenterPortlet.java
+++ b/modules/apps/contacts/contacts-web/src/main/java/com/liferay/contacts/web/internal/portlet/ContactsCenterPortlet.java
@@ -74,7 +74,7 @@ import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
 import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -1269,7 +1269,7 @@ public class ContactsCenterPortlet extends MVCPortlet {
 		String twitterSn = BeanParamUtil.getString(
 			contact, actionRequest, "twitterSn");
 
-		Calendar cal = CalendarFactoryUtil.getCalendar();
+		Calendar cal = _calendarFactory.getCalendar();
 
 		cal.setTime(user.getBirthday());
 
@@ -1310,6 +1310,9 @@ public class ContactsCenterPortlet extends MVCPortlet {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ContactsCenterPortlet.class);
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	private volatile UserFileUploadsConfiguration _userFileUploadsConfiguration;
 

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/portlet/action/UpdateMembershipsMVCActionCommand.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/portlet/action/UpdateMembershipsMVCActionCommand.java
@@ -25,7 +25,7 @@ import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -67,7 +67,7 @@ public class UpdateMembershipsMVCActionCommand extends BaseMVCActionCommand {
 
 			Contact contact = user.getContact();
 
-			Calendar birthdayCal = CalendarFactoryUtil.getCalendar();
+			Calendar birthdayCal = _calendarFactory.getCalendar();
 
 			birthdayCal.setTime(user.getBirthday());
 
@@ -128,6 +128,9 @@ public class UpdateMembershipsMVCActionCommand extends BaseMVCActionCommand {
 
 		return ArrayUtil.toLongArray(groupIds);
 	}
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/portlet/action/UpdateRolesMVCActionCommand.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/portlet/action/UpdateRolesMVCActionCommand.java
@@ -25,7 +25,7 @@ import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.servlet.SessionErrors;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -68,7 +68,7 @@ public class UpdateRolesMVCActionCommand extends BaseMVCActionCommand {
 
 			Contact contact = user.getContact();
 
-			Calendar birthdayCal = CalendarFactoryUtil.getCalendar();
+			Calendar birthdayCal = _calendarFactory.getCalendar();
 
 			birthdayCal.setTime(user.getBirthday());
 
@@ -177,6 +177,9 @@ public class UpdateRolesMVCActionCommand extends BaseMVCActionCommand {
 			0L
 		);
 	}
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
@@ -66,7 +66,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserService;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -845,7 +845,7 @@ public class UserAccountResourceImpl
 			userAccount.getBirthDate()
 		).map(
 			date -> {
-				Calendar calendar = CalendarFactoryUtil.getCalendar();
+				Calendar calendar = _calendarFactory.getCalendar();
 
 				calendar.setTime(date);
 
@@ -1057,6 +1057,9 @@ public class UserAccountResourceImpl
 	@Reference
 	private AnnouncementsDeliveryLocalService
 		_announcementsDeliveryLocalService;
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private ContactLocalService _contactLocalService;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -83,7 +83,7 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
 import com.liferay.portal.kernel.settings.GroupServiceSettingsLocator;
 import com.liferay.portal.kernel.trash.TrashHandler;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -674,7 +674,7 @@ public class JournalArticleStagedModelDataHandler
 		int displayDateMinute = 0;
 
 		if (displayDate != null) {
-			Calendar displayCal = CalendarFactoryUtil.getCalendar(
+			Calendar displayCal = _calendarFactory.getCalendar(
 				user.getTimeZone());
 
 			displayCal.setTime(displayDate);
@@ -700,7 +700,7 @@ public class JournalArticleStagedModelDataHandler
 		boolean neverExpire = true;
 
 		if (expirationDate != null) {
-			Calendar expirationCal = CalendarFactoryUtil.getCalendar(
+			Calendar expirationCal = _calendarFactory.getCalendar(
 				user.getTimeZone());
 
 			expirationCal.setTime(expirationDate);
@@ -728,7 +728,7 @@ public class JournalArticleStagedModelDataHandler
 		boolean neverReview = true;
 
 		if (reviewDate != null) {
-			Calendar reviewCal = CalendarFactoryUtil.getCalendar(
+			Calendar reviewCal = _calendarFactory.getCalendar(
 				user.getTimeZone());
 
 			reviewCal.setTime(reviewDate);
@@ -1799,6 +1799,9 @@ public class JournalArticleStagedModelDataHandler
 
 	@Reference
 	private AssetTagLocalService _assetTagLocalService;
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private ChangesetCollectionLocalService _changesetCollectionLocalService;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -175,7 +175,7 @@ import com.liferay.portal.kernel.systemevent.SystemEventHierarchyEntryThreadLoca
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
@@ -736,7 +736,7 @@ public class JournalArticleLocalServiceImpl
 
 		User user = _userLocalService.getUser(userId);
 
-		Calendar calendar = CalendarFactoryUtil.getCalendar(user.getTimeZone());
+		Calendar calendar = _calendarFactory.getCalendar(user.getTimeZone());
 
 		int displayDateMonth = calendar.get(Calendar.MONTH);
 		int displayDateDay = calendar.get(Calendar.DAY_OF_MONTH);
@@ -5985,7 +5985,7 @@ public class JournalArticleLocalServiceImpl
 		int displayDateMinute = 0;
 
 		if (displayDate != null) {
-			Calendar displayCal = CalendarFactoryUtil.getCalendar(
+			Calendar displayCal = _calendarFactory.getCalendar(
 				user.getTimeZone());
 
 			displayCal.setTime(displayDate);
@@ -6011,7 +6011,7 @@ public class JournalArticleLocalServiceImpl
 		boolean neverExpire = true;
 
 		if (expirationDate != null) {
-			Calendar expirationCal = CalendarFactoryUtil.getCalendar(
+			Calendar expirationCal = _calendarFactory.getCalendar(
 				user.getTimeZone());
 
 			expirationCal.setTime(expirationDate);
@@ -6039,7 +6039,7 @@ public class JournalArticleLocalServiceImpl
 		boolean neverReview = true;
 
 		if (reviewDate != null) {
-			Calendar reviewCal = CalendarFactoryUtil.getCalendar(
+			Calendar reviewCal = _calendarFactory.getCalendar(
 				user.getTimeZone());
 
 			reviewCal.setTime(reviewDate);
@@ -9265,6 +9265,9 @@ public class JournalArticleLocalServiceImpl
 
 	@Reference
 	private AttachmentContentUpdater _attachmentContentUpdater;
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private ClassNameLocalService _classNameLocalService;

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java
@@ -55,7 +55,7 @@ import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.ColorSchemeFactoryUtil;
+import com.liferay.portal.kernel.util.ColorSchemeFactory;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.DateRange;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -535,7 +535,7 @@ public class StagedLayoutSetStagedModelDataHandler
 				ThemeFactoryUtil.getDefaultRegularThemeId(
 					stagedLayoutSet.getCompanyId()));
 			layoutSet.setColorSchemeId(
-				ColorSchemeFactoryUtil.getDefaultRegularColorSchemeId());
+				_colorSchemeFactory.getDefaultRegularColorSchemeId());
 			layoutSet.setCss(StringPool.BLANK);
 
 			return;
@@ -967,6 +967,9 @@ public class StagedLayoutSetStagedModelDataHandler
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		StagedLayoutSetStagedModelDataHandler.class);
+
+	@Reference
+	private ColorSchemeFactory _colorSchemeFactory;
 
 	@Reference(target = "(content.processor.type=DLReferences)")
 	private ExportImportContentProcessor<String>

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-collection/src/main/java/com/liferay/layout/type/controller/collection/internal/layout/type/controller/CollectionPageLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-collection/src/main/java/com/liferay/layout/type/controller/collection/internal/layout/type/controller/CollectionPageLayoutTypeController.java
@@ -30,7 +30,7 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
 import com.liferay.portal.kernel.servlet.PipingServletResponse;
-import com.liferay.portal.kernel.servlet.TransferHeadersHelperUtil;
+import com.liferay.portal.kernel.servlet.TransferHeadersHelper;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.Http;
@@ -121,7 +121,7 @@ public class CollectionPageLayoutTypeController
 		}
 
 		RequestDispatcher requestDispatcher =
-			TransferHeadersHelperUtil.getTransferHeadersRequestDispatcher(
+			_transferHeadersHelper.getTransferHeadersRequestDispatcher(
 				servletContext.getRequestDispatcher(page));
 
 		UnsyncStringWriter unsyncStringWriter = new UnsyncStringWriter();
@@ -304,5 +304,8 @@ public class CollectionPageLayoutTypeController
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private TransferHeadersHelper _transferHeadersHelper;
 
 }

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/java/com/liferay/layout/type/controller/content/internal/layout/type/controller/ContentLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/java/com/liferay/layout/type/controller/content/internal/layout/type/controller/ContentLayoutTypeController.java
@@ -33,7 +33,7 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.permission.LayoutPermission;
 import com.liferay.portal.kernel.servlet.PipingServletResponse;
-import com.liferay.portal.kernel.servlet.TransferHeadersHelperUtil;
+import com.liferay.portal.kernel.servlet.TransferHeadersHelper;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.Http;
@@ -129,7 +129,7 @@ public class ContentLayoutTypeController extends BaseLayoutTypeControllerImpl {
 		}
 
 		RequestDispatcher requestDispatcher =
-			TransferHeadersHelperUtil.getTransferHeadersRequestDispatcher(
+			_transferHeadersHelper.getTransferHeadersRequestDispatcher(
 				servletContext.getRequestDispatcher(page));
 
 		UnsyncStringWriter unsyncStringWriter = new UnsyncStringWriter();
@@ -375,5 +375,8 @@ public class ContentLayoutTypeController extends BaseLayoutTypeControllerImpl {
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private TransferHeadersHelper _transferHeadersHelper;
 
 }

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/java/com/liferay/layout/type/controller/display/page/internal/layout/type/controller/DisplayPageLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/java/com/liferay/layout/type/controller/display/page/internal/layout/type/controller/DisplayPageLayoutTypeController.java
@@ -38,7 +38,7 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
 import com.liferay.portal.kernel.servlet.PipingServletResponse;
-import com.liferay.portal.kernel.servlet.TransferHeadersHelperUtil;
+import com.liferay.portal.kernel.servlet.TransferHeadersHelper;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.Http;
@@ -163,7 +163,7 @@ public class DisplayPageLayoutTypeController
 		}
 
 		RequestDispatcher requestDispatcher =
-			TransferHeadersHelperUtil.getTransferHeadersRequestDispatcher(
+			_transferHeadersHelper.getTransferHeadersRequestDispatcher(
 				servletContext.getRequestDispatcher(page));
 
 		UnsyncStringWriter unsyncStringWriter = new UnsyncStringWriter();
@@ -388,5 +388,8 @@ public class DisplayPageLayoutTypeController
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private TransferHeadersHelper _transferHeadersHelper;
 
 }

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-portlet/src/main/java/com/liferay/layout/type/controller/portlet/internal/layout/type/controller/PortletLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-portlet/src/main/java/com/liferay/layout/type/controller/portlet/internal/layout/type/controller/PortletLayoutTypeController.java
@@ -27,7 +27,7 @@ import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.servlet.DirectRequestDispatcherFactoryUtil;
 import com.liferay.portal.kernel.servlet.PipingServletResponse;
-import com.liferay.portal.kernel.servlet.TransferHeadersHelperUtil;
+import com.liferay.portal.kernel.servlet.TransferHeadersHelper;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
@@ -66,7 +66,7 @@ public class PortletLayoutTypeController extends BaseLayoutTypeControllerImpl {
 		httpServletRequest.setAttribute(WebKeys.SEL_LAYOUT, layout);
 
 		RequestDispatcher requestDispatcher =
-			TransferHeadersHelperUtil.getTransferHeadersRequestDispatcher(
+			_transferHeadersHelper.getTransferHeadersRequestDispatcher(
 				DirectRequestDispatcherFactoryUtil.getRequestDispatcher(
 					servletContext, getEditPage()));
 
@@ -87,7 +87,7 @@ public class PortletLayoutTypeController extends BaseLayoutTypeControllerImpl {
 		throws Exception {
 
 		RequestDispatcher requestDispatcher =
-			TransferHeadersHelperUtil.getTransferHeadersRequestDispatcher(
+			_transferHeadersHelper.getTransferHeadersRequestDispatcher(
 				DirectRequestDispatcherFactoryUtil.getRequestDispatcher(
 					servletContext, getViewPage()));
 
@@ -224,5 +224,8 @@ public class PortletLayoutTypeController extends BaseLayoutTypeControllerImpl {
 
 	@Reference
 	private PortletLocalService _portletLocalService;
+
+	@Reference
+	private TransferHeadersHelper _transferHeadersHelper;
 
 }

--- a/modules/apps/login/login-authentication-facebook-connect-web/src/main/java/com/liferay/login/authentication/facebook/connect/web/internal/struts/FacebookConnectStrutsAction.java
+++ b/modules/apps/login/login-authentication-facebook-connect-web/src/main/java/com/liferay/login/authentication/facebook/connect/web/internal/struts/FacebookConnectStrutsAction.java
@@ -37,7 +37,7 @@ import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.struts.StrutsAction;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -450,7 +450,7 @@ public class FacebookConnectStrutsAction implements StrutsAction {
 
 		Contact contact = user.getContact();
 
-		Calendar birthdayCal = CalendarFactoryUtil.getCalendar();
+		Calendar birthdayCal = _calendarFactory.getCalendar();
 
 		birthdayCal.setTime(contact.getBirthday());
 
@@ -489,6 +489,9 @@ public class FacebookConnectStrutsAction implements StrutsAction {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		FacebookConnectStrutsAction.class);
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private CompanyLocalService _companyLocalService;

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMailingListLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMailingListLocalServiceImpl.java
@@ -42,7 +42,7 @@ import com.liferay.portal.kernel.scheduler.TriggerFactoryUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.io.Closeable;
@@ -253,7 +253,7 @@ public class MBMailingListLocalServiceImpl
 
 		String groupName = getSchedulerGroupName(mailingList);
 
-		Calendar startDate = CalendarFactoryUtil.getCalendar();
+		Calendar startDate = _calendarFactory.getCalendar();
 
 		Trigger trigger = TriggerFactoryUtil.createTrigger(
 			groupName, groupName, startDate.getTime(),
@@ -327,6 +327,9 @@ public class MBMailingListLocalServiceImpl
 			}
 		}
 	}
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private LiferayJSONDeserializationWhitelist

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/messaging/OAuth2AuthorizationMessageListener.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/messaging/OAuth2AuthorizationMessageListener.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.scheduler.SchedulerEntryImpl;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 
 import java.util.Calendar;
 import java.util.Map;
@@ -55,7 +55,7 @@ public class OAuth2AuthorizationMessageListener extends BaseMessageListener {
 
 		String className = clazz.getName();
 
-		Calendar calendar = CalendarFactoryUtil.getCalendar();
+		Calendar calendar = _calendarFactory.getCalendar();
 
 		Trigger trigger = _triggerFactory.createTrigger(
 			className, className, calendar.getTime(), null,
@@ -78,6 +78,9 @@ public class OAuth2AuthorizationMessageListener extends BaseMessageListener {
 	protected void doReceive(Message message) throws Exception {
 		_oAuth2AuthorizationLocalService.deleteExpiredOAuth2Authorizations();
 	}
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private OAuth2AuthorizationLocalService _oAuth2AuthorizationLocalService;

--- a/modules/apps/portal-instances/portal-instances-service/src/main/java/com/liferay/portal/instances/service/impl/PortalInstancesLocalServiceImpl.java
+++ b/modules/apps/portal-instances/portal-instances-service/src/main/java/com/liferay/portal/instances/service/impl/PortalInstancesLocalServiceImpl.java
@@ -56,7 +56,7 @@ import com.liferay.portal.kernel.servlet.DummyHttpServletResponse;
 import com.liferay.portal.kernel.servlet.ServletContextPool;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.ColorSchemeFactoryUtil;
+import com.liferay.portal.kernel.util.ColorSchemeFactory;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -321,7 +321,7 @@ public class PortalInstancesLocalServiceImpl
 			company.getCompanyId(), themeId);
 
 		themeDisplay.setLookAndFeel(
-			theme, ColorSchemeFactoryUtil.getDefaultRegularColorScheme());
+			theme, _colorSchemeFactory.getDefaultRegularColorScheme());
 
 		themeDisplay.setPermissionChecker(permissionChecker);
 		themeDisplay.setPlid(controlPanelPlid);
@@ -377,6 +377,9 @@ public class PortalInstancesLocalServiceImpl
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		PortalInstancesLocalServiceImpl.class);
+
+	@Reference
+	private ColorSchemeFactory _colorSchemeFactory;
 
 	@Reference
 	private CompanyLocalService _companyLocalService;

--- a/modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java
+++ b/modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java
@@ -48,7 +48,7 @@ import com.liferay.portal.kernel.scheduler.TriggerState;
 import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListener;
 import com.liferay.portal.kernel.scheduler.messaging.SchedulerEventMessageListenerWrapper;
 import com.liferay.portal.kernel.scheduler.messaging.SchedulerResponse;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.InetAddressUtil;
 import com.liferay.portal.kernel.util.ObjectValuePair;
@@ -176,7 +176,7 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 		Calendar recurrenceCalendar = null;
 
 		if (timeZoneSensitive) {
-			recurrenceCalendar = CalendarFactoryUtil.getCalendar();
+			recurrenceCalendar = _calendarFactory.getCalendar();
 
 			recurrenceCalendar.setTime(calendar.getTime());
 		}
@@ -904,6 +904,10 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 	private volatile AuditRouter _auditRouter;
 
 	private volatile BundleContext _bundleContext;
+
+	@Reference
+	private CalendarFactory _calendarFactory;
+
 	private DestinationFactory _destinationFactory;
 	private final Set<ServiceRegistration<Destination>>
 		_destinationServiceRegistrations = new HashSet<>();

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/facet/ModifiedSearchFacet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/facet/ModifiedSearchFacet.java
@@ -23,7 +23,6 @@ import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.search.facet.config.FacetConfiguration;
 import com.liferay.portal.kernel.search.facet.util.FacetFactory;
 import com.liferay.portal.kernel.util.CalendarFactory;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.DateFormatFactory;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -169,23 +168,14 @@ public class ModifiedSearchFacet extends BaseJSPSearchFacet {
 		return modifiedFacetFactory;
 	}
 
+	@Reference
 	protected CalendarFactory calendarFactory;
+
 	protected DateFormatFactory dateFormatFactory;
 	protected JSONFactory jsonFactory;
 
 	@Reference
 	protected ModifiedFacetFactory modifiedFacetFactory;
-
-	private CalendarFactory _getCalendarFactory() {
-
-		// See LPS-72507 and LPS-76500
-
-		if (calendarFactory != null) {
-			return calendarFactory;
-		}
-
-		return CalendarFactoryUtil.getCalendarFactory();
-	}
 
 	private DateFormatFactory _getDateFormatFactory() {
 
@@ -212,8 +202,6 @@ public class ModifiedSearchFacet extends BaseJSPSearchFacet {
 	private JSONArray _replaceAliases(JSONArray rangesJSONArray) {
 		DateRangeFactory dateRangeFactory = new DateRangeFactory(
 			_getDateFormatFactory());
-
-		CalendarFactory calendarFactory = _getCalendarFactory();
 
 		return dateRangeFactory.replaceAliases(
 			rangesJSONArray, calendarFactory.getCalendar(), _getJSONFactory());

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/modified/facet/portlet/ModifiedFacetPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/modified/facet/portlet/ModifiedFacetPortlet.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.CalendarFactory;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.DateFormatFactory;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.Http;
@@ -101,7 +100,9 @@ public class ModifiedFacetPortlet extends MVCPortlet {
 		super.render(renderRequest, renderResponse);
 	}
 
+	@Reference
 	protected CalendarFactory calendarFactory;
+
 	protected DateFormatFactory dateFormatFactory;
 
 	@Reference
@@ -127,8 +128,7 @@ public class ModifiedFacetPortlet extends MVCPortlet {
 
 		ModifiedFacetDisplayBuilder modifiedFacetDisplayBuilder =
 			_createModifiedFacetDisplayBuilder(
-				_getCalendarFactory(), _getDateFormatFactory(), http,
-				renderRequest);
+				calendarFactory, _getDateFormatFactory(), http, renderRequest);
 
 		modifiedFacetDisplayBuilder.setCurrentURL(
 			portal.getCurrentURL(renderRequest));
@@ -182,17 +182,6 @@ public class ModifiedFacetPortlet extends MVCPortlet {
 		catch (ConfigurationException configurationException) {
 			throw new RuntimeException(configurationException);
 		}
-	}
-
-	private CalendarFactory _getCalendarFactory() {
-
-		// See LPS-72507 and LPS-76500
-
-		if (calendarFactory != null) {
-			return calendarFactory;
-		}
-
-		return CalendarFactoryUtil.getCalendarFactory();
 	}
 
 	private DateFormatFactory _getDateFormatFactory() {

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/modified/facet/portlet/shared/search/ModifiedFacetPortletSharedSearchContributor.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/modified/facet/portlet/shared/search/ModifiedFacetPortletSharedSearchContributor.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.search.facet.Facet;
 import com.liferay.portal.kernel.util.CalendarFactory;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.DateFormatFactory;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.search.facet.modified.ModifiedFacetFactory;
@@ -61,7 +60,9 @@ public class ModifiedFacetPortletSharedSearchContributor
 				modifiedFacetPortletPreferences, portletSharedSearchSettings));
 	}
 
+	@Reference
 	protected CalendarFactory calendarFactory;
+
 	protected DateFormatFactory dateFormatFactory;
 	protected DateRangeFactory dateRangeFactory;
 	protected JSONFactory jsonFactory;
@@ -74,8 +75,8 @@ public class ModifiedFacetPortletSharedSearchContributor
 		PortletSharedSearchSettings portletSharedSearchSettings) {
 
 		ModifiedFacetBuilder modifiedFacetBuilder = new ModifiedFacetBuilder(
-			modifiedFacetFactory, _getCalendarFactory(),
-			_getDateFormatFactory(), _getJSONFactory());
+			modifiedFacetFactory, calendarFactory, _getDateFormatFactory(),
+			_getJSONFactory());
 
 		modifiedFacetBuilder.setRangesJSONArray(
 			_replaceAliases(
@@ -101,17 +102,6 @@ public class ModifiedFacetPortletSharedSearchContributor
 			modifiedFacetBuilder::setCustomRangeTo);
 
 		return modifiedFacetBuilder.build();
-	}
-
-	private CalendarFactory _getCalendarFactory() {
-
-		// See LPS-72507 and LPS-76500
-
-		if (calendarFactory != null) {
-			return calendarFactory;
-		}
-
-		return CalendarFactoryUtil.getCalendarFactory();
 	}
 
 	private DateFormatFactory _getDateFormatFactory() {
@@ -146,8 +136,6 @@ public class ModifiedFacetPortletSharedSearchContributor
 
 	private JSONArray _replaceAliases(JSONArray rangesJSONArray) {
 		DateRangeFactory dateRangeFactory = _getDateRangeFactory();
-
-		CalendarFactory calendarFactory = _getCalendarFactory();
 
 		return dateRangeFactory.replaceAliases(
 			rangesJSONArray, calendarFactory.getCalendar(), _getJSONFactory());

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/DefaultLDAPToPortalConverter.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/DefaultLDAPToPortalConverter.java
@@ -35,7 +35,7 @@ import com.liferay.portal.kernel.service.ListTypeService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.persistence.ContactPersistence;
 import com.liferay.portal.kernel.service.persistence.UserPersistence;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PrefsPropsUtil;
@@ -229,7 +229,7 @@ public class DefaultLDAPToPortalConverter implements LDAPToPortalConverter {
 				_log.debug(parseException, parseException);
 			}
 
-			Calendar birthdayCalendar = CalendarFactoryUtil.getCalendar(
+			Calendar birthdayCalendar = _calendarFactory.getCalendar(
 				1970, Calendar.JANUARY, 1);
 
 			contact.setBirthday(birthdayCalendar.getTime());
@@ -398,6 +398,9 @@ public class DefaultLDAPToPortalConverter implements LDAPToPortalConverter {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DefaultLDAPToPortalConverter.class);
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private CompanyLocalService _companyLocalService;

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -51,7 +51,7 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.PrefsPropsUtil;
@@ -639,7 +639,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 			}
 		}
 
-		Calendar birthdayCal = CalendarFactoryUtil.getCalendar();
+		Calendar birthdayCal = _calendarFactory.getCalendar();
 
 		birthdayCal.setTime(ldapUser.getBirthday());
 
@@ -1913,7 +1913,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 			ldapImportContext.getUserMappings(),
 			ldapImportContext.getContactMappings(), ldapUserIgnoreAttributes);
 
-		Calendar birthdayCal = CalendarFactoryUtil.getCalendar();
+		Calendar birthdayCal = _calendarFactory.getCalendar();
 
 		birthdayCal.setTime(ldapContact.getBirthday());
 
@@ -2040,6 +2040,9 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 
 	@Reference
 	private BeanProperties _beanProperties;
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	private CompanyLocalService _companyLocalService;
 	private String _companySecurityAuthType;

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImplTest.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImplTest.java
@@ -14,11 +14,14 @@
 
 package com.liferay.portal.security.ldap.internal.exportimport;
 
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.util.CalendarFactoryImpl;
 
 import javax.naming.InvalidNameException;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -32,6 +35,13 @@ public class LDAPUserImporterImplTest {
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		ReflectionTestUtil.setFieldValue(
+			_ldapUserImporterImpl, "_calendarFactory",
+			new CalendarFactoryImpl());
+	}
 
 	@Test
 	public void testBindingInNamespaceEscape() throws InvalidNameException {

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/calendar/DefaultDueDateCalculator.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/calendar/DefaultDueDateCalculator.java
@@ -14,7 +14,7 @@
 
 package com.liferay.portal.workflow.kaleo.runtime.internal.calendar;
 
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.workflow.kaleo.definition.DelayDuration;
 import com.liferay.portal.workflow.kaleo.definition.DurationScale;
 import com.liferay.portal.workflow.kaleo.runtime.calendar.DueDateCalculator;
@@ -23,6 +23,7 @@ import java.util.Calendar;
 import java.util.Date;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Michael C. Han
@@ -32,7 +33,7 @@ public class DefaultDueDateCalculator implements DueDateCalculator {
 
 	@Override
 	public Date getDueDate(Date startDate, DelayDuration delayDuration) {
-		Calendar cal = CalendarFactoryUtil.getCalendar();
+		Calendar cal = _calendarFactory.getCalendar();
 
 		cal.setTime(startDate);
 
@@ -61,5 +62,8 @@ public class DefaultDueDateCalculator implements DueDateCalculator {
 
 		return cal.getTime();
 	}
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 }

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/internal/calendar/DefaultDueDateCalculatorTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/test/java/com/liferay/portal/workflow/kaleo/runtime/internal/calendar/DefaultDueDateCalculatorTest.java
@@ -14,8 +14,10 @@
 
 package com.liferay.portal.workflow.kaleo.runtime.internal.calendar;
 
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.util.CalendarFactoryImpl;
 import com.liferay.portal.workflow.kaleo.definition.DelayDuration;
 import com.liferay.portal.workflow.kaleo.definition.DurationScale;
 
@@ -25,6 +27,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -55,6 +58,13 @@ public class DefaultDueDateCalculatorTest {
 				{Calendar.SECOND, 1.5, DurationScale.SECOND, 2},
 				{Calendar.YEAR, 1.5, DurationScale.YEAR, 2}
 			});
+	}
+
+	@Before
+	public void setUp() {
+		ReflectionTestUtil.setFieldValue(
+			_defaultDueDateCalculator, "_calendarFactory",
+			new CalendarFactoryImpl());
 	}
 
 	@Test

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoTaskInstanceTokenLocalServiceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoTaskInstanceTokenLocalServiceImpl.java
@@ -38,7 +38,7 @@ import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -851,7 +851,7 @@ public class KaleoTaskInstanceTokenLocalServiceImpl
 		kaleoTaskInstanceToken.setModifiedDate(new Date());
 
 		if (dueDate != null) {
-			Calendar cal = CalendarFactoryUtil.getCalendar(
+			Calendar cal = _calendarFactory.getCalendar(
 				LocaleUtil.getDefault());
 
 			cal.setTime(dueDate);
@@ -1093,6 +1093,9 @@ public class KaleoTaskInstanceTokenLocalServiceImpl
 		).put(
 			KaleoTaskInstanceTokenField.DUE_DATE, Sort.LONG_TYPE
 		).build();
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private KaleoTaskAssignmentInstanceLocalService

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/info/item/updater/JournalArticleInfoItemFieldValuesUpdaterImpl.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/info/item/updater/JournalArticleInfoItemFieldValuesUpdaterImpl.java
@@ -39,7 +39,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -239,7 +239,7 @@ public class JournalArticleInfoItemFieldValuesUpdaterImpl
 
 		int[] dateArray = new int[5];
 
-		Calendar calendar = CalendarFactoryUtil.getCalendar(user.getTimeZone());
+		Calendar calendar = _calendarFactory.getCalendar(user.getTimeZone());
 
 		calendar.setTime(date);
 
@@ -411,6 +411,9 @@ public class JournalArticleInfoItemFieldValuesUpdaterImpl
 
 	@Reference
 	private AssetLinkLocalService _assetLinkLocalService;
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private JournalArticleLocalService _journalArticleLocalService;

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/EditUserMVCActionCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/EditUserMVCActionCommand.java
@@ -61,7 +61,7 @@ import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.Http;
@@ -393,7 +393,7 @@ public class EditUserMVCActionCommand extends BaseMVCActionCommand {
 		boolean male = BeanParamUtil.getBoolean(
 			user, actionRequest, "male", true);
 
-		Calendar birthdayCal = CalendarFactoryUtil.getCalendar();
+		Calendar birthdayCal = _calendarFactory.getCalendar();
 
 		birthdayCal.setTime(contact.getBirthday());
 
@@ -567,6 +567,9 @@ public class EditUserMVCActionCommand extends BaseMVCActionCommand {
 
 		return dynamicActionRequest;
 	}
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	private DLAppLocalService _dlAppLocalService;
 	private ListTypeLocalService _listTypeLocalService;

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/EditUserOrganizationsMVCActionCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/EditUserOrganizationsMVCActionCommand.java
@@ -28,7 +28,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.servlet.SessionErrors;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.users.admin.constants.UsersAdminPortletKeys;
 import com.liferay.users.admin.kernel.util.UsersAdmin;
@@ -68,7 +68,7 @@ public class EditUserOrganizationsMVCActionCommand
 
 			Contact contact = user.getContact();
 
-			Calendar birthdayCal = CalendarFactoryUtil.getCalendar();
+			Calendar birthdayCal = _calendarFactory.getCalendar();
 
 			birthdayCal.setTime(user.getBirthday());
 
@@ -118,6 +118,9 @@ public class EditUserOrganizationsMVCActionCommand
 			}
 		}
 	}
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/UpdateMembershipsMVCActionCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/UpdateMembershipsMVCActionCommand.java
@@ -28,7 +28,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.servlet.SessionErrors;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.users.admin.constants.UsersAdminPortletKeys;
 import com.liferay.users.admin.kernel.util.UsersAdmin;
@@ -66,7 +66,7 @@ public class UpdateMembershipsMVCActionCommand extends BaseMVCActionCommand {
 
 			Contact contact = user.getContact();
 
-			Calendar birthdayCal = CalendarFactoryUtil.getCalendar();
+			Calendar birthdayCal = _calendarFactory.getCalendar();
 
 			birthdayCal.setTime(user.getBirthday());
 
@@ -115,6 +115,9 @@ public class UpdateMembershipsMVCActionCommand extends BaseMVCActionCommand {
 			}
 		}
 	}
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/UpdateUserRolesMVCActionCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/UpdateUserRolesMVCActionCommand.java
@@ -41,7 +41,7 @@ import com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.JavaConstants;
@@ -91,7 +91,7 @@ public class UpdateUserRolesMVCActionCommand extends BaseMVCActionCommand {
 
 			Contact contact = user.getContact();
 
-			Calendar birthdayCal = CalendarFactoryUtil.getCalendar();
+			Calendar birthdayCal = _calendarFactory.getCalendar();
 
 			birthdayCal.setTime(user.getBirthday());
 
@@ -257,6 +257,9 @@ public class UpdateUserRolesMVCActionCommand extends BaseMVCActionCommand {
 			throw new RequiredRoleException.MustNotRemoveLastAdministator();
 		}
 	}
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private Http _http;

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -71,7 +71,7 @@ import com.liferay.portal.kernel.settings.LocalizedValuesMap;
 import com.liferay.portal.kernel.social.SocialActivityManagerUtil;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.systemevent.SystemEventHierarchyEntryThreadLocal;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
@@ -1515,7 +1515,7 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 	public List<WikiPage> getRecentChanges(
 		long groupId, long nodeId, int start, int end) {
 
-		Calendar cal = CalendarFactoryUtil.getCalendar();
+		Calendar cal = _calendarFactory.getCalendar();
 
 		cal.add(Calendar.WEEK_OF_YEAR, -1);
 
@@ -1526,7 +1526,7 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 
 	@Override
 	public int getRecentChangesCount(long groupId, long nodeId) {
-		Calendar cal = CalendarFactoryUtil.getCalendar();
+		Calendar cal = _calendarFactory.getCalendar();
 
 		cal.add(Calendar.WEEK_OF_YEAR, -1);
 
@@ -3447,6 +3447,9 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 
 	@Reference
 	private AssetTagLocalService _assetTagLocalService;
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private CommentManager _commentManager;

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageServiceImpl.java
@@ -27,7 +27,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.settings.GroupServiceSettingsLocator;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -660,7 +660,7 @@ public class WikiPageServiceImpl extends WikiPageServiceBaseImpl {
 		_wikiNodeModelResourcePermission.check(
 			getPermissionChecker(), nodeId, ActionKeys.VIEW);
 
-		Calendar calendar = CalendarFactoryUtil.getCalendar();
+		Calendar calendar = _calendarFactory.getCalendar();
 
 		calendar.add(Calendar.WEEK_OF_YEAR, -1);
 
@@ -676,7 +676,7 @@ public class WikiPageServiceImpl extends WikiPageServiceBaseImpl {
 		_wikiNodeModelResourcePermission.check(
 			getPermissionChecker(), nodeId, ActionKeys.VIEW);
 
-		Calendar calendar = CalendarFactoryUtil.getCalendar();
+		Calendar calendar = _calendarFactory.getCalendar();
 
 		calendar.add(Calendar.WEEK_OF_YEAR, -1);
 
@@ -994,6 +994,9 @@ public class WikiPageServiceImpl extends WikiPageServiceBaseImpl {
 
 		return _rssExporter.export(syndFeed);
 	}
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private ConfigurationProvider _configurationProvider;

--- a/modules/dxp/apps/commerce/commerce-shop-by-diagram-web/src/main/java/com/liferay/commerce/shop/by/diagram/admin/web/internal/portlet/action/EditCSDiagramSettingMVCActionCommand.java
+++ b/modules/dxp/apps/commerce/commerce-shop-by-diagram-web/src/main/java/com/liferay/commerce/shop/by/diagram/admin/web/internal/portlet/action/EditCSDiagramSettingMVCActionCommand.java
@@ -39,7 +39,7 @@ import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -153,9 +153,9 @@ public class EditCSDiagramSettingMVCActionCommand extends BaseMVCActionCommand {
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			CPAttachmentFileEntry.class.getName(), actionRequest);
 
-		Calendar displayCalendar = CalendarFactoryUtil.getCalendar(
+		Calendar displayCalendar = _calendarFactory.getCalendar(
 			serviceContext.getTimeZone());
-		Calendar expirationCalendar = CalendarFactoryUtil.getCalendar(
+		Calendar expirationCalendar = _calendarFactory.getCalendar(
 			serviceContext.getTimeZone());
 
 		if (csDiagramSetting == null) {
@@ -247,6 +247,9 @@ public class EditCSDiagramSettingMVCActionCommand extends BaseMVCActionCommand {
 	private static final TransactionConfig _transactionConfig =
 		TransactionConfig.Factory.create(
 			Propagation.REQUIRED, new Class<?>[] {Exception.class});
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private CPAttachmentFileEntryService _cpAttachmentFileEntryService;

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/java/com/liferay/portal/reports/engine/console/web/internal/admin/portlet/action/AddSchedulerMVCActionCommand.java
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/java/com/liferay/portal/reports/engine/console/web/internal/admin/portlet/action/AddSchedulerMVCActionCommand.java
@@ -28,7 +28,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -178,7 +178,7 @@ public class AddSchedulerMVCActionCommand extends BaseMVCActionCommand {
 		Calendar calendar = null;
 
 		if (timeZoneSensitive) {
-			calendar = CalendarFactoryUtil.getCalendar();
+			calendar = _calendarFactory.getCalendar();
 
 			calendar.setTime(startCalendar.getTime());
 		}
@@ -322,6 +322,9 @@ public class AddSchedulerMVCActionCommand extends BaseMVCActionCommand {
 			dayAndPositions.add(new DayAndPosition(day, 0));
 		}
 	}
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private DefinitionService _definitionService;

--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/test/java/com/liferay/portal/reports/engine/console/web/internal/admin/portlet/action/AddSchedulerMVCActionCommandTest.java
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/test/java/com/liferay/portal/reports/engine/console/web/internal/admin/portlet/action/AddSchedulerMVCActionCommandTest.java
@@ -15,10 +15,12 @@
 package com.liferay.portal.reports.engine.console.web.internal.admin.portlet.action;
 
 import com.liferay.portal.kernel.cal.Recurrence;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.TimeZoneUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.util.CalendarFactoryImpl;
 import com.liferay.portal.util.FastDateFormatFactoryImpl;
 
 import java.util.Calendar;
@@ -45,6 +47,7 @@ public class AddSchedulerMVCActionCommandTest {
 
 	@Before
 	public void setUp() {
+		_setCalendarFactory();
 		_setUpFastDateFormatFactoryUtil();
 	}
 
@@ -181,6 +184,12 @@ public class AddSchedulerMVCActionCommandTest {
 		calendar.set(Calendar.MILLISECOND, 0);
 
 		return calendar;
+	}
+
+	private void _setCalendarFactory() {
+		ReflectionTestUtil.setFieldValue(
+			_addSchedulerMVCActionCommand, "_calendarFactory",
+			new CalendarFactoryImpl());
 	}
 
 	private void _setUpFastDateFormatFactoryUtil() {

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/field/expression/handler/DefaultUserFieldExpressionHandler.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/field/expression/handler/DefaultUserFieldExpressionHandler.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.model.Contact;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.CalendarFactory;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -246,7 +246,7 @@ public class DefaultUserFieldExpressionHandler
 		}
 
 		Contact contact = newUser.getContact();
-		Calendar birthdayCalendar = CalendarFactoryUtil.getCalendar();
+		Calendar birthdayCalendar = _calendarFactory.getCalendar();
 
 		birthdayCalendar.setTime(contact.getBirthday());
 
@@ -285,6 +285,9 @@ public class DefaultUserFieldExpressionHandler
 
 	private final Set<String> _authFieldExpressions = new HashSet<>(
 		Arrays.asList("emailAddress", "screenName", "uuid"));
+
+	@Reference
+	private CalendarFactory _calendarFactory;
 
 	@Reference
 	private LDAPUserImporter _ldapUserImporter;

--- a/portal-impl/src/META-INF/util-spring.xml
+++ b/portal-impl/src/META-INF/util-spring.xml
@@ -204,10 +204,9 @@
 	<bean class="com.liferay.portal.kernel.servlet.SharedSessionUtil" id="com.liferay.portal.kernel.servlet.SharedSessionUtil">
 		<property name="sharedSession" ref="com.liferay.portal.kernel.servlet.SharedSession" />
 	</bean>
+	<bean class="com.liferay.portal.servlet.TransferHeadersHelperImpl" id="com.liferay.portal.kernel.servlet.TransferHeadersHelper" />
 	<bean class="com.liferay.portal.kernel.servlet.TransferHeadersHelperUtil" id="com.liferay.portal.kernel.servlet.TransferHeadersHelperUtil">
-		<property name="transferHeadersHelper">
-			<bean class="com.liferay.portal.servlet.TransferHeadersHelperImpl" />
-		</property>
+		<property name="transferHeadersHelper" ref="com.liferay.portal.kernel.servlet.TransferHeadersHelper" />
 	</bean>
 	<bean class="com.liferay.portal.kernel.spring.orm.LastSessionRecorderHelperUtil" id="com.liferay.portal.kernel.spring.orm.LastSessionRecorderHelperUtil">
 		<property name="lastSessionRecorderHelper">

--- a/portal-impl/src/META-INF/util-spring.xml
+++ b/portal-impl/src/META-INF/util-spring.xml
@@ -232,10 +232,9 @@
 	<bean class="com.liferay.portal.kernel.util.CalendarFactoryUtil" id="com.liferay.portal.kernel.util.CalendarFactoryUtil">
 		<property name="calendarFactory" ref="com.liferay.portal.kernel.util.CalendarFactory" />
 	</bean>
+	<bean class="com.liferay.portal.util.ColorSchemeFactoryImpl" id="com.liferay.portal.kernel.util.ColorScheme" />
 	<bean class="com.liferay.portal.kernel.util.ColorSchemeFactoryUtil" id="com.liferay.portal.kernel.util.ColorSchemeFactoryUtil">
-		<property name="colorSchemeFactory">
-			<bean class="com.liferay.portal.util.ColorSchemeFactoryImpl" />
-		</property>
+		<property name="colorSchemeFactory" ref="com.liferay.portal.kernel.util.ColorScheme" />
 	</bean>
 	<bean class="com.liferay.portal.kernel.util.CustomJspRegistryUtil" id="com.liferay.portal.kernel.util.CustomJspRegistryUtil">
 		<property name="customJspRegistry">

--- a/portal-impl/src/META-INF/util-spring.xml
+++ b/portal-impl/src/META-INF/util-spring.xml
@@ -228,10 +228,9 @@
 			<bean class="com.liferay.portal.upgrade.util.MemoryValueMapperFactoryImpl" />
 		</property>
 	</bean>
+	<bean class="com.liferay.portal.util.CalendarFactoryImpl" id="com.liferay.portal.kernel.util.CalendarFactory" />
 	<bean class="com.liferay.portal.kernel.util.CalendarFactoryUtil" id="com.liferay.portal.kernel.util.CalendarFactoryUtil">
-		<property name="calendarFactory">
-			<bean class="com.liferay.portal.util.CalendarFactoryImpl" />
-		</property>
+		<property name="calendarFactory" ref="com.liferay.portal.kernel.util.CalendarFactory" />
 	</bean>
 	<bean class="com.liferay.portal.kernel.util.ColorSchemeFactoryUtil" id="com.liferay.portal.kernel.util.ColorSchemeFactoryUtil">
 		<property name="colorSchemeFactory">

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -514,6 +514,7 @@
         com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil,\
         com.liferay.portal.kernel.image.GhostscriptUtil,\
         com.liferay.portal.kernel.servlet.TransferHeadersHelperUtil,\
+        com.liferay.portal.kernel.util.CalendarFactoryUtil,\
         com.liferay.portal.kernel.util.HttpUtil,\
         com.liferay.portal.kernel.util.PortalUtil
 

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -515,6 +515,7 @@
         com.liferay.portal.kernel.image.GhostscriptUtil,\
         com.liferay.portal.kernel.servlet.TransferHeadersHelperUtil,\
         com.liferay.portal.kernel.util.CalendarFactoryUtil,\
+        com.liferay.portal.kernel.util.ColorSchemeFactoryUtil,\
         com.liferay.portal.kernel.util.HttpUtil,\
         com.liferay.portal.kernel.util.PortalUtil
 

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -513,6 +513,7 @@
         com.liferay.portal.kernel.dao.jdbc.CurrentConnectionUtil,\
         com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil,\
         com.liferay.portal.kernel.image.GhostscriptUtil,\
+        com.liferay.portal.kernel.servlet.TransferHeadersHelperUtil,\
         com.liferay.portal.kernel.util.HttpUtil,\
         com.liferay.portal.kernel.util.PortalUtil
 


### PR DESCRIPTION
Hi Tina,

Main Task: [LPS-143403](https://issues.liferay.com/browse/LPS-143403)
Sub Task 11: [LPS-143630](https://issues.liferay.com/browse/LPS-143630)
Removes TransferHeadersHelperUtil, CalendarFactoryUtil, and ColorSchemeFactoryUtil from modules components

Note: from sub task 6 and onwards, tasks no longer depend on previous tasks.

Thank you!