### PR TITLE
LPS-143633 Avoid using LicenseManagerUtil, RawMetadataProcessorUtil, PatcherUtil directly in modules

### DIFF
--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/instance/lifecycle/AddDefaultDocumentLibraryStructuresPortalInstanceLifecycleListener.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/instance/lifecycle/AddDefaultDocumentLibraryStructuresPortalInstanceLifecycleListener.java
@@ -15,7 +15,6 @@
 package com.liferay.document.library.internal.instance.lifecycle;
 
 import com.liferay.document.library.configuration.DLConfiguration;
-import com.liferay.document.library.kernel.util.RawMetadataProcessor;
 import com.liferay.dynamic.data.mapping.constants.DDMStructureConstants;
 import com.liferay.dynamic.data.mapping.io.DDMFormSerializer;
 import com.liferay.dynamic.data.mapping.io.DDMFormSerializerSerializeRequest;
@@ -37,7 +36,7 @@ import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener
 import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
 import com.liferay.portal.kernel.cache.PortalCache;
 import com.liferay.portal.kernel.cache.SingleVMPool;
-import com.liferay.portal.kernel.metadata.RawMetadataProcessorUtil;
+import com.liferay.portal.kernel.metadata.RawMetadataProcessor;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
@@ -145,7 +144,7 @@ public class AddDefaultDocumentLibraryStructuresPortalInstanceLifecycleListener
 		Locale locale = _portal.getSiteDefaultLocale(group.getGroupId());
 
 		Map<String, Set<String>> fieldNames =
-			RawMetadataProcessorUtil.getFieldNames();
+			_rawMetadataProcessor.getFieldNames();
 
 		for (Map.Entry<String, Set<String>> entry : fieldNames.entrySet()) {
 			String name = entry.getKey();
@@ -282,6 +281,9 @@ public class AddDefaultDocumentLibraryStructuresPortalInstanceLifecycleListener
 	private Portal _portal;
 
 	private volatile PortalCache<DDMForm, String> _portalCache;
+
+	@Reference
+	private RawMetadataProcessor _rawMetadataProcessor;
 
 	@Reference
 	private SingleVMPool _singleVMPool;

--- a/modules/apps/marketplace/marketplace-store-web/src/main/java/com/liferay/marketplace/store/web/internal/portlet/MarketplaceStorePortlet.java
+++ b/modules/apps/marketplace/marketplace-store-web/src/main/java/com/liferay/marketplace/store/web/internal/portlet/MarketplaceStorePortlet.java
@@ -31,7 +31,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.patcher.PatcherUtil;
+import com.liferay.portal.kernel.patcher.Patcher;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -494,7 +494,7 @@ public class MarketplaceStorePortlet extends RemoteMVCPortlet {
 				new String[] {String.valueOf(ReleaseInfo.getBuildNumber())});
 		}
 
-		parameterMap.put("installedPatches", PatcherUtil.getInstalledPatches());
+		parameterMap.put("installedPatches", _patcher.getInstalledPatches());
 		parameterMap.put(
 			"supportsHotDeploy", new String[] {Boolean.TRUE.toString()});
 	}
@@ -564,6 +564,10 @@ public class MarketplaceStorePortlet extends RemoteMVCPortlet {
 
 	private AppLocalService _appLocalService;
 	private AppService _appService;
+
+	@Reference
+	private Patcher _patcher;
+
 	private final ReentrantLock _reentrantLock = new ReentrantLock();
 
 }

--- a/modules/apps/portal/portal-license-deployer/src/main/java/com/liferay/portal/license/deployer/internal/installer/LicenseInstaller.java
+++ b/modules/apps/portal/portal-license-deployer/src/main/java/com/liferay/portal/license/deployer/internal/installer/LicenseInstaller.java
@@ -16,7 +16,7 @@ package com.liferay.portal.license.deployer.internal.installer;
 
 import com.liferay.portal.file.install.FileInstaller;
 import com.liferay.portal.kernel.json.JSONUtil;
