### PR TITLE
LPS-143634 Avoid using SanitizerUtil, CommonPermissionUtil, GroupPermissionUtil directly in modules

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
@@ -25,7 +25,7 @@ import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigura
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portlet.asset.service.permission.AssetCategoriesPermission;
@@ -35,6 +35,7 @@ import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Eudaldo Alonso
@@ -102,7 +103,7 @@ public class PermissionsPortletConfigurationIcon
 			if (!AssetCategoriesPermission.contains(
 					permissionChecker, themeDisplay.getSiteGroupId(),
 					ActionKeys.PERMISSIONS) ||
-				!GroupPermissionUtil.contains(
+				!_groupPermission.contains(
 					permissionChecker, themeDisplay.getSiteGroupId(),
 					ActionKeys.PERMISSIONS)) {
 
@@ -132,5 +133,8 @@ public class PermissionsPortletConfigurationIcon
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		PermissionsPortletConfigurationIcon.class);
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 }

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/helper/AssetPublisherWebHelper.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/helper/AssetPublisherWebHelper.java
@@ -48,7 +48,7 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
 import com.liferay.portal.kernel.settings.LocalizedValuesMap;
 import com.liferay.portal.kernel.theme.PortletDisplay;
@@ -488,12 +488,12 @@ public class AssetPublisherWebHelper {
 			}
 
 			if (checkPermission) {
-				return GroupPermissionUtil.contains(
+				return _groupPermission.contains(
 					permissionChecker, group, ActionKeys.UPDATE);
 			}
 		}
 		else if ((groupId != companyGroupId) && checkPermission) {
-			return GroupPermissionUtil.contains(
+			return _groupPermission.contains(
 				permissionChecker, groupId, ActionKeys.UPDATE);
 		}
 
@@ -675,6 +675,9 @@ public class AssetPublisherWebHelper {
 
 	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/persistence/impl/BlogsEntryPersistenceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/persistence/impl/BlogsEntryPersistenceImpl.java
@@ -39,7 +39,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
-import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.InlineSQLHelperUtil;
@@ -21983,21 +21982,24 @@ public class BlogsEntryPersistenceImpl
 
 			try {
 				blogsEntry.setTitle(
-					SanitizerUtil.sanitize(
+					_sanitizer.sanitize(
 						companyId, groupId, userId, BlogsEntry.class.getName(),
-						entryId, ContentTypes.TEXT_PLAIN, Sanitizer.MODE_ALL,
+						entryId, ContentTypes.TEXT_PLAIN, new String[]{
+							Sanitizer.MODE_ALL},
 						blogsEntry.getTitle(), null));
 
 				blogsEntry.setContent(
-					SanitizerUtil.sanitize(
+					_sanitizer.sanitize(
 						companyId, groupId, userId, BlogsEntry.class.getName(),
-						entryId, ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL,
+						entryId, ContentTypes.TEXT_HTML, new String[]{
+							Sanitizer.MODE_ALL},
 						blogsEntry.getContent(), null));
 
 				blogsEntry.setCoverImageCaption(
-					SanitizerUtil.sanitize(
+					_sanitizer.sanitize(
 						companyId, groupId, userId, BlogsEntry.class.getName(),
-						entryId, ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL,
+						entryId, ContentTypes.TEXT_HTML, new String[]{
+							Sanitizer.MODE_ALL},
 						blogsEntry.getCoverImageCaption(), null));
 			}
 			catch (SanitizerException sanitizerException) {
@@ -23158,5 +23160,8 @@ public class BlogsEntryPersistenceImpl
 
 	@Reference
 	private BlogsEntryModelArgumentsResolver _blogsEntryModelArgumentsResolver;
+
+	@Reference
+	private Sanitizer _sanitizer;
 
 }

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/struts/RSSStrutsAction.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/struts/RSSStrutsAction.java
@@ -22,7 +22,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.settings.GroupServiceSettingsLocator;
 import com.liferay.portal.kernel.struts.StrutsAction;
@@ -166,7 +166,7 @@ public class RSSStrutsAction implements StrutsAction {
 		long groupId = ParamUtil.getLong(httpServletRequest, "groupId");
 
 		if ((groupId == 0) ||
-			GroupPermissionUtil.contains(
+			_groupPermission.contains(
 				themeDisplay.getPermissionChecker(), groupId,
 				ActionKeys.VIEW)) {
 
@@ -199,6 +199,9 @@ public class RSSStrutsAction implements StrutsAction {
 
 	@Reference
 	private ConfigurationProvider _configurationProvider;
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/bookmarks/bookmarks-web/src/main/java/com/liferay/bookmarks/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/java/com/liferay/bookmarks/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigura
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.AggregateResourceBundle;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
@@ -40,6 +40,7 @@ import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Sergio González
@@ -117,7 +118,7 @@ public class PermissionsPortletConfigurationIcon
 			themeDisplay.getPermissionChecker();
 
 		try {
-			if (!GroupPermissionUtil.contains(
+			if (!_groupPermission.contains(
 					permissionChecker, themeDisplay.getScopeGroupId(),
 					ActionKeys.PERMISSIONS)) {
 
@@ -150,5 +151,8 @@ public class PermissionsPortletConfigurationIcon
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		PermissionsPortletConfigurationIcon.class);
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 }

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
@@ -71,7 +71,6 @@ import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
-import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -152,11 +151,11 @@ public class CalendarBookingLocalServiceImpl
 		long calendarBookingId = counterLocalService.increment();
 
 		for (Map.Entry<Locale, String> entry : descriptionMap.entrySet()) {
-			String sanitizedDescription = SanitizerUtil.sanitize(
+			String sanitizedDescription = _sanitizer.sanitize(
 				calendar.getCompanyId(), calendar.getGroupId(), userId,
 				CalendarBooking.class.getName(), calendarBookingId,
-				ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL, entry.getValue(),
-				null);
+				ContentTypes.TEXT_HTML, new String[] {Sanitizer.MODE_ALL},
+				entry.getValue(), null);
 
 			descriptionMap.put(entry.getKey(), sanitizedDescription);
 		}
@@ -1198,11 +1197,11 @@ public class CalendarBookingLocalServiceImpl
 		}
 
 		for (Map.Entry<Locale, String> entry : descriptionMap.entrySet()) {
-			String sanitizedDescription = SanitizerUtil.sanitize(
+			String sanitizedDescription = _sanitizer.sanitize(
 				calendar.getCompanyId(), calendar.getGroupId(), userId,
 				CalendarBooking.class.getName(), calendarBookingId,
-				ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL, entry.getValue(),
-				null);
+				ContentTypes.TEXT_HTML, new String[] {Sanitizer.MODE_ALL},
+				entry.getValue(), null);
 
 			descriptionMap.put(entry.getKey(), sanitizedDescription);
 		}
@@ -2728,6 +2727,9 @@ public class CalendarBookingLocalServiceImpl
 
 	@Reference
 	private RatingsStatsLocalService _ratingsStatsLocalService;
+
+	@Reference
+	private Sanitizer _sanitizer;
 
 	@Reference
 	private SocialActivityCounterLocalService

--- a/modules/apps/commerce/commerce-product-asset-categories-web/src/main/java/com/liferay/commerce/product/asset/categories/web/internal/frontend/taglib/servlet/taglib/CommerceChannelCategoryDisplayLayoutsScreenNavigationCategory.java
+++ b/modules/apps/commerce/commerce-product-asset-categories-web/src/main/java/com/liferay/commerce/product/asset/categories/web/internal/frontend/taglib/servlet/taglib/CommerceChannelCategoryDisplayLayoutsScreenNavigationCategory.java
@@ -34,7 +34,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -91,7 +91,7 @@ public class CommerceChannelCategoryDisplayLayoutsScreenNavigationCategory
 	@Override
 	public boolean isVisible(User user, CommerceChannel commerceChannel) {
 		try {
-			if (!GroupPermissionUtil.contains(
+			if (!_groupPermission.contains(
 					PermissionThreadLocal.getPermissionChecker(),
 					commerceChannel.getSiteGroupId(), ActionKeys.ADD_LAYOUT)) {
 
@@ -153,6 +153,9 @@ public class CommerceChannelCategoryDisplayLayoutsScreenNavigationCategory
 
 	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 	@Reference
 	private ItemSelector _itemSelector;

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/java/com/liferay/commerce/product/definitions/web/internal/frontend/taglib/servlet/taglib/CommerceChannelProductDisplayLayoutsScreenNavigationCategory.java
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/java/com/liferay/commerce/product/definitions/web/internal/frontend/taglib/servlet/taglib/CommerceChannelProductDisplayLayoutsScreenNavigationCategory.java
@@ -34,7 +34,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -91,7 +91,7 @@ public class CommerceChannelProductDisplayLayoutsScreenNavigationCategory
 	@Override
 	public boolean isVisible(User user, CommerceChannel commerceChannel) {
 		try {
-			if (!GroupPermissionUtil.contains(
+			if (!_groupPermission.contains(
 					PermissionThreadLocal.getPermissionChecker(),
 					commerceChannel.getSiteGroupId(), ActionKeys.ADD_LAYOUT)) {
 
@@ -153,6 +153,9 @@ public class CommerceChannelProductDisplayLayoutsScreenNavigationCategory
 
 	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 	@Reference
 	private ItemSelector _itemSelector;

--- a/modules/apps/commerce/commerce-term-service/src/main/java/com/liferay/commerce/term/service/persistence/impl/CTermEntryLocalizationPersistenceImpl.java
+++ b/modules/apps/commerce/commerce-term-service/src/main/java/com/liferay/commerce/term/service/persistence/impl/CTermEntryLocalizationPersistenceImpl.java
@@ -37,7 +37,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
-import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
@@ -1166,11 +1165,11 @@ public class CTermEntryLocalizationPersistenceImpl
 
 			try {
 				cTermEntryLocalization.setDescription(
-					SanitizerUtil.sanitize(
+					_sanitizer.sanitize(
 						companyId, groupId, userId,
 						CTermEntryLocalization.class.getName(),
 						cTermEntryLocalizationId, ContentTypes.TEXT_HTML,
-						Sanitizer.MODE_ALL,
+						new String[]{Sanitizer.MODE_ALL},
 						cTermEntryLocalization.getDescription(), null));
 			}
 			catch (SanitizerException sanitizerException) {
@@ -1608,5 +1607,8 @@ public class CTermEntryLocalizationPersistenceImpl
 	@Reference
 	private CTermEntryLocalizationModelArgumentsResolver
 		_cTermEntryLocalizationModelArgumentsResolver;
+
+	@Reference
+	private Sanitizer _sanitizer;
 
 }

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/portlet/SiteSettingsPortlet.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/portlet/SiteSettingsPortlet.java
@@ -18,7 +18,7 @@ import com.liferay.configuration.admin.constants.ConfigurationAdminPortletKeys;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -32,6 +32,7 @@ import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Raymond Augé
@@ -66,7 +67,7 @@ public class SiteSettingsPortlet extends MVCPortlet {
 			renderRequest, "groupId", themeDisplay.getScopeGroupId());
 
 		try {
-			GroupPermissionUtil.check(
+			_groupPermission.check(
 				themeDisplay.getPermissionChecker(), groupId, ActionKeys.VIEW);
 		}
 		catch (PortalException portalException) {
@@ -75,5 +76,8 @@ public class SiteSettingsPortlet extends MVCPortlet {
 
 		super.doDispatch(renderRequest, renderResponse);
 	}
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 }

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/service/DepotGroupLocalServiceWrapper.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/service/DepotGroupLocalServiceWrapper.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.GroupServiceWrapper;
 import com.liferay.portal.kernel.service.ServiceWrapper;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.Portal;
 
@@ -45,7 +45,7 @@ public class DepotGroupLocalServiceWrapper extends GroupServiceWrapper {
 		Group group = _groupLocalService.getGroup(groupId);
 
 		if (group.isDepot()) {
-			GroupPermissionUtil.check(
+			_groupPermission.check(
 				GuestOrUserUtil.getPermissionChecker(), group,
 				ActionKeys.UPDATE);
 
@@ -77,6 +77,9 @@ public class DepotGroupLocalServiceWrapper extends GroupServiceWrapper {
 
 	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 	@Reference
 	private Http _http;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/info/display/field/DDMFormValuesInfoDisplayFieldProviderImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/info/display/field/DDMFormValuesInfoDisplayFieldProviderImpl.java
@@ -32,7 +32,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
-import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -246,10 +245,11 @@ public class DDMFormValuesInfoDisplayFieldProviderImpl<T extends GroupedModel>
 			return jsonObject;
 		}
 
-		return SanitizerUtil.sanitize(
+		return _sanitizer.sanitize(
 			t.getCompanyId(), t.getGroupId(), t.getUserId(),
 			t.getModelClassName(), (long)t.getPrimaryKeyObj(),
-			ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL, valueString, null);
+			ContentTypes.TEXT_HTML, new String[] {Sanitizer.MODE_ALL},
+			valueString, null);
 	}
 
 	private String _transformFileEntryURL(String data) {
@@ -286,5 +286,8 @@ public class DDMFormValuesInfoDisplayFieldProviderImpl<T extends GroupedModel>
 
 	@Reference
 	private DLURLHelper _dlURLHelper;
+
+	@Reference
+	private Sanitizer _sanitizer;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/info/item/provider/DDMFormValuesInfoFieldValuesProviderImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/info/item/provider/DDMFormValuesInfoFieldValuesProviderImpl.java
@@ -38,7 +38,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
-import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -257,11 +256,11 @@ public class DDMFormValuesInfoFieldValuesProviderImpl
 					JSONFactoryUtil.createJSONObject(valueString));
 			}
 
-			return SanitizerUtil.sanitize(
+			return _sanitizer.sanitize(
 				groupedModel.getCompanyId(), groupedModel.getGroupId(),
 				groupedModel.getUserId(), groupedModel.getModelClassName(),
 				(long)groupedModel.getPrimaryKeyObj(), ContentTypes.TEXT_HTML,
-				Sanitizer.MODE_ALL, valueString, null);
+				new String[] {Sanitizer.MODE_ALL}, valueString, null);
 		}
 		catch (Exception exception) {
 			_log.error(
@@ -286,5 +285,8 @@ public class DDMFormValuesInfoFieldValuesProviderImpl
 
 	@Reference
 	private DLURLHelper _dlURLHelper;
+
+	@Reference
+	private Sanitizer _sanitizer;
 
 }

--- a/modules/apps/export-import/export-import-changeset-web/src/main/java/com/liferay/exportimport/changeset/web/internal/portlet/ChangesetPortletControlPanelEntry.java
+++ b/modules/apps/export-import/export-import-changeset-web/src/main/java/com/liferay/exportimport/changeset/web/internal/portlet/ChangesetPortletControlPanelEntry.java
@@ -22,9 +22,10 @@ import com.liferay.portal.kernel.portlet.BaseControlPanelEntry;
 import com.liferay.portal.kernel.portlet.ControlPanelEntry;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Máté Thurzó
@@ -41,7 +42,7 @@ public class ChangesetPortletControlPanelEntry extends BaseControlPanelEntry {
 			PermissionChecker permissionChecker, Group group, Portlet portlet)
 		throws PortalException {
 
-		if (GroupPermissionUtil.contains(
+		if (_groupPermission.contains(
 				permissionChecker, group,
 				ActionKeys.EXPORT_IMPORT_PORTLET_INFO)) {
 
@@ -51,5 +52,8 @@ public class ChangesetPortletControlPanelEntry extends BaseControlPanelEntry {
 		return super.hasAccessPermissionExplicitlyGranted(
 			permissionChecker, group, portlet);
 	}
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 }

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
@@ -128,7 +128,7 @@ import com.liferay.portal.kernel.service.RecentLayoutSetBranchLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalService;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.servlet.ServletResponseConstants;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadRequestSizeException;
@@ -1736,15 +1736,12 @@ public class StagingImpl implements Staging {
 
 				long scopeGroupId = stagingGroup.getGroupId();
 
-				boolean hasManageStagingPermission =
-					GroupPermissionUtil.contains(
-						permissionChecker, scopeGroupId,
-						ActionKeys.MANAGE_STAGING);
-				boolean hasPublishStagingPermission =
-					GroupPermissionUtil.contains(
-						permissionChecker, scopeGroupId,
-						ActionKeys.PUBLISH_STAGING);
-				boolean hasViewStagingPermission = GroupPermissionUtil.contains(
+				boolean hasManageStagingPermission = _groupPermission.contains(
+					permissionChecker, scopeGroupId, ActionKeys.MANAGE_STAGING);
+				boolean hasPublishStagingPermission = _groupPermission.contains(
+					permissionChecker, scopeGroupId,
+					ActionKeys.PUBLISH_STAGING);
+				boolean hasViewStagingPermission = _groupPermission.contains(
 					permissionChecker, scopeGroupId, ActionKeys.VIEW_STAGING);
 
 				if (hasManageStagingPermission || hasPublishStagingPermission ||
@@ -3801,7 +3798,7 @@ public class StagingImpl implements Staging {
 			ExportImportConfiguration exportImportConfiguration)
 		throws PortalException {
 
-		GroupPermissionUtil.check(
+		_groupPermission.check(
 			PermissionThreadLocal.getPermissionChecker(),
 			exportImportConfiguration.getGroupId(), ActionKeys.PUBLISH_STAGING);
 	}
@@ -4066,6 +4063,9 @@ public class StagingImpl implements Staging {
 
 	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 	@Reference
 	private LayoutBranchLocalService _layoutBranchLocalService;

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/ExportImportControlPanelEntry.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/ExportImportControlPanelEntry.java
@@ -22,9 +22,10 @@ import com.liferay.portal.kernel.portlet.BaseControlPanelEntry;
 import com.liferay.portal.kernel.portlet.ControlPanelEntry;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Julio Camarero
@@ -54,7 +55,7 @@ public class ExportImportControlPanelEntry extends BaseControlPanelEntry {
 			PermissionChecker permissionChecker, Group group, Portlet portlet)
 		throws PortalException {
 
-		if (GroupPermissionUtil.contains(
+		if (_groupPermission.contains(
 				permissionChecker, group, ActionKeys.EXPORT_IMPORT_LAYOUTS)) {
 
 			return true;
@@ -63,5 +64,8 @@ public class ExportImportControlPanelEntry extends BaseControlPanelEntry {
 		return super.hasAccessPermissionExplicitlyGranted(
 			permissionChecker, group, portlet);
 	}
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 }

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/configuration/icon/ExportImportPortletConfigurationIcon.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/portlet/configuration/icon/ExportImportPortletConfigurationIcon.java
@@ -23,7 +23,7 @@ import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigura
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.PortletLocalService;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HtmlUtil;
@@ -121,7 +121,7 @@ public class ExportImportPortletConfigurationIcon
 		}
 
 		try {
-			return GroupPermissionUtil.contains(
+			return _groupPermission.contains(
 				themeDisplay.getPermissionChecker(),
 				themeDisplay.getScopeGroup(),
 				ActionKeys.EXPORT_IMPORT_PORTLET_INFO);
@@ -150,6 +150,9 @@ public class ExportImportPortletConfigurationIcon
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ExportImportPortletConfigurationIcon.class);
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 	@Reference
 	private PortletLocalService _portletLocalService;

--- a/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/trash/ExportImportConfigurationTrashHandler.java
+++ b/modules/apps/export-import/export-import-web/src/main/java/com/liferay/exportimport/web/internal/trash/ExportImportConfigurationTrashHandler.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.TrashedModel;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.trash.BaseTrashHandler;
 import com.liferay.portal.kernel.trash.TrashHandler;
@@ -114,7 +114,7 @@ public class ExportImportConfigurationTrashHandler extends BaseTrashHandler {
 		Group group = _groupLocalService.getGroup(
 			exportImportConfiguration.getGroupId());
 
-		return GroupPermissionUtil.contains(permissionChecker, group, actionId);
+		return _groupPermission.contains(permissionChecker, group, actionId);
 	}
 
 	@Reference(unbind = "-")
@@ -136,5 +136,8 @@ public class ExportImportConfigurationTrashHandler extends BaseTrashHandler {
 	private ExportImportConfigurationLocalService
 		_exportImportConfigurationLocalService;
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 }

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/PostalAddressResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/PostalAddressResourceImpl.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.AddressLocalService;
 import com.liferay.portal.kernel.service.AddressService;
 import com.liferay.portal.kernel.service.UserService;
-import com.liferay.portal.kernel.service.permission.CommonPermissionUtil;
+import com.liferay.portal.kernel.service.permission.CommonPermission;
 import com.liferay.portal.vulcan.pagination.Page;
 
 import org.osgi.service.component.annotations.Component;
@@ -80,7 +80,7 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 
 		User user = _userService.getUserById(userAccountId);
 
-		CommonPermissionUtil.check(
+		_commonPermission.check(
 			PermissionThreadLocal.getPermissionChecker(),
 			user.getModelClassName(), user.getUserId(), ActionKeys.VIEW);
 
@@ -100,6 +100,9 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 
 	@Reference
 	private AddressService _addressService;
+
+	@Reference
+	private CommonPermission _commonPermission;
 
 	@Reference
 	private OrganizationResourceDTOConverter _organizationResourceDTOConverter;

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/SiteResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/SiteResourceImpl.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.GroupService;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.vulcan.pagination.Page;
@@ -77,7 +77,7 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 				"No site exists with friendly URL " + url);
 		}
 
-		GroupPermissionUtil.check(
+		_groupPermission.check(
 			PermissionThreadLocal.getPermissionChecker(), group,
 			ActionKeys.VIEW);
 
@@ -121,6 +121,9 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 
 	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 	@Reference
 	private GroupService _groupService;

--- a/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/display/field/InfoDisplayFieldProviderImpl.java
+++ b/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/display/field/InfoDisplayFieldProviderImpl.java
@@ -21,7 +21,6 @@ import com.liferay.info.display.contributor.field.InfoDisplayContributorFieldTyp
 import com.liferay.info.display.field.InfoDisplayFieldProvider;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
-import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -103,11 +102,11 @@ public class InfoDisplayFieldProviderImpl implements InfoDisplayFieldProvider {
 					infoDisplayContributorFieldType) &&
 				(fieldValue instanceof String)) {
 
-				fieldValue = SanitizerUtil.sanitize(
+				fieldValue = _sanitizer.sanitize(
 					serviceContext.getCompanyId(),
 					serviceContext.getScopeGroupId(),
 					serviceContext.getUserId(), className, 0,
-					ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL,
+					ContentTypes.TEXT_HTML, new String[] {Sanitizer.MODE_ALL},
 					(String)fieldValue, null);
 			}
 
@@ -121,5 +120,8 @@ public class InfoDisplayFieldProviderImpl implements InfoDisplayFieldProvider {
 	@Reference
 	private InfoDisplayContributorFieldTracker
 		_infoDisplayContributorFieldTracker;
+
+	@Reference
+	private Sanitizer _sanitizer;
 
 }

--- a/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/item/field/reader/InfoItemFieldReaderFieldSetProviderImpl.java
+++ b/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/item/field/reader/InfoItemFieldReaderFieldSetProviderImpl.java
@@ -24,7 +24,6 @@ import com.liferay.info.item.field.reader.InfoItemFieldReaderTracker;
 import com.liferay.info.localized.InfoLocalizedValue;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
-import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -88,12 +87,12 @@ public class InfoItemFieldReaderFieldSetProviderImpl
 				(value instanceof String)) {
 
 				try {
-					value = SanitizerUtil.sanitize(
+					value = _sanitizer.sanitize(
 						serviceContext.getCompanyId(),
 						serviceContext.getScopeGroupId(),
 						serviceContext.getUserId(), className, 0,
-						ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL,
-						(String)value, null);
+						ContentTypes.TEXT_HTML,
+						new String[] {Sanitizer.MODE_ALL}, (String)value, null);
 				}
 				catch (SanitizerException sanitizerException) {
 					throw new RuntimeException(sanitizerException);
@@ -108,5 +107,8 @@ public class InfoItemFieldReaderFieldSetProviderImpl
 
 	@Reference
 	private InfoItemFieldReaderTracker _infoItemFieldReaderTracker;
+
+	@Reference
+	private Sanitizer _sanitizer;
 
 }

--- a/modules/apps/item-selector/item-selector-impl/src/main/java/com/liferay/item/selector/internal/provider/GroupItemSelectorProviderImpl.java
+++ b/modules/apps/item-selector/item-selector-impl/src/main/java/com/liferay/item/selector/internal/provider/GroupItemSelectorProviderImpl.java
@@ -28,7 +28,7 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.GroupService;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portlet.usersadmin.search.GroupSearch;
 
@@ -131,7 +131,7 @@ public class GroupItemSelectorProviderImpl
 		for (Group group : groups) {
 			if (group.isCompany() ||
 				permissionChecker.isGroupAdmin(group.getGroupId()) ||
-				GroupPermissionUtil.contains(
+				_groupPermission.contains(
 					permissionChecker, group, ActionKeys.VIEW)) {
 
 				filteredGroups.add(group);
@@ -151,6 +151,9 @@ public class GroupItemSelectorProviderImpl
 
 	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 	@Reference
 	private GroupService _groupService;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -144,7 +144,7 @@ import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
 import com.liferay.portal.kernel.repository.capabilities.TemporaryFileEntriesCapability;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
-import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
+import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.search.BaseModelSearchResult;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Hits;
@@ -7597,10 +7597,11 @@ public class JournalArticleLocalServiceImpl
 							contentType = ContentTypes.TEXT_HTML;
 						}
 
-						dynamicContent = SanitizerUtil.sanitize(
+						dynamicContent = _sanitizer.sanitize(
 							user.getCompanyId(), groupId, user.getUserId(),
 							JournalArticle.class.getName(), 0, contentType,
-							dynamicContent);
+							new String[] {Sanitizer.MODE_ALL}, dynamicContent,
+							null);
 
 						dynamicContentElement.clearContent();
 
@@ -8331,9 +8332,10 @@ public class JournalArticleLocalServiceImpl
 		}
 
 		for (Map.Entry<Locale, String> entry : descriptionMap.entrySet()) {
-			String description = SanitizerUtil.sanitize(
+			String description = _sanitizer.sanitize(
 				companyId, groupId, userId, JournalArticle.class.getName(),
-				classPK, ContentTypes.TEXT_HTML, entry.getValue());
+				classPK, ContentTypes.TEXT_HTML,
+				new String[] {Sanitizer.MODE_ALL}, entry.getValue(), null);
 
 			descriptionMap.put(entry.getKey(), description);
 		}
@@ -9362,6 +9364,9 @@ public class JournalArticleLocalServiceImpl
 
 	@Reference
 	private ResourceLocalService _resourceLocalService;
+
+	@Reference
+	private Sanitizer _sanitizer;
 
 	@Reference
 	private SubscriptionLocalService _subscriptionLocalService;

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBArticlePersistenceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBArticlePersistenceImpl.java
@@ -38,7 +38,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
-import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.InlineSQLHelperUtil;
@@ -35074,9 +35073,9 @@ public class KBArticlePersistenceImpl
 
 			try {
 				kbArticle.setContent(
-					SanitizerUtil.sanitize(
+					_sanitizer.sanitize(
 						companyId, groupId, userId, KBArticle.class.getName(),
-						kbArticleId, ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL,
+						kbArticleId, ContentTypes.TEXT_HTML, new String[]{Sanitizer.MODE_ALL},
 						kbArticle.getContent(), null));
 			}
 			catch (SanitizerException sanitizerException) {
@@ -36314,5 +36313,8 @@ public class KBArticlePersistenceImpl
 
 	@Reference
 	private KBArticleModelArgumentsResolver _kbArticleModelArgumentsResolver;
+
+	@Reference
+	private Sanitizer _sanitizer;
 
 }

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBTemplatePersistenceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/persistence/impl/KBTemplatePersistenceImpl.java
@@ -38,7 +38,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
-import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.InlineSQLHelperUtil;
@@ -2606,10 +2605,10 @@ public class KBTemplatePersistenceImpl
 
 			try {
 				kbTemplate.setContent(
-					SanitizerUtil.sanitize(
+					_sanitizer.sanitize(
 						companyId, groupId, userId, KBTemplate.class.getName(),
 						kbTemplateId, ContentTypes.TEXT_HTML,
-						Sanitizer.MODE_ALL, kbTemplate.getContent(), null));
+						new String[]{Sanitizer.MODE_ALL}, kbTemplate.getContent(), null));
 			}
 			catch (SanitizerException sanitizerException) {
 				throw new SystemException(sanitizerException);
@@ -3101,5 +3100,8 @@ public class KBTemplatePersistenceImpl
 
 	@Reference
 	private KBTemplateModelArgumentsResolver _kbTemplateModelArgumentsResolver;
+
+	@Reference
+	private Sanitizer _sanitizer;
 
 }

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/portlet/configuration/icon/PermissionsPortletConfigurationIcon.java
@@ -27,7 +27,7 @@ import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfiguration
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.AggregateResourceBundle;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
@@ -119,7 +119,7 @@ public class PermissionsPortletConfigurationIcon
 			if (!_portletResourcePermission.contains(
 					permissionChecker, themeDisplay.getScopeGroup(),
 					ActionKeys.PERMISSIONS) ||
-				!GroupPermissionUtil.contains(
+				!_groupPermission.contains(
 					permissionChecker, themeDisplay.getScopeGroup(),
 					ActionKeys.PERMISSIONS)) {
 
@@ -144,6 +144,9 @@ public class PermissionsPortletConfigurationIcon
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		PermissionsPortletConfigurationIcon.class);
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 	@Reference(
 		target = "(resource.name=" + KBConstants.RESOURCE_NAME_ADMIN + ")"

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/GroupPagesControlPanelEntry.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/GroupPagesControlPanelEntry.java
@@ -21,9 +21,10 @@ import com.liferay.portal.kernel.portlet.BaseControlPanelEntry;
 import com.liferay.portal.kernel.portlet.ControlPanelEntry;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Jorge Ferrer
@@ -59,7 +60,7 @@ public class GroupPagesControlPanelEntry extends BaseControlPanelEntry {
 			PermissionChecker permissionChecker, Group group, Portlet portlet)
 		throws Exception {
 
-		if (GroupPermissionUtil.contains(
+		if (_groupPermission.contains(
 				permissionChecker, group, ActionKeys.MANAGE_LAYOUTS)) {
 
 			return true;
@@ -68,5 +69,8 @@ public class GroupPagesControlPanelEntry extends BaseControlPanelEntry {
 		return super.hasPermissionImplicitlyGranted(
 			permissionChecker, group, portlet);
 	}
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 }

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/DeleteLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/DeleteLayoutMVCActionCommand.java
@@ -30,7 +30,7 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.servlet.SessionMessages;
@@ -109,10 +109,10 @@ public class DeleteLayoutMVCActionCommand extends BaseMVCActionCommand {
 		}
 
 		if (group.isStagingGroup() &&
-			!GroupPermissionUtil.contains(
+			!_groupPermission.contains(
 				themeDisplay.getPermissionChecker(), group,
 				ActionKeys.MANAGE_STAGING) &&
-			!GroupPermissionUtil.contains(
+			!_groupPermission.contains(
 				themeDisplay.getPermissionChecker(), group,
 				ActionKeys.PUBLISH_STAGING)) {
 
@@ -172,6 +172,9 @@ public class DeleteLayoutMVCActionCommand extends BaseMVCActionCommand {
 			}
 		}
 	}
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutSetMVCRenderCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutSetMVCRenderCommand.java
@@ -20,7 +20,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -30,6 +30,7 @@ import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Víctor Galán
@@ -55,7 +56,7 @@ public class EditLayoutSetMVCRenderCommand implements MVCRenderCommand {
 				(ThemeDisplay)renderRequest.getAttribute(WebKeys.THEME_DISPLAY);
 
 			try {
-				GroupPermissionUtil.check(
+				_groupPermission.check(
 					themeDisplay.getPermissionChecker(), groupId,
 					ActionKeys.VIEW);
 			}
@@ -73,5 +74,8 @@ public class EditLayoutSetMVCRenderCommand implements MVCRenderCommand {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		EditLayoutSetMVCRenderCommand.class);
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 }

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutsTreeImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutsTreeImpl.java
@@ -40,7 +40,7 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutRevisionLocalService;
 import com.liferay.portal.kernel.service.LayoutService;
 import com.liferay.portal.kernel.service.LayoutSetBranchLocalService;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.service.permission.LayoutPermission;
 import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
 import com.liferay.portal.kernel.servlet.BrowserSnifferUtil;
@@ -500,7 +500,7 @@ public class LayoutsTreeImpl implements LayoutsTree {
 
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
-		boolean hasManageLayoutsPermission = GroupPermissionUtil.contains(
+		boolean hasManageLayoutsPermission = _groupPermission.contains(
 			themeDisplay.getPermissionChecker(), groupId,
 			ActionKeys.MANAGE_LAYOUTS);
 		boolean mobile = BrowserSnifferUtil.isMobile(httpServletRequest);
@@ -690,6 +690,9 @@ public class LayoutsTreeImpl implements LayoutsTree {
 
 	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 	@Reference
 	private LayoutContentModelResourcePermission

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
@@ -89,7 +89,6 @@ import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
-import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.search.Indexer;
@@ -437,9 +436,10 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 
 		body = getBody(subject, body, format);
 
-		body = SanitizerUtil.sanitize(
+		body = _sanitizer.sanitize(
 			user.getCompanyId(), groupId, userId, MBMessage.class.getName(),
-			messageId, "text/" + format, Sanitizer.MODE_ALL, body,
+			messageId, "text/" + format, new String[] {Sanitizer.MODE_ALL},
+			body,
 			HashMapBuilder.<String, Object>put(
 				"discussion",
 				() -> {
@@ -2714,10 +2714,10 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 
 		body = getBody(subject, body, message.getFormat());
 
-		body = SanitizerUtil.sanitize(
+		body = _sanitizer.sanitize(
 			message.getCompanyId(), message.getGroupId(), userId,
 			MBMessage.class.getName(), messageId, "text/" + message.getFormat(),
-			Sanitizer.MODE_ALL, body,
+			new String[] {Sanitizer.MODE_ALL}, body,
 			HashMapBuilder.<String, Object>put(
 				"discussion", message.isDiscussion()
 			).build());
@@ -2950,6 +2950,9 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 
 	@Reference
 	private ResourceLocalService _resourceLocalService;
+
+	@Reference
+	private Sanitizer _sanitizer;
 
 	@Reference
 	private SubscriptionLocalService _subscriptionLocalService;

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/persistence/impl/MBMessagePersistenceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/persistence/impl/MBMessagePersistenceImpl.java
@@ -39,7 +39,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
-import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.InlineSQLHelperUtil;
@@ -21726,9 +21725,9 @@ public class MBMessagePersistenceImpl
 
 			try {
 				mbMessage.setSubject(
-					SanitizerUtil.sanitize(
+					_sanitizer.sanitize(
 						companyId, groupId, userId, MBMessage.class.getName(),
-						messageId, ContentTypes.TEXT_PLAIN, Sanitizer.MODE_ALL,
+						messageId, ContentTypes.TEXT_PLAIN, new String[]{Sanitizer.MODE_ALL},
 						mbMessage.getSubject(), null));
 			}
 			catch (SanitizerException sanitizerException) {
@@ -23029,5 +23028,8 @@ public class MBMessagePersistenceImpl
 
 	@Reference
 	private MBMessageModelArgumentsResolver _mbMessageModelArgumentsResolver;
+
+	@Reference
+	private Sanitizer _sanitizer;
 
 }

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/persistence/impl/MBThreadPersistenceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/persistence/impl/MBThreadPersistenceImpl.java
@@ -39,7 +39,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
-import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.InlineSQLHelperUtil;
@@ -13536,9 +13535,9 @@ public class MBThreadPersistenceImpl
 
 			try {
 				mbThread.setTitle(
-					SanitizerUtil.sanitize(
+					_sanitizer.sanitize(
 						companyId, groupId, userId, MBThread.class.getName(),
-						threadId, ContentTypes.TEXT_PLAIN, Sanitizer.MODE_ALL,
+						threadId, ContentTypes.TEXT_PLAIN, new String[]{Sanitizer.MODE_ALL},
 						mbThread.getTitle(), null));
 			}
 			catch (SanitizerException sanitizerException) {
@@ -14477,5 +14476,8 @@ public class MBThreadPersistenceImpl
 
 	@Reference
 	private MBThreadModelArgumentsResolver _mbThreadModelArgumentsResolver;
+
+	@Reference
+	private Sanitizer _sanitizer;
 
 }

--- a/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/persistence/impl/PLOEntryPersistenceImpl.java
+++ b/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/persistence/impl/PLOEntryPersistenceImpl.java
@@ -29,7 +29,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
-import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -2316,9 +2315,9 @@ public class PLOEntryPersistenceImpl
 
 			try {
 				ploEntry.setValue(
-					SanitizerUtil.sanitize(
+					_sanitizer.sanitize(
 						companyId, groupId, userId, PLOEntry.class.getName(),
-						ploEntryId, ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL,
+						ploEntryId, ContentTypes.TEXT_HTML, new String[]{Sanitizer.MODE_ALL},
 						ploEntry.getValue(), null));
 			}
 			catch (SanitizerException sanitizerException) {
@@ -2795,5 +2794,8 @@ public class PLOEntryPersistenceImpl
 
 	@Reference
 	private PLOEntryModelArgumentsResolver _ploEntryModelArgumentsResolver;
+
+	@Reference
+	private Sanitizer _sanitizer;
 
 }

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/configuration/icon/ConfigurationTemplatesPortletConfigurationIcon.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/configuration/icon/ConfigurationTemplatesPortletConfigurationIcon.java
@@ -28,7 +28,7 @@ import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigura
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -41,6 +41,7 @@ import javax.portlet.PortletResponse;
 import javax.portlet.WindowState;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Eudaldo Alonso
@@ -134,7 +135,7 @@ public class ConfigurationTemplatesPortletConfigurationIcon
 			themeDisplay.getPermissionChecker();
 
 		try {
-			if (!GroupPermissionUtil.contains(
+			if (!_groupPermission.contains(
 					permissionChecker, themeDisplay.getScopeGroupId(),
 					ActionKeys.MANAGE_ARCHIVED_SETUPS)) {
 
@@ -183,5 +184,8 @@ public class ConfigurationTemplatesPortletConfigurationIcon
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ConfigurationTemplatesPortletConfigurationIcon.class);
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 }

--- a/modules/apps/product-navigation/product-navigation-simulation-device/src/main/java/com/liferay/product/navigation/simulation/device/internal/application/list/DevicePreviewPanelApp.java
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/src/main/java/com/liferay/product/navigation/simulation/device/internal/application/list/DevicePreviewPanelApp.java
@@ -22,7 +22,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.product.navigation.simulation.constants.ProductNavigationSimulationConstants;
 import com.liferay.product.navigation.simulation.constants.ProductNavigationSimulationPortletKeys;
@@ -102,8 +102,11 @@ public class DevicePreviewPanelApp extends BaseJSPPanelApp {
 			PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
-		return GroupPermissionUtil.contains(
+		return _groupPermission.contains(
 			permissionChecker, group, ActionKeys.PREVIEW_IN_DEVICE);
 	}
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 }

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/application/list/SiteAdministrationPanelCategory.java
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/application/list/SiteAdministrationPanelCategory.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.product.navigation.site.administration.internal.constants.SiteAdministrationWebKeys;
 import com.liferay.site.util.GroupURLProvider;
 import com.liferay.site.util.RecentGroupManager;
@@ -112,7 +112,7 @@ public class SiteAdministrationPanelCategory extends BaseJSPPanelCategory {
 			return false;
 		}
 
-		if (GroupPermissionUtil.contains(
+		if (_groupPermission.contains(
 				permissionChecker, group,
 				ActionKeys.VIEW_SITE_ADMINISTRATION)) {
 
@@ -130,6 +130,9 @@ public class SiteAdministrationPanelCategory extends BaseJSPPanelCategory {
 	public void setServletContext(ServletContext servletContext) {
 		super.setServletContext(servletContext);
 	}
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 	@Reference
 	private GroupURLProvider _groupURLProvider;

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/persistence/impl/RedirectEntryPersistenceImpl.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/persistence/impl/RedirectEntryPersistenceImpl.java
@@ -30,7 +30,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
-import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.InlineSQLHelperUtil;
@@ -3919,17 +3918,17 @@ public class RedirectEntryPersistenceImpl
 
 			try {
 				redirectEntry.setDestinationURL(
-					SanitizerUtil.sanitize(
+					_sanitizer.sanitize(
 						companyId, groupId, userId,
 						RedirectEntry.class.getName(), redirectEntryId,
-						ContentTypes.TEXT_PLAIN, Sanitizer.MODE_ALL,
+						ContentTypes.TEXT_PLAIN, new String[]{Sanitizer.MODE_ALL},
 						redirectEntry.getDestinationURL(), null));
 
 				redirectEntry.setSourceURL(
-					SanitizerUtil.sanitize(
+					_sanitizer.sanitize(
 						companyId, groupId, userId,
 						RedirectEntry.class.getName(), redirectEntryId,
-						ContentTypes.TEXT_PLAIN, Sanitizer.MODE_ALL,
+						ContentTypes.TEXT_PLAIN, new String[]{Sanitizer.MODE_ALL},
 						redirectEntry.getSourceURL(), null));
 			}
 			catch (SanitizerException sanitizerException) {
@@ -4454,5 +4453,8 @@ public class RedirectEntryPersistenceImpl
 	@Reference
 	private RedirectEntryModelArgumentsResolver
 		_redirectEntryModelArgumentsResolver;
+
+	@Reference
+	private Sanitizer _sanitizer;
 
 }

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/persistence/impl/RedirectNotFoundEntryPersistenceImpl.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/service/persistence/impl/RedirectNotFoundEntryPersistenceImpl.java
@@ -29,7 +29,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
-import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -1153,11 +1152,11 @@ public class RedirectNotFoundEntryPersistenceImpl
 
 			try {
 				redirectNotFoundEntry.setUrl(
-					SanitizerUtil.sanitize(
+					_sanitizer.sanitize(
 						companyId, groupId, userId,
 						RedirectNotFoundEntry.class.getName(),
 						redirectNotFoundEntryId, ContentTypes.TEXT_PLAIN,
-						Sanitizer.MODE_ALL, redirectNotFoundEntry.getUrl(),
+						new String[]{Sanitizer.MODE_ALL}, redirectNotFoundEntry.getUrl(),
 						null));
 			}
 			catch (SanitizerException sanitizerException) {
@@ -1593,5 +1592,8 @@ public class RedirectNotFoundEntryPersistenceImpl
 	@Reference
 	private RedirectNotFoundEntryModelArgumentsResolver
 		_redirectNotFoundEntryModelArgumentsResolver;
+
+	@Reference
+	private Sanitizer _sanitizer;
 
 }

--- a/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/persistence/impl/RemoteAppEntryPersistenceImpl.java
+++ b/modules/apps/remote-app/remote-app-service/src/main/java/com/liferay/remote/app/service/persistence/impl/RemoteAppEntryPersistenceImpl.java
@@ -30,7 +30,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
-import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.InlineSQLHelperUtil;
@@ -2661,10 +2660,10 @@ public class RemoteAppEntryPersistenceImpl
 
 			try {
 				remoteAppEntry.setDescription(
-					SanitizerUtil.sanitize(
+					_sanitizer.sanitize(
 						companyId, groupId, userId,
 						RemoteAppEntry.class.getName(), remoteAppEntryId,
-						ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL,
+						ContentTypes.TEXT_HTML, new String[]{Sanitizer.MODE_ALL},
 						remoteAppEntry.getDescription(), null));
 			}
 			catch (SanitizerException sanitizerException) {
@@ -3142,5 +3141,8 @@ public class RemoteAppEntryPersistenceImpl
 	@Reference
 	private RemoteAppEntryModelArgumentsResolver
 		_remoteAppEntryModelArgumentsResolver;
+
+	@Reference
+	private Sanitizer _sanitizer;
 
 }

--- a/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/portlet/SiteSettingsControlPanelEntry.java
+++ b/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/portlet/SiteSettingsControlPanelEntry.java
@@ -21,9 +21,10 @@ import com.liferay.portal.kernel.portlet.BaseControlPanelEntry;
 import com.liferay.portal.kernel.portlet.ControlPanelEntry;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Eric Min
@@ -42,7 +43,7 @@ public class SiteSettingsControlPanelEntry extends BaseControlPanelEntry {
 		throws Exception {
 
 		if (group.isUser() || group.isLayoutSetPrototype() ||
-			!GroupPermissionUtil.contains(
+			!_groupPermission.contains(
 				permissionChecker, group, ActionKeys.UPDATE)) {
 
 			return true;
@@ -51,5 +52,8 @@ public class SiteSettingsControlPanelEntry extends BaseControlPanelEntry {
 		return super.hasAccessPermissionDenied(
 			permissionChecker, group, portlet);
 	}
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 }

--- a/modules/apps/site/site-api/src/main/java/com/liferay/site/util/GroupSearchProvider.java
+++ b/modules/apps/site/site-api/src/main/java/com/liferay/site/util/GroupSearchProvider.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.GroupService;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -183,7 +183,7 @@ public class GroupSearchProvider {
 				themeDisplay.getPermissionChecker();
 
 			if (!permissionChecker.isCompanyAdmin() &&
-				!GroupPermissionUtil.contains(
+				!_groupPermission.contains(
 					permissionChecker, ActionKeys.VIEW)) {
 
 				User user = themeDisplay.getUser();
@@ -224,7 +224,7 @@ public class GroupSearchProvider {
 			themeDisplay.getPermissionChecker();
 
 		if (permissionChecker.isCompanyAdmin() ||
-			GroupPermissionUtil.contains(permissionChecker, ActionKeys.VIEW)) {
+			_groupPermission.contains(permissionChecker, ActionKeys.VIEW)) {
 
 			return false;
 		}
@@ -259,6 +259,10 @@ public class GroupSearchProvider {
 
 	private long[] _classNameIds;
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private GroupPermission _groupPermission;
+
 	private GroupService _groupService;
 
 }

--- a/modules/apps/site/site-api/src/main/java/com/liferay/site/util/GroupURLProvider.java
+++ b/modules/apps/site/site-api/src/main/java/com/liferay/site/util/GroupURLProvider.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Http;
@@ -134,7 +134,7 @@ public class GroupURLProvider {
 
 		if (includeStagingGroup && group.hasStagingGroup()) {
 			try {
-				if (GroupPermissionUtil.contains(
+				if (_groupPermission.contains(
 						themeDisplay.getPermissionChecker(), group,
 						ActionKeys.VIEW_STAGING)) {
 
@@ -205,6 +205,9 @@ public class GroupURLProvider {
 		policyOption = ReferencePolicyOption.GREEDY
 	)
 	private volatile DepotEntryLocalService _depotEntryLocalService;
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 	@Reference
 	private Http _http;

--- a/modules/apps/site/site-api/src/main/java/com/liferay/site/util/RecentGroupManager.java
+++ b/modules/apps/site/site-api/src/main/java/com/liferay/site/util/RecentGroupManager.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
@@ -152,7 +152,7 @@ public class RecentGroupManager {
 		for (long groupId : groupIds) {
 			Group group = _groupLocalService.fetchGroup(groupId);
 
-			if (!GroupPermissionUtil.contains(
+			if (!_groupPermission.contains(
 					permissionChecker, group.getGroupId(), ActionKeys.VIEW) ||
 				!_groupLocalService.isLiveGroupActive(group)) {
 
@@ -232,6 +232,9 @@ public class RecentGroupManager {
 		RecentGroupManager.class);
 
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 	@Reference
 	private GroupURLProvider _groupURLProvider;

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/portlet/SiteMembershipsControlPanelEntry.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/portlet/SiteMembershipsControlPanelEntry.java
@@ -20,10 +20,11 @@ import com.liferay.portal.kernel.portlet.BaseControlPanelEntry;
 import com.liferay.portal.kernel.portlet.ControlPanelEntry;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.site.memberships.constants.SiteMembershipsPortletKeys;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Raymond Augé
@@ -56,7 +57,7 @@ public class SiteMembershipsControlPanelEntry extends BaseControlPanelEntry {
 			PermissionChecker permissionChecker, Group group, Portlet portlet)
 		throws Exception {
 
-		if (GroupPermissionUtil.contains(
+		if (_groupPermission.contains(
 				permissionChecker, group, ActionKeys.ASSIGN_MEMBERS)) {
 
 			return true;
@@ -65,5 +66,8 @@ public class SiteMembershipsControlPanelEntry extends BaseControlPanelEntry {
 		return super.hasPermissionImplicitlyGranted(
 			permissionChecker, group, portlet);
 	}
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 }

--- a/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/portlet/SiteTeamsControlPanelEntry.java
+++ b/modules/apps/site/site-teams-web/src/main/java/com/liferay/site/teams/web/internal/portlet/SiteTeamsControlPanelEntry.java
@@ -20,10 +20,11 @@ import com.liferay.portal.kernel.portlet.BaseControlPanelEntry;
 import com.liferay.portal.kernel.portlet.ControlPanelEntry;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.site.teams.web.internal.constants.SiteTeamsPortletKeys;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Jorge Ferrer
@@ -55,7 +56,7 @@ public class SiteTeamsControlPanelEntry extends BaseControlPanelEntry {
 			PermissionChecker permissionChecker, Group group, Portlet portlet)
 		throws Exception {
 
-		if (GroupPermissionUtil.contains(
+		if (_groupPermission.contains(
 				permissionChecker, group, ActionKeys.MANAGE_TEAMS)) {
 
 			return true;
@@ -64,5 +65,8 @@ public class SiteTeamsControlPanelEntry extends BaseControlPanelEntry {
 		return super.hasPermissionImplicitlyGranted(
 			permissionChecker, group, portlet);
 	}
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 }

--- a/modules/apps/staging/staging-configuration-web/src/main/java/com/liferay/staging/configuration/web/internal/portlet/configuration/icon/StagingPortletConfigurationIcon.java
+++ b/modules/apps/staging/staging-configuration-web/src/main/java/com/liferay/staging/configuration/web/internal/portlet/configuration/icon/StagingPortletConfigurationIcon.java
@@ -27,7 +27,7 @@ import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigura
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.PortletLocalService;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HtmlUtil;
@@ -152,7 +152,7 @@ public class StagingPortletConfigurationIcon
 		}
 
 		try {
-			return GroupPermissionUtil.contains(
+			return _groupPermission.contains(
 				themeDisplay.getPermissionChecker(),
 				themeDisplay.getScopeGroup(), ActionKeys.PUBLISH_PORTLET_INFO);
 		}
@@ -175,6 +175,9 @@ public class StagingPortletConfigurationIcon
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		StagingPortletConfigurationIcon.class);
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 	@Reference
 	private PortletLocalService _portletLocalService;

--- a/modules/apps/staging/staging-processes-web/src/main/java/com/liferay/staging/processes/web/internal/portlet/StagingProcessesControlPanelEntry.java
+++ b/modules/apps/staging/staging-processes-web/src/main/java/com/liferay/staging/processes/web/internal/portlet/StagingProcessesControlPanelEntry.java
@@ -21,11 +21,12 @@ import com.liferay.portal.kernel.portlet.BaseControlPanelEntry;
 import com.liferay.portal.kernel.portlet.ControlPanelEntry;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.staging.constants.StagingProcessesPortletKeys;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Julio Camarero
@@ -55,15 +56,15 @@ public class StagingProcessesControlPanelEntry extends BaseControlPanelEntry {
 		}
 
 		if (!group.isStaged() && !group.hasLocalOrRemoteStagingGroup() &&
-			(!GroupPermissionUtil.contains(
+			(!_groupPermission.contains(
 				permissionChecker, group, ActionKeys.MANAGE_STAGING) ||
-			 !GroupPermissionUtil.contains(
+			 !_groupPermission.contains(
 				 permissionChecker, group, ActionKeys.VIEW_STAGING))) {
 
 			return true;
 		}
 
-		if (!GroupPermissionUtil.contains(
+		if (!_groupPermission.contains(
 				permissionChecker, group, ActionKeys.VIEW_STAGING)) {
 
 			return true;
@@ -78,7 +79,7 @@ public class StagingProcessesControlPanelEntry extends BaseControlPanelEntry {
 			PermissionChecker permissionChecker, Group group, Portlet portlet)
 		throws PortalException {
 
-		if (GroupPermissionUtil.contains(
+		if (_groupPermission.contains(
 				permissionChecker, group, ActionKeys.VIEW_STAGING)) {
 
 			return true;
@@ -87,5 +88,8 @@ public class StagingProcessesControlPanelEntry extends BaseControlPanelEntry {
 		return super.hasAccessPermissionExplicitlyGranted(
 			permissionChecker, group, portlet);
 	}
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 }

--- a/modules/apps/staging/staging-processes-web/src/main/java/com/liferay/staging/processes/web/internal/portlet/configuration/icon/PublishTemplatesConfigurationIcon.java
+++ b/modules/apps/staging/staging-processes-web/src/main/java/com/liferay/staging/processes/web/internal/portlet/configuration/icon/PublishTemplatesConfigurationIcon.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
@@ -92,7 +92,7 @@ public class PublishTemplatesConfigurationIcon
 		Group scopeGroup = themeDisplay.getScopeGroup();
 
 		try {
-			if (!GroupPermissionUtil.contains(
+			if (!_groupPermission.contains(
 					themeDisplay.getPermissionChecker(), scopeGroup,
 					ActionKeys.PUBLISH_STAGING)) {
 
@@ -137,6 +137,9 @@ public class PublishTemplatesConfigurationIcon
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		PublishTemplatesConfigurationIcon.class);
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/staging/staging-processes-web/src/main/java/com/liferay/staging/processes/web/internal/portlet/configuration/icon/StagingConfigurationPortletConfigurationIcon.java
+++ b/modules/apps/staging/staging-processes-web/src/main/java/com/liferay/staging/processes/web/internal/portlet/configuration/icon/StagingConfigurationPortletConfigurationIcon.java
@@ -25,7 +25,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -115,7 +115,7 @@ public class StagingConfigurationPortletConfigurationIcon
 		Group liveGroup = _staging.getLiveGroup(group.getGroupId());
 
 		try {
-			return GroupPermissionUtil.contains(
+			return _groupPermission.contains(
 				themeDisplay.getPermissionChecker(), liveGroup,
 				ActionKeys.MANAGE_STAGING);
 		}
@@ -138,6 +138,9 @@ public class StagingConfigurationPortletConfigurationIcon
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		StagingConfigurationPortletConfigurationIcon.class);
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/java/com/liferay/user/groups/admin/web/internal/portlet/configuration/icon/DashboardPagesPortletConfigurationIcon.java
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/java/com/liferay/user/groups/admin/web/internal/portlet/configuration/icon/DashboardPagesPortletConfigurationIcon.java
@@ -23,7 +23,7 @@ import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.user.groups.admin.constants.UserGroupsAdminPortletKeys;
@@ -33,6 +33,7 @@ import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Pei-Jung Lan
@@ -95,7 +96,7 @@ public class DashboardPagesPortletConfigurationIcon
 
 			Group group = userGroup.getGroup();
 
-			if (GroupPermissionUtil.contains(
+			if (_groupPermission.contains(
 					themeDisplay.getPermissionChecker(), group,
 					ActionKeys.VIEW) &&
 				(group.getPrivateLayoutsPageCount() > 0)) {
@@ -116,5 +117,8 @@ public class DashboardPagesPortletConfigurationIcon
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DashboardPagesPortletConfigurationIcon.class);
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 }

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/java/com/liferay/user/groups/admin/web/internal/portlet/configuration/icon/ManagePagesPortletConfigurationIcon.java
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/java/com/liferay/user/groups/admin/web/internal/portlet/configuration/icon/ManagePagesPortletConfigurationIcon.java
@@ -26,7 +26,7 @@ import com.liferay.portal.kernel.portlet.PortletProviderUtil;
 import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -97,7 +97,7 @@ public class ManagePagesPortletConfigurationIcon
 
 			UserGroup userGroup = ActionUtil.getUserGroup(portletRequest);
 
-			return GroupPermissionUtil.contains(
+			return _groupPermission.contains(
 				themeDisplay.getPermissionChecker(), userGroup.getGroup(),
 				ActionKeys.PERMISSIONS);
 		}
@@ -112,6 +112,9 @@ public class ManagePagesPortletConfigurationIcon
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ManagePagesPortletConfigurationIcon.class);
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/java/com/liferay/user/groups/admin/web/internal/portlet/configuration/icon/ProfilePagesPortletConfigurationIcon.java
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/java/com/liferay/user/groups/admin/web/internal/portlet/configuration/icon/ProfilePagesPortletConfigurationIcon.java
@@ -23,7 +23,7 @@ import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.user.groups.admin.constants.UserGroupsAdminPortletKeys;
@@ -33,6 +33,7 @@ import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Pei-Jung Lan
@@ -95,7 +96,7 @@ public class ProfilePagesPortletConfigurationIcon
 
 			Group group = userGroup.getGroup();
 
-			if (GroupPermissionUtil.contains(
+			if (_groupPermission.contains(
 					themeDisplay.getPermissionChecker(), group,
 					ActionKeys.VIEW) &&
 				(group.getPublicLayoutsPageCount() > 0)) {
@@ -116,5 +117,8 @@ public class ProfilePagesPortletConfigurationIcon
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ProfilePagesPortletConfigurationIcon.class);
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 }

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/java/com/liferay/user/groups/admin/web/internal/portlet/configuration/icon/UserGroupPagesPermissionsPortletConfigurationIcon.java
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/java/com/liferay/user/groups/admin/web/internal/portlet/configuration/icon/UserGroupPagesPermissionsPortletConfigurationIcon.java
@@ -24,7 +24,7 @@ import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -38,6 +38,7 @@ import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Pei-Jung Lan
@@ -105,7 +106,7 @@ public class UserGroupPagesPermissionsPortletConfigurationIcon
 
 			UserGroup userGroup = ActionUtil.getUserGroup(portletRequest);
 
-			return GroupPermissionUtil.contains(
+			return _groupPermission.contains(
 				themeDisplay.getPermissionChecker(), userGroup.getGroup(),
 				ActionKeys.PERMISSIONS);
 		}
@@ -125,5 +126,8 @@ public class UserGroupPagesPermissionsPortletConfigurationIcon
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		UserGroupPagesPermissionsPortletConfigurationIcon.class);
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 }

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/frontend/taglib/servlet/taglib/OrganizationScreenNavigationRegistrar.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/frontend/taglib/servlet/taglib/OrganizationScreenNavigationRegistrar.java
@@ -20,7 +20,7 @@ import com.liferay.frontend.taglib.servlet.taglib.util.JSPRenderer;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.OrganizationService;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.users.admin.constants.UserScreenNavigationEntryConstants;
 
@@ -89,7 +89,7 @@ public class OrganizationScreenNavigationRegistrar {
 					}
 
 					try {
-						if (!GroupPermissionUtil.contains(
+						if (!_groupPermission.contains(
 								PermissionThreadLocal.getPermissionChecker(),
 								organization.getGroup(), ActionKeys.UPDATE)) {
 
@@ -197,6 +197,9 @@ public class OrganizationScreenNavigationRegistrar {
 	}
 
 	private BundleContext _bundleContext;
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 	@Reference
 	private JSPRenderer _jspRenderer;

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/EditProfileAndDashboardMVCActionCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/EditProfileAndDashboardMVCActionCommand.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -66,7 +66,7 @@ public class EditProfileAndDashboardMVCActionCommand
 		PermissionChecker permissionChecker =
 			themeDisplay.getPermissionChecker();
 
-		if (GroupPermissionUtil.contains(
+		if (_groupPermission.contains(
 				permissionChecker, group.getGroupId(), ActionKeys.UPDATE) &&
 			PortalPermissionUtil.contains(
 				permissionChecker, ActionKeys.UNLINK_LAYOUT_SET_PROTOTYPE)) {
@@ -98,6 +98,9 @@ public class EditProfileAndDashboardMVCActionCommand
 			}
 		}
 	}
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/UpdateOrganizationOrganizationSiteMVCActionCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/UpdateOrganizationOrganizationSiteMVCActionCommand.java
@@ -30,7 +30,7 @@ import com.liferay.portal.kernel.service.OrgLaborService;
 import com.liferay.portal.kernel.service.OrganizationService;
 import com.liferay.portal.kernel.service.PhoneService;
 import com.liferay.portal.kernel.service.WebsiteService;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -117,7 +117,7 @@ public class UpdateOrganizationOrganizationSiteMVCActionCommand
 
 		Group organizationGroup = organization.getGroup();
 
-		if (GroupPermissionUtil.contains(
+		if (_groupPermission.contains(
 				themeDisplay.getPermissionChecker(), organizationGroup,
 				ActionKeys.UPDATE)) {
 
@@ -142,6 +142,9 @@ public class UpdateOrganizationOrganizationSiteMVCActionCommand
 
 	@Reference
 	private EmailAddressService _emailAddressService;
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 	@Reference
 	private OrganizationService _organizationService;

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/configuration/icon/ManageSitePortletConfigurationIcon.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/configuration/icon/ManageSitePortletConfigurationIcon.java
@@ -27,7 +27,7 @@ import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigura
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
@@ -114,7 +114,7 @@ public class ManageSitePortletConfigurationIcon
 			Group organizationGroup = organization.getGroup();
 
 			if (organizationGroup.isSite() &&
-				(GroupPermissionUtil.contains(
+				(_groupPermission.contains(
 					permissionChecker, organizationGroup,
 					ActionKeys.MANAGE_STAGING) ||
 				 OrganizationPermissionUtil.contains(
@@ -134,6 +134,9 @@ public class ManageSitePortletConfigurationIcon
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ManageSitePortletConfigurationIcon.class);
+
+	@Reference
+	private GroupPermission _groupPermission;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -57,7 +57,7 @@ import com.liferay.portal.kernel.portlet.PortletURLFactory;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
-import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
+import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.service.ResourceLocalService;
@@ -263,9 +263,10 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 		_validateExternalReferenceCode(
 			externalReferenceCode, node.getGroupId());
 
-		content = SanitizerUtil.sanitize(
+		content = _sanitizer.sanitize(
 			user.getCompanyId(), node.getGroupId(), userId,
-			WikiPage.class.getName(), pageId, "text/" + format, content);
+			WikiPage.class.getName(), pageId, "text/" + format,
+			new String[] {Sanitizer.MODE_ALL}, content, null);
 
 		title = StringUtil.replace(
 			title, CharPool.NO_BREAK_SPACE, CharPool.SPACE);
@@ -3290,9 +3291,10 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 			pageId = oldPage.getPageId();
 		}
 
-		content = SanitizerUtil.sanitize(
+		content = _sanitizer.sanitize(
 			user.getCompanyId(), oldPage.getGroupId(), userId,
-			WikiPage.class.getName(), pageId, "text/" + format, content);
+			WikiPage.class.getName(), pageId, "text/" + format,
+			new String[] {Sanitizer.MODE_ALL}, content, null);
 
 		long nodeId = oldPage.getNodeId();
 
@@ -3485,6 +3487,9 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 
 	@Reference
 	private ResourceLocalService _resourceLocalService;
+
+	@Reference
+	private Sanitizer _sanitizer;
 
 	private ServiceTrackerMap<String, WikiPageRenameContentProcessor>
 		_serviceTrackerMap;

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/persistence/impl/WikiPagePersistenceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/persistence/impl/WikiPagePersistenceImpl.java
@@ -30,7 +30,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
-import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.InlineSQLHelperUtil;
@@ -88,7 +87,8 @@ import org.osgi.service.component.annotations.Reference;
  * @generated
  */
 @Component(service = {WikiPagePersistence.class, BasePersistence.class})
-public class WikiPagePersistenceImpl
+public class
+WikiPagePersistenceImpl
 	extends BasePersistenceImpl<WikiPage> implements WikiPagePersistence {
 
 	/*
@@ -23806,9 +23806,9 @@ public class WikiPagePersistenceImpl
 
 			try {
 				wikiPage.setTitle(
-					SanitizerUtil.sanitize(
+					_sanitizer.sanitize(
 						companyId, groupId, userId, WikiPage.class.getName(),
-						pageId, ContentTypes.TEXT_PLAIN, Sanitizer.MODE_ALL,
+						pageId, ContentTypes.TEXT_PLAIN, new String[]{Sanitizer.MODE_ALL},
 						wikiPage.getTitle(), null));
 			}
 			catch (SanitizerException sanitizerException) {
@@ -25014,6 +25014,9 @@ public class WikiPagePersistenceImpl
 	protected FinderCache getFinderCache() {
 		return finderCache;
 	}
+
+	@Reference
+	private Sanitizer _sanitizer;
 
 	@Reference
 	private WikiPageModelArgumentsResolver _wikiPageModelArgumentsResolver;

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/persistence/impl/SXPBlueprintPersistenceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/persistence/impl/SXPBlueprintPersistenceImpl.java
@@ -30,7 +30,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
-import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.InlineSQLHelperUtil;
@@ -3225,10 +3224,10 @@ public class SXPBlueprintPersistenceImpl
 
 			try {
 				sxpBlueprint.setTitle(
-					SanitizerUtil.sanitize(
+					_sanitizer.sanitize(
 						companyId, groupId, userId,
 						SXPBlueprint.class.getName(), sxpBlueprintId,
-						ContentTypes.TEXT_PLAIN, Sanitizer.MODE_ALL,
+						ContentTypes.TEXT_PLAIN, new String[]{Sanitizer.MODE_ALL},
 						sxpBlueprint.getTitle(), null));
 			}
 			catch (SanitizerException sanitizerException) {
@@ -3707,6 +3706,9 @@ public class SXPBlueprintPersistenceImpl
 	protected FinderCache getFinderCache() {
 		return finderCache;
 	}
+
+	@Reference
+	private Sanitizer _sanitizer;
 
 	@Reference
 	private SXPBlueprintModelArgumentsResolver

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/persistence/impl/SXPElementPersistenceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/service/persistence/impl/SXPElementPersistenceImpl.java
@@ -30,7 +30,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerException;
-import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.InlineSQLHelperUtil;
@@ -6048,10 +6047,10 @@ public class SXPElementPersistenceImpl
 
 			try {
 				sxpElement.setTitle(
-					SanitizerUtil.sanitize(
+					_sanitizer.sanitize(
 						companyId, groupId, userId, SXPElement.class.getName(),
 						sxpElementId, ContentTypes.TEXT_PLAIN,
-						Sanitizer.MODE_ALL, sxpElement.getTitle(), null));
+						new String[]{Sanitizer.MODE_ALL}, sxpElement.getTitle(), null));
 			}
 			catch (SanitizerException sanitizerException) {
 				throw new SystemException(sanitizerException);
@@ -6591,6 +6590,9 @@ public class SXPElementPersistenceImpl
 	protected FinderCache getFinderCache() {
 		return finderCache;
 	}
+
+	@Reference
+	private Sanitizer _sanitizer;
 
 	@Reference
 	private SXPElementModelArgumentsResolver _sxpElementModelArgumentsResolver;

--- a/portal-impl/src/META-INF/util-spring.xml
+++ b/portal-impl/src/META-INF/util-spring.xml
@@ -150,8 +150,9 @@
 	<bean class="com.liferay.portal.kernel.service.permission.CommonPermissionUtil" id="com.liferay.portal.kernel.service.permission.CommonPermissionUtil">
 		<property name="commonPermission" ref="com.liferay.portal.kernel.service.permission.CommonPermission" />
 	</bean>
+	<bean class="com.liferay.portal.service.permission.GroupPermissionImpl" id="com.liferay.portal.kernel.service.permission.GroupPermission" />
 	<bean class="com.liferay.portal.kernel.service.permission.GroupPermissionUtil" id="com.liferay.portal.kernel.service.permission.GroupPermissionUtil">
-		<property name="groupPermission" ref="com.liferay.portal.service.permission.GroupPermissionImpl" />
+		<property name="groupPermission" ref="com.liferay.portal.kernel.service.permission.GroupPermission" />
 	</bean>
 	<bean class="com.liferay.portal.service.permission.OrganizationPermissionImpl" id="com.liferay.portal.kernel.service.permission.OrganizationPermission" />
 	<bean class="com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil" id="com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil">
@@ -350,7 +351,6 @@
 	<bean class="com.liferay.portal.language.LanguageImpl" id="com.liferay.portal.language.LanguageImpl" />
 	<bean class="com.liferay.portal.language.LanguageResources" id="com.liferay.portal.language.LanguageResources" />
 	<bean class="com.liferay.portal.model.adapter.builder.ServiceTrackerMapModelAdapterBuilderLocator" id="com.liferay.portal.model.adapter.builder.ServiceTrackerMapModelAdapterBuilderLocator" />
-	<bean class="com.liferay.portal.service.permission.GroupPermissionImpl" id="com.liferay.portal.service.permission.GroupPermissionImpl" />
 	<bean class="com.liferay.portal.service.permission.UserPermissionImpl" id="com.liferay.portal.service.permission.UserPermissionImpl" />
 	<bean class="com.liferay.portal.servlet.BrowserSnifferImpl" id="com.liferay.portal.servlet.BrowserSnifferImpl" />
 	<bean class="com.liferay.portal.servlet.filters.util.BrowserIdCacheFileNameContributor" id="com.liferay.portal.servlet.filters.util.BrowserIdCacheFileNameContributor" />

--- a/portal-impl/src/META-INF/util-spring.xml
+++ b/portal-impl/src/META-INF/util-spring.xml
@@ -145,7 +145,6 @@
 	<bean class="com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIconMenu" id="com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIconMenu" />
 	<bean class="com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIconTracker" id="com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIconTracker" />
 	<bean class="com.liferay.portal.kernel.portlet.toolbar.PortletToolbar" id="com.liferay.portal.kernel.portlet.toolbar.PortletToolbar" />
-	<bean class="com.liferay.portal.kernel.sanitizer.SanitizerUtil" id="com.liferay.portal.kernel.sanitizer.SanitizerUtil" />
 	<bean class="com.liferay.portal.service.permission.CommonPermissionImpl" id="com.liferay.portal.kernel.service.permission.CommonPermission" />
 	<bean class="com.liferay.portal.kernel.service.permission.CommonPermissionUtil" id="com.liferay.portal.kernel.service.permission.CommonPermissionUtil">
 		<property name="commonPermission" ref="com.liferay.portal.kernel.service.permission.CommonPermission" />

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -513,6 +513,7 @@
         com.liferay.portal.kernel.dao.jdbc.CurrentConnectionUtil,\
         com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil,\
         com.liferay.portal.kernel.image.GhostscriptUtil,\
+        com.liferay.portal.kernel.service.permission.CommonPermissionUtil,\
         com.liferay.portal.kernel.util.HttpUtil,\
         com.liferay.portal.kernel.util.PortalUtil
 

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -514,6 +514,7 @@
         com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil,\
         com.liferay.portal.kernel.image.GhostscriptUtil,\
         com.liferay.portal.kernel.service.permission.CommonPermissionUtil,\
+        com.liferay.portal.kernel.service.permission.GroupPermissionUtil,\
         com.liferay.portal.kernel.util.HttpUtil,\
         com.liferay.portal.kernel.util.PortalUtil
 

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -513,6 +513,7 @@
         com.liferay.portal.kernel.dao.jdbc.CurrentConnectionUtil,\
         com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil,\
         com.liferay.portal.kernel.image.GhostscriptUtil,\
+        com.liferay.portal.kernel.sanitizer.SanitizerUtil,\
         com.liferay.portal.kernel.service.permission.CommonPermissionUtil,\
         com.liferay.portal.kernel.service.permission.GroupPermissionUtil,\
         com.liferay.portal.kernel.util.HttpUtil,\


### PR DESCRIPTION
Hi Tina,

Main Task: [LPS-143403](https://issues.liferay.com/browse/LPS-143403)
Sub Task 7: [LPS-143634](https://issues.liferay.com/browse/LPS-143634)
Removes SanitizerUtil, CommonPermissionUtil, GroupPermissionUtil from modules components

Note: from sub task 6 and onwards, tasks no longer depend on previous tasks.

Thank you!