-import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
+import com.liferay.portal.kernel.license.util.LicenseManager;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
@@ -72,7 +72,7 @@ public class LicenseInstaller implements FileInstaller {
 
 	@Override
 	public URL transformURL(File file) throws Exception {
-		LicenseManagerUtil.registerLicense(
+		_licenseManager.registerLicense(
 			JSONUtil.put("licenseXML", FileUtil.read(file)));
 
 		return null;
@@ -84,6 +84,9 @@ public class LicenseInstaller implements FileInstaller {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		LicenseInstaller.class);
+
+	@Reference
+	private LicenseManager _licenseManager;
 
 	@Reference(target = ModuleServiceLifecycle.LICENSE_INSTALL)
 	private ModuleServiceLifecycle _moduleServiceLifecycle;

--- a/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/DefaultLPKGDeployer.java
+++ b/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/DefaultLPKGDeployer.java
@@ -23,7 +23,7 @@ import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
-import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
+import com.liferay.portal.kernel.license.util.LicenseManager;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.framework.ThrowableCollector;
@@ -398,7 +398,7 @@ public class DefaultLPKGDeployer implements LPKGDeployer {
 
 					JSONObject jsonObject = JSONUtil.put("licenseXML", content);
 
-					LicenseManagerUtil.registerLicense(jsonObject);
+					_licenseManager.registerLicense(jsonObject);
 				}
 				catch (Exception exception) {
 					if (_log.isDebugEnabled()) {
@@ -778,6 +778,10 @@ public class DefaultLPKGDeployer implements LPKGDeployer {
 		DefaultLPKGDeployer.class);
 
 	private Path _deploymentDirPath;
+
+	@Reference
+	private LicenseManager _licenseManager;
+
 	private BundleTracker<List<Bundle>> _lpkgBundleTracker;
 
 	@Reference

--- a/portal-impl/src/META-INF/util-spring.xml
+++ b/portal-impl/src/META-INF/util-spring.xml
@@ -125,10 +125,9 @@
 			<bean class="com.liferay.portal.oauth.OAuthFactoryImpl" />
 		</property>
 	</bean>
+	<bean class="com.liferay.portal.patcher.PatcherImpl" id="com.liferay.portal.kernel.patcher.Patcher" />
 	<bean class="com.liferay.portal.kernel.patcher.PatcherUtil" id="com.liferay.portal.kernel.patcher.PatcherUtil">
-		<property name="patcher">
-			<bean class="com.liferay.portal.patcher.PatcherImpl" />
-		</property>
+		<property name="patcher" ref="com.liferay.portal.kernel.patcher.Patcher" />
 	</bean>
 	<bean class="com.liferay.portal.kernel.poller.comet.CometHandlerPoolUtil" id="com.liferay.portal.kernel.poller.comet.CometHandlerPoolUtil">
 		<property name="cometHandlerPool">

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -519,6 +519,7 @@
         com.liferay.portal.kernel.language.UnicodeLanguageUtil,\
         com.liferay.portal.kernel.license.util.LicenseManagerUtil,\
         com.liferay.portal.kernel.metadata.RawMetadataProcessorUtil,\
+        com.liferay.portal.kernel.patcher.PatcherUtil,\
         com.liferay.portal.kernel.util.HttpUtil,\
         com.liferay.portal.kernel.util.PortalUtil
 

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -518,6 +518,7 @@
         com.liferay.portal.kernel.image.ImageToolUtil,\
         com.liferay.portal.kernel.language.UnicodeLanguageUtil,\
         com.liferay.portal.kernel.license.util.LicenseManagerUtil,\
+        com.liferay.portal.kernel.metadata.RawMetadataProcessorUtil,\
         com.liferay.portal.kernel.util.HttpUtil,\
         com.liferay.portal.kernel.util.PortalUtil
 

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -517,6 +517,7 @@
         com.liferay.portal.kernel.image.GhostscriptUtil,\
         com.liferay.portal.kernel.image.ImageToolUtil,\
         com.liferay.portal.kernel.language.UnicodeLanguageUtil,\
+        com.liferay.portal.kernel.license.util.LicenseManagerUtil,\
         com.liferay.portal.kernel.util.HttpUtil,\
         com.liferay.portal.kernel.util.PortalUtil
 


### PR DESCRIPTION
Hi Tina,

Main Task: [LPS-143403](https://issues.liferay.com/browse/LPS-143403)
Sub Task 6: [LPS-143633](https://issues.liferay.com/browse/LPS-143633)
Removes LicenseManagerUtil, RawMetadataProcessorUtil, and PatcherUtil from modules components

From sub task 6 and onwards, tasks no longer depend on previous tasks.