### PR TITLE
LPS-151251 (Discussion) Move param methods from HttpComponentUtil to URIBuilder

### DIFF
--- a/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/field/filter/parser/ListObjectFieldFilterParserTest.java
+++ b/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/field/filter/parser/ListObjectFieldFilterParserTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.internal.field.filter.parser;
+
+import com.liferay.object.constants.ObjectViewFilterColumnConstants;
+import com.liferay.object.exception.ObjectViewFilterColumnException;
+import com.liferay.object.model.ObjectViewFilterColumn;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Feliphe Marinho
+ */
+public class ListObjectFieldFilterParserTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testValidate() throws PortalException {
+		ObjectViewFilterColumn objectViewFilterColumn = Mockito.mock(
+			ObjectViewFilterColumn.class);
+
+		Mockito.when(
+			objectViewFilterColumn.getFilterType()
+		).thenReturn(
+			ObjectViewFilterColumnConstants.FILTER_TYPE_EXCLUDES
+		);
+
+		Mockito.when(
+			objectViewFilterColumn.getJson()
+		).thenReturn(
+			"{\"includes\": [0, 1]}"
+		);
+
+		try {
+			_listObjectFieldFilterParser.validate(0L, objectViewFilterColumn);
+
+			Assert.fail();
+		}
+		catch (ObjectViewFilterColumnException
+					objectViewFilterColumnException) {
+
+			Assert.assertEquals(
+				"JSON array is null for filter type excludes",
+				objectViewFilterColumnException.getMessage());
+		}
+
+		Mockito.when(
+			objectViewFilterColumn.getObjectFieldName()
+		).thenReturn(
+			"status"
+		);
+
+		Mockito.when(
+			objectViewFilterColumn.getJson()
+		).thenReturn(
+			"{\"excludes\": [\"brazil\"]}"
+		);
+
+		try {
+			_listObjectFieldFilterParser.validate(0L, objectViewFilterColumn);
+
+			Assert.fail();
+		}
+		catch (ObjectViewFilterColumnException
+					objectViewFilterColumnException) {
+
+			Assert.assertEquals(
+				"JSON array is invalid for filter type excludes",
+				objectViewFilterColumnException.getMessage());
+		}
+
+		Mockito.when(
+			objectViewFilterColumn.getJson()
+		).thenReturn(
+			"{\"excludes\": [0, 1]}"
+		);
+
+		_listObjectFieldFilterParser.validate(0L, objectViewFilterColumn);
+	}
+
+	private final ListObjectFieldFilterParser _listObjectFieldFilterParser =
+		new ListObjectFieldFilterParser();
+
+}

--- a/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/field/filter/parser/ListObjectFieldFilterParserTest.java
+++ b/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/field/filter/parser/ListObjectFieldFilterParserTest.java
@@ -68,15 +68,15 @@ public class ListObjectFieldFilterParserTest {
 		}
 
 		Mockito.when(
-			objectViewFilterColumn.getObjectFieldName()
-		).thenReturn(
-			"status"
-		);
-
-		Mockito.when(
 			objectViewFilterColumn.getJson()
 		).thenReturn(
 			"{\"excludes\": [\"brazil\"]}"
+		);
+
+		Mockito.when(
+			objectViewFilterColumn.getObjectFieldName()
+		).thenReturn(
+			"status"
 		);
 
 		try {

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectViewLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectViewLocalServiceTest.java
@@ -16,7 +16,6 @@ package com.liferay.object.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.list.type.model.ListTypeDefinition;
-import com.liferay.list.type.model.ListTypeEntry;
 import com.liferay.list.type.service.ListTypeDefinitionLocalService;
 import com.liferay.list.type.service.ListTypeEntryLocalService;
 import com.liferay.object.constants.ObjectViewFilterColumnConstants;
@@ -364,8 +363,7 @@ public class ObjectViewLocalServiceTest {
 
 		_listTypeEntryLocalService.addListTypeEntry(
 			TestPropsValues.getUserId(),
-			listTypeDefinition.getListTypeDefinitionId(),
-			StringUtil.randomId(),
+			listTypeDefinition.getListTypeDefinitionId(), StringUtil.randomId(),
 			Collections.singletonMap(LocaleUtil.US, "Brazil"));
 
 		ObjectField objectField = ObjectFieldUtil.createObjectField(

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectViewLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectViewLocalServiceTest.java
@@ -161,12 +161,6 @@ public class ObjectViewLocalServiceTest {
 			Collections.emptyList());
 		_assertFailureAddOrUpdateObjectView(
 			false, ObjectViewFilterColumnException.class,
-			"Object field name \"name\" is not filterable", null,
-			Collections.emptyList(),
-			Arrays.asList(_createObjectViewFilterColumn(null, null, "name")),
-			Collections.emptyList());
-		_assertFailureAddOrUpdateObjectView(
-			false, ObjectViewFilterColumnException.class,
 			"Object field name \"country\" needs to have the filter type and " +
 				"JSON specified",
 			null, Collections.emptyList(),
@@ -182,6 +176,12 @@ public class ObjectViewLocalServiceTest {
 			Arrays.asList(
 				_createObjectViewFilterColumn(
 					RandomTestUtil.randomString(), null, "country")),
+			Collections.emptyList());
+		_assertFailureAddOrUpdateObjectView(
+			false, ObjectViewFilterColumnException.class,
+			"Object field name \"name\" is not filterable", null,
+			Collections.emptyList(),
+			Arrays.asList(_createObjectViewFilterColumn(null, null, "name")),
 			Collections.emptyList());
 		_assertFailureAddOrUpdateObjectView(
 			false, ObjectViewSortColumnException.class,
@@ -251,16 +251,16 @@ public class ObjectViewLocalServiceTest {
 		_assertFailureAddOrUpdateObjectView(
 			objectView.isDefaultObjectView(),
 			ObjectViewColumnFieldNameException.class,
-			"There is no object field with the name: zebra", objectView,
-			Collections.singletonList(
-				_createObjectViewColumnWithNonexistentObjectFieldName()),
+			"There is already an object view column with the object field " +
+				"name: roger",
+			objectView, _createObjectViewColumnsWithDuplicateObjectFieldName(),
 			Collections.emptyList(), Collections.emptyList());
 		_assertFailureAddOrUpdateObjectView(
 			objectView.isDefaultObjectView(),
 			ObjectViewColumnFieldNameException.class,
-			"There is already an object view column with the object field " +
-				"name: roger",
-			objectView, _createObjectViewColumnsWithDuplicateObjectFieldName(),
+			"There is no object field with the name: zebra", objectView,
+			Collections.singletonList(
+				_createObjectViewColumnWithNonexistentObjectFieldName()),
 			Collections.emptyList(), Collections.emptyList());
 		_assertFailureAddOrUpdateObjectView(
 			objectView.isDefaultObjectView(),
@@ -274,13 +274,6 @@ public class ObjectViewLocalServiceTest {
 			"Object field name \"creator\" is not filterable", objectView,
 			Collections.emptyList(),
 			Arrays.asList(_createObjectViewFilterColumn(null, null, "creator")),
-			Collections.emptyList());
-		_assertFailureAddOrUpdateObjectView(
-			objectView.isDefaultObjectView(),
-			ObjectViewFilterColumnException.class,
-			"Object field name \"name\" is not filterable", objectView,
-			Collections.emptyList(),
-			Arrays.asList(_createObjectViewFilterColumn(null, null, "name")),
 			Collections.emptyList());
 		_assertFailureAddOrUpdateObjectView(
 			objectView.isDefaultObjectView(),
@@ -301,6 +294,13 @@ public class ObjectViewLocalServiceTest {
 			Arrays.asList(
 				_createObjectViewFilterColumn(
 					RandomTestUtil.randomString(), null, "country")),
+			Collections.emptyList());
+		_assertFailureAddOrUpdateObjectView(
+			objectView.isDefaultObjectView(),
+			ObjectViewFilterColumnException.class,
+			"Object field name \"name\" is not filterable", objectView,
+			Collections.emptyList(),
+			Arrays.asList(_createObjectViewFilterColumn(null, null, "name")),
 			Collections.emptyList());
 		_assertFailureAddOrUpdateObjectView(
 			objectView.isDefaultObjectView(),
@@ -403,8 +403,9 @@ public class ObjectViewLocalServiceTest {
 	}
 
 	private void _assertFailureAddOrUpdateObjectView(
-		boolean defaultObjectView, Class<?> expectedException, String message,
-		ObjectView objectView, List<ObjectViewColumn> objectViewColumns,
+		boolean defaultObjectView, Class<?> expectedExceptionClass,
+		String message, ObjectView objectView,
+		List<ObjectViewColumn> objectViewColumns,
 		List<ObjectViewFilterColumn> objectViewFilterColumns,
 		List<ObjectViewSortColumn> objectViewSortColumns) {
 
@@ -429,7 +430,7 @@ public class ObjectViewLocalServiceTest {
 			Assert.fail();
 		}
 		catch (PortalException portalException) {
-			if (expectedException.isInstance(portalException)) {
+			if (expectedExceptionClass.isInstance(portalException)) {
 				Assert.assertEquals(message, portalException.getMessage());
 			}
 		}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectViewLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectViewLocalServiceTest.java
@@ -81,14 +81,11 @@ public class ObjectViewLocalServiceTest {
 				TestPropsValues.getUserId(),
 				Collections.singletonMap(LocaleUtil.US, "Countries"));
 
-		ListTypeEntry listTypeEntry =
-			_listTypeEntryLocalService.addListTypeEntry(
-				TestPropsValues.getUserId(),
-				listTypeDefinition.getListTypeDefinitionId(),
-				StringUtil.randomId(),
-				Collections.singletonMap(LocaleUtil.US, "Brazil"));
-
-		Assert.assertNotNull(listTypeEntry);
+		_listTypeEntryLocalService.addListTypeEntry(
+			TestPropsValues.getUserId(),
+			listTypeDefinition.getListTypeDefinitionId(),
+			StringUtil.randomId(),
+			Collections.singletonMap(LocaleUtil.US, "Brazil"));
 
 		ObjectField objectField = ObjectFieldUtil.createObjectField(
 			"Picklist", "String", "country");

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectViewLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectViewLocalServiceTest.java
@@ -264,22 +264,6 @@ public class ObjectViewLocalServiceTest {
 			Collections.emptyList(), Collections.emptyList());
 		_assertFailureAddOrUpdateObjectView(
 			objectView.isDefaultObjectView(),
-			ObjectViewSortColumnException.class,
-			"There is no object view column with the name: king", objectView,
-			Collections.singletonList(_createObjectViewColumn("Jig", "jig")),
-			Collections.emptyList(),
-			Collections.singletonList(
-				_createObjectViewSortColumn("king", "desc")));
-		_assertFailureAddOrUpdateObjectView(
-			objectView.isDefaultObjectView(),
-			ObjectViewSortColumnException.class,
-			"There is no sort order of type: zulu", objectView,
-			Collections.singletonList(_createObjectViewColumn("Love", "love")),
-			Collections.emptyList(),
-			Collections.singletonList(
-				_createObjectViewSortColumn("love", "zulu")));
-		_assertFailureAddOrUpdateObjectView(
-			objectView.isDefaultObjectView(),
 			ObjectViewFilterColumnException.class, "Object field name is null",
 			objectView, Collections.emptyList(),
 			Arrays.asList(_createObjectViewFilterColumn(null, null, null)),
@@ -318,6 +302,22 @@ public class ObjectViewLocalServiceTest {
 				_createObjectViewFilterColumn(
 					RandomTestUtil.randomString(), null, "country")),
 			Collections.emptyList());
+		_assertFailureAddOrUpdateObjectView(
+			objectView.isDefaultObjectView(),
+			ObjectViewSortColumnException.class,
+			"There is no object view column with the name: king", objectView,
+			Collections.singletonList(_createObjectViewColumn("Jig", "jig")),
+			Collections.emptyList(),
+			Collections.singletonList(
+				_createObjectViewSortColumn("king", "desc")));
+		_assertFailureAddOrUpdateObjectView(
+			objectView.isDefaultObjectView(),
+			ObjectViewSortColumnException.class,
+			"There is no sort order of type: zulu", objectView,
+			Collections.singletonList(_createObjectViewColumn("Love", "love")),
+			Collections.emptyList(),
+			Collections.singletonList(
+				_createObjectViewSortColumn("love", "zulu")));
 
 		objectView = _objectViewLocalService.updateObjectView(
 			objectView.getObjectViewId(), objectView.isDefaultObjectView(),

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectViewLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectViewLocalServiceTest.java
@@ -83,8 +83,7 @@ public class ObjectViewLocalServiceTest {
 
 		_listTypeEntryLocalService.addListTypeEntry(
 			TestPropsValues.getUserId(),
-			listTypeDefinition.getListTypeDefinitionId(),
-			StringUtil.randomId(),
+			listTypeDefinition.getListTypeDefinitionId(), StringUtil.randomId(),
 			Collections.singletonMap(LocaleUtil.US, "Brazil"));
 
 		ObjectField objectField = ObjectFieldUtil.createObjectField(
@@ -363,14 +362,11 @@ public class ObjectViewLocalServiceTest {
 				TestPropsValues.getUserId(),
 				Collections.singletonMap(LocaleUtil.US, "Countries"));
 
-		ListTypeEntry listTypeEntry =
-			_listTypeEntryLocalService.addListTypeEntry(
-				TestPropsValues.getUserId(),
-				listTypeDefinition.getListTypeDefinitionId(),
-				StringUtil.randomId(),
-				Collections.singletonMap(LocaleUtil.US, "Brazil"));
-
-		Assert.assertNotNull(listTypeEntry);
+		_listTypeEntryLocalService.addListTypeEntry(
+			TestPropsValues.getUserId(),
+			listTypeDefinition.getListTypeDefinitionId(),
+			StringUtil.randomId(),
+			Collections.singletonMap(LocaleUtil.US, "Brazil"));
 
 		ObjectField objectField = ObjectFieldUtil.createObjectField(
 			"Picklist", "String", "country");

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectViewLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectViewLocalServiceTest.java
@@ -149,19 +149,6 @@ public class ObjectViewLocalServiceTest {
 			Collections.emptyList());
 
 		_assertFailureAddOrUpdateObjectView(
-			false, ObjectViewSortColumnException.class,
-			"There is no object view column with the name: zulu", null,
-			Arrays.asList(_createObjectViewColumn("Item", "item")),
-			Collections.emptyList(),
-			Arrays.asList(
-				_createObjectViewSortColumnWithWrongObjectFieldName()));
-		_assertFailureAddOrUpdateObjectView(
-			false, ObjectViewSortColumnException.class,
-			"There is no sort order of type: zulu", null,
-			Arrays.asList(_createObjectViewColumn("King", "king")),
-			Collections.emptyList(),
-			Arrays.asList(_createObjectViewSortColumn("king", "zulu")));
-		_assertFailureAddOrUpdateObjectView(
 			false, ObjectViewFilterColumnException.class,
 			"Object field name is null", null, Collections.emptyList(),
 			Arrays.asList(_createObjectViewFilterColumn(null, null, null)),
@@ -196,6 +183,19 @@ public class ObjectViewLocalServiceTest {
 				_createObjectViewFilterColumn(
 					RandomTestUtil.randomString(), null, "country")),
 			Collections.emptyList());
+		_assertFailureAddOrUpdateObjectView(
+			false, ObjectViewSortColumnException.class,
+			"There is no object view column with the name: zulu", null,
+			Arrays.asList(_createObjectViewColumn("Item", "item")),
+			Collections.emptyList(),
+			Arrays.asList(
+				_createObjectViewSortColumnWithWrongObjectFieldName()));
+		_assertFailureAddOrUpdateObjectView(
+			false, ObjectViewSortColumnException.class,
+			"There is no sort order of type: zulu", null,
+			Arrays.asList(_createObjectViewColumn("King", "king")),
+			Collections.emptyList(),
+			Arrays.asList(_createObjectViewSortColumn("king", "zulu")));
 
 		_deleteObjectFields();
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/ExportImportObjectDefinitionTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/portlet/action/test/ExportImportObjectDefinitionTest.java
@@ -36,10 +36,12 @@ import com.liferay.portal.kernel.util.File;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.model.impl.LayoutImpl;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PropsUtil;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -70,6 +72,11 @@ public class ExportImportObjectDefinitionTest {
 
 	@Test
 	public void testExportImportObjectDefinition() throws Exception {
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-144957", "true"
+			).build());
+
 		ObjectDefinition objectDefinition = _importObjectDefinition();
 
 		MockLiferayResourceResponse mockLiferayResourceResponse =
@@ -96,6 +103,11 @@ public class ExportImportObjectDefinitionTest {
 
 		_objectDefinitionResource.deleteObjectDefinition(
 			objectDefinition.getId());
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-144957", "false"
+			).build());
 	}
 
 	private MockLiferayPortletActionRequest

--- a/modules/apps/object/object-test/src/testIntegration/resources/com/liferay/object/web/internal/portlet/action/test/dependencies/object_definition.json
+++ b/modules/apps/object/object-test/src/testIntegration/resources/com/liferay/object/web/internal/portlet/action/test/dependencies/object_definition.json
@@ -126,6 +126,18 @@
 				}
 			],
 			"objectViewFilterColumns": [
+				{
+					"objectFieldName": "dateCreated"
+				},
+				{
+					"objectFieldName": "dateModified"
+				},
+				{
+					"filterType": "excludes",
+					"json": "{ \"excludes\": [0, 1]}",
+					"objectFieldName": "status",
+					"valueSummary": "Approved, Pending"
+				}
 			],
 			"objectViewSortColumns": [
 				{

--- a/portal-kernel/src/com/liferay/portal/kernel/util/HttpComponentsUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/HttpComponentsUtil.java
@@ -43,58 +43,6 @@ import javax.servlet.http.HttpSession;
  */
 public class HttpComponentsUtil {
 
-	public static String addParameter(String url, String name, boolean value) {
-		return addParameter(url, name, String.valueOf(value));
-	}
-
-	public static String addParameter(String url, String name, double value) {
-		return addParameter(url, name, String.valueOf(value));
-	}
-
-	public static String addParameter(String url, String name, int value) {
-		return addParameter(url, name, String.valueOf(value));
-	}
-
-	public static String addParameter(String url, String name, long value) {
-		return addParameter(url, name, String.valueOf(value));
-	}
-
-	public static String addParameter(String url, String name, short value) {
-		return addParameter(url, name, String.valueOf(value));
-	}
-
-	public static String addParameter(String url, String name, String value) {
-		if (url == null) {
-			return null;
-		}
-
-		String[] urlArray = PortalUtil.stripURLAnchor(url, StringPool.POUND);
-
-		url = urlArray[0];
-
-		String anchor = urlArray[1];
-
-		StringBundler sb = new StringBundler(6);
-
-		sb.append(url);
-
-		if (url.indexOf(CharPool.QUESTION) == -1) {
-			sb.append(StringPool.QUESTION);
-		}
-		else if (!url.endsWith(StringPool.QUESTION) &&
-				 !url.endsWith(StringPool.AMPERSAND)) {
-
-			sb.append(StringPool.AMPERSAND);
-		}
-
-		sb.append(name);
-		sb.append(StringPool.EQUAL);
-		sb.append(URLCodec.encodeURL(value));
-		sb.append(anchor);
-
-		return shortenURL(sb.toString());
-	}
-
 	public static String decodePath(String path) {
 		return decodeURL(path);
 	}
@@ -114,23 +62,6 @@ public class HttpComponentsUtil {
 		}
 
 		return StringPool.BLANK;
-	}
-
-	public static String encodeParameters(String url) {
-		if (Validator.isNull(url)) {
-			return url;
-		}
-
-		String queryString = getQueryString(url);
-
-		if (Validator.isNull(queryString)) {
-			return url;
-		}
-
-		String encodedQueryString = parameterMapToString(
-			parameterMapFromString(queryString), false);
-
-		return StringUtil.replace(url, queryString, encodedQueryString);
 	}
 
 	public static String encodePath(String path) {
@@ -742,66 +673,6 @@ public class HttpComponentsUtil {
 		return url;
 	}
 
-	public static String removeParameter(String url, String name) {
-		if (Validator.isNull(url) || Validator.isNull(name)) {
-			return url;
-		}
-
-		int pos = url.indexOf(CharPool.QUESTION);
-
-		if (pos == -1) {
-			return url;
-		}
-
-		String[] array = PortalUtil.stripURLAnchor(url, StringPool.POUND);
-
-		url = array[0];
-
-		String anchor = array[1];
-
-		StringBundler sb = new StringBundler();
-
-		sb.append(url.substring(0, pos + 1));
-
-		String[] parameters = StringUtil.split(
-			url.substring(pos + 1), CharPool.AMPERSAND);
-
-		for (String parameter : parameters) {
-			if (parameter.length() > 0) {
-				String[] kvp = StringUtil.split(parameter, CharPool.EQUAL);
-
-				String key = kvp[0];
-
-				String value = StringPool.BLANK;
-
-				if (kvp.length > 1) {
-					value = kvp[1];
-				}
-
-				if (!key.equals(name)) {
-					sb.append(key);
-					sb.append(StringPool.EQUAL);
-					sb.append(value);
-					sb.append(StringPool.AMPERSAND);
-				}
-			}
-		}
-
-		url = StringUtil.replace(
-			sb.toString(), StringPool.AMPERSAND + StringPool.AMPERSAND,
-			StringPool.AMPERSAND);
-
-		if (url.endsWith(StringPool.AMPERSAND)) {
-			url = url.substring(0, url.length() - 1);
-		}
-
-		if (url.endsWith(StringPool.QUESTION)) {
-			url = url.substring(0, url.length() - 1);
-		}
-
-		return url + anchor;
-	}
-
 	public static String removePathParameters(String uri) {
 		if (Validator.isNull(uri)) {
 			return uri;
@@ -888,36 +759,6 @@ public class HttpComponentsUtil {
 		}
 
 		return header;
-	}
-
-	public static String setParameter(String url, String name, boolean value) {
-		return setParameter(url, name, String.valueOf(value));
-	}
-
-	public static String setParameter(String url, String name, double value) {
-		return setParameter(url, name, String.valueOf(value));
-	}
-
-	public static String setParameter(String url, String name, int value) {
-		return setParameter(url, name, String.valueOf(value));
-	}
-
-	public static String setParameter(String url, String name, long value) {
-		return setParameter(url, name, String.valueOf(value));
-	}
-
-	public static String setParameter(String url, String name, short value) {
-		return setParameter(url, name, String.valueOf(value));
-	}
-
-	public static String setParameter(String url, String name, String value) {
-		if (Validator.isNull(url) || Validator.isNull(name)) {
-			return url;
-		}
-
-		url = removeParameter(url, name);
-
-		return addParameter(url, name, value);
 	}
 
 	public static String shortenURL(String url) {

--- a/portal-kernel/src/com/liferay/portal/kernel/util/HttpComponentsUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/HttpComponentsUtil.java
@@ -43,6 +43,58 @@ import javax.servlet.http.HttpSession;
  */
 public class HttpComponentsUtil {
 
+	public static String addParameter(String url, String name, boolean value) {
+		return addParameter(url, name, String.valueOf(value));
+	}
+
+	public static String addParameter(String url, String name, double value) {
+		return addParameter(url, name, String.valueOf(value));
+	}
+
+	public static String addParameter(String url, String name, int value) {
+		return addParameter(url, name, String.valueOf(value));
+	}
+
+	public static String addParameter(String url, String name, long value) {
+		return addParameter(url, name, String.valueOf(value));
+	}
+
+	public static String addParameter(String url, String name, short value) {
+		return addParameter(url, name, String.valueOf(value));
+	}
+
+	public static String addParameter(String url, String name, String value) {
+		if (url == null) {
+			return null;
+		}
+
+		String[] urlArray = PortalUtil.stripURLAnchor(url, StringPool.POUND);
+
+		url = urlArray[0];
+
+		String anchor = urlArray[1];
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(url);
+
+		if (url.indexOf(CharPool.QUESTION) == -1) {
+			sb.append(StringPool.QUESTION);
+		}
+		else if (!url.endsWith(StringPool.QUESTION) &&
+				 !url.endsWith(StringPool.AMPERSAND)) {
+
+			sb.append(StringPool.AMPERSAND);
+		}
+
+		sb.append(name);
+		sb.append(StringPool.EQUAL);
+		sb.append(URLCodec.encodeURL(value));
+		sb.append(anchor);
+
+		return shortenURL(sb.toString());
+	}
+
 	public static String decodePath(String path) {
 		return decodeURL(path);
 	}
@@ -62,6 +114,23 @@ public class HttpComponentsUtil {
 		}
 
 		return StringPool.BLANK;
+	}
+
+	public static String encodeParameters(String url) {
+		if (Validator.isNull(url)) {
+			return url;
+		}
+
+		String queryString = getQueryString(url);
+
+		if (Validator.isNull(queryString)) {
+			return url;
+		}
+
+		String encodedQueryString = parameterMapToString(
+			parameterMapFromString(queryString), false);
+
+		return StringUtil.replace(url, queryString, encodedQueryString);
 	}
 
 	public static String encodePath(String path) {
@@ -673,6 +742,66 @@ public class HttpComponentsUtil {
 		return url;
 	}
 
+	public static String removeParameter(String url, String name) {
+		if (Validator.isNull(url) || Validator.isNull(name)) {
+			return url;
+		}
+
+		int pos = url.indexOf(CharPool.QUESTION);
+
+		if (pos == -1) {
+			return url;
+		}
+
+		String[] array = PortalUtil.stripURLAnchor(url, StringPool.POUND);
+
+		url = array[0];
+
+		String anchor = array[1];
+
+		StringBundler sb = new StringBundler();
+
+		sb.append(url.substring(0, pos + 1));
+
+		String[] parameters = StringUtil.split(
+			url.substring(pos + 1), CharPool.AMPERSAND);
+
+		for (String parameter : parameters) {
+			if (parameter.length() > 0) {
+				String[] kvp = StringUtil.split(parameter, CharPool.EQUAL);
+
+				String key = kvp[0];
+
+				String value = StringPool.BLANK;
+
+				if (kvp.length > 1) {
+					value = kvp[1];
+				}
+
+				if (!key.equals(name)) {
+					sb.append(key);
+					sb.append(StringPool.EQUAL);
+					sb.append(value);
+					sb.append(StringPool.AMPERSAND);
+				}
+			}
+		}
+
+		url = StringUtil.replace(
+			sb.toString(), StringPool.AMPERSAND + StringPool.AMPERSAND,
+			StringPool.AMPERSAND);
+
+		if (url.endsWith(StringPool.AMPERSAND)) {
+			url = url.substring(0, url.length() - 1);
+		}
+
+		if (url.endsWith(StringPool.QUESTION)) {
+			url = url.substring(0, url.length() - 1);
+		}
+
+		return url + anchor;
+	}
+
 	public static String removePathParameters(String uri) {
 		if (Validator.isNull(uri)) {
 			return uri;
@@ -759,6 +888,36 @@ public class HttpComponentsUtil {
 		}
 
 		return header;
+	}
+
+	public static String setParameter(String url, String name, boolean value) {
+		return setParameter(url, name, String.valueOf(value));
+	}
+
+	public static String setParameter(String url, String name, double value) {
+		return setParameter(url, name, String.valueOf(value));
+	}
+
+	public static String setParameter(String url, String name, int value) {
+		return setParameter(url, name, String.valueOf(value));
+	}
+
+	public static String setParameter(String url, String name, long value) {
+		return setParameter(url, name, String.valueOf(value));
+	}
+
+	public static String setParameter(String url, String name, short value) {
+		return setParameter(url, name, String.valueOf(value));
+	}
+
+	public static String setParameter(String url, String name, String value) {
+		if (Validator.isNull(url) || Validator.isNull(name)) {
+			return url;
+		}
+
+		url = removeParameter(url, name);
+
+		return addParameter(url, name, value);
 	}
 
 	public static String shortenURL(String url) {

--- a/portal-kernel/src/com/liferay/portal/kernel/util/URIBuilder.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/URIBuilder.java
@@ -17,51 +17,61 @@ package com.liferay.portal.kernel.util;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 
+import java.net.URI;
+
 /**
  * @author Julius Lee
  */
-public class URLBuilder {
+public class URIBuilder {
 
-	public static String addParameter(String url, String name, boolean value) {
-		return addParameter(url, name, String.valueOf(value));
+	public static URIBuilder create(String uri) {
+		return new URIBuilder(uri);
 	}
 
-	public static String addParameter(String url, String name, double value) {
-		return addParameter(url, name, String.valueOf(value));
+	public static URIBuilder create(URI uri) {
+		return new URIBuilder(uri.toString());
 	}
 
-	public static String addParameter(String url, String name, int value) {
-		return addParameter(url, name, String.valueOf(value));
+	public URIBuilder addParameter(String name, boolean value) {
+		return addParameter(name, String.valueOf(value));
 	}
 
-	public static String addParameter(String url, String name, long value) {
-		return addParameter(url, name, String.valueOf(value));
+	public URIBuilder addParameter(String name, double value) {
+		return addParameter(name, String.valueOf(value));
 	}
 
-	public static String addParameter(String url, String name, short value) {
-		return addParameter(url, name, String.valueOf(value));
+	public URIBuilder addParameter(String name, int value) {
+		return addParameter(name, String.valueOf(value));
 	}
 
-	public static String addParameter(String url, String name, String value) {
-		if (url == null) {
-			return null;
+	public URIBuilder addParameter(String name, long value) {
+		return addParameter(name, String.valueOf(value));
+	}
+
+	public URIBuilder addParameter(String name, short value) {
+		return addParameter(name, String.valueOf(value));
+	}
+
+	public URIBuilder addParameter(String name, String value) {
+		if (Validator.isNull(_uri) || Validator.isNull(value)) {
+			return this;
 		}
 
-		String[] urlArray = PortalUtil.stripURLAnchor(url, StringPool.POUND);
+		String[] urlArray = PortalUtil.stripURLAnchor(_uri, StringPool.POUND);
 
-		url = urlArray[0];
+		_uri = urlArray[0];
 
 		String anchor = urlArray[1];
 
 		StringBundler sb = new StringBundler(6);
 
-		sb.append(url);
+		sb.append(_uri);
 
-		if (url.indexOf(CharPool.QUESTION) == -1) {
+		if (_uri.indexOf(CharPool.QUESTION) == -1) {
 			sb.append(StringPool.QUESTION);
 		}
-		else if (!url.endsWith(StringPool.QUESTION) &&
-				 !url.endsWith(StringPool.AMPERSAND)) {
+		else if (!_uri.endsWith(StringPool.QUESTION) &&
+				 !_uri.endsWith(StringPool.AMPERSAND)) {
 
 			sb.append(StringPool.AMPERSAND);
 		}
@@ -71,49 +81,61 @@ public class URLBuilder {
 		sb.append(URLCodec.encodeURL(value));
 		sb.append(anchor);
 
-		return shortenURL(sb.toString());
+		_uri = HttpComponentsUtil.shortenURL(sb.toString());
+
+		return this;
 	}
 
-	public static String encodeParameters(String url) {
-		if (Validator.isNull(url)) {
-			return url;
+	public String build() {
+		if (Validator.isNull(_uri)) {
+			return null;
 		}
 
-		String queryString = getQueryString(url);
+		return _uri;
+	}
+
+	public URIBuilder encodeParameters() {
+		if (Validator.isNull(_uri)) {
+			return this;
+		}
+
+		String queryString = HttpComponentsUtil.getQueryString(_uri);
 
 		if (Validator.isNull(queryString)) {
-			return url;
+			return this;
 		}
 
-		String encodedQueryString = parameterMapToString(
-			parameterMapFromString(queryString), false);
+		String encodedQueryString = HttpComponentsUtil.parameterMapToString(
+			HttpComponentsUtil.parameterMapFromString(queryString), false);
 
-		return StringUtil.replace(url, queryString, encodedQueryString);
+		_uri = StringUtil.replace(_uri, queryString, encodedQueryString);
+
+		return this;
 	}
 
-	public static String removeParameter(String url, String name) {
-		if (Validator.isNull(url) || Validator.isNull(name)) {
-			return url;
+	public URIBuilder removeParameter(String name) {
+		if (Validator.isNull(_uri) || Validator.isNull(name)) {
+			return this;
 		}
 
-		int pos = url.indexOf(CharPool.QUESTION);
+		int pos = _uri.indexOf(CharPool.QUESTION);
 
 		if (pos == -1) {
-			return url;
+			return this;
 		}
 
-		String[] array = PortalUtil.stripURLAnchor(url, StringPool.POUND);
+		String[] array = PortalUtil.stripURLAnchor(_uri, StringPool.POUND);
 
-		url = array[0];
+		_uri = array[0];
 
 		String anchor = array[1];
 
 		StringBundler sb = new StringBundler();
 
-		sb.append(url.substring(0, pos + 1));
+		sb.append(_uri.substring(0, pos + 1));
 
 		String[] parameters = StringUtil.split(
-			url.substring(pos + 1), CharPool.AMPERSAND);
+			_uri.substring(pos + 1), CharPool.AMPERSAND);
 
 		for (String parameter : parameters) {
 			if (parameter.length() > 0) {
@@ -136,51 +158,57 @@ public class URLBuilder {
 			}
 		}
 
-		url = StringUtil.replace(
+		_uri = StringUtil.replace(
 			sb.toString(), StringPool.AMPERSAND + StringPool.AMPERSAND,
 			StringPool.AMPERSAND);
 
-		if (url.endsWith(StringPool.AMPERSAND)) {
-			url = url.substring(0, url.length() - 1);
+		if (_uri.endsWith(StringPool.AMPERSAND)) {
+			_uri = _uri.substring(0, _uri.length() - 1);
 		}
 
-		if (url.endsWith(StringPool.QUESTION)) {
-			url = url.substring(0, url.length() - 1);
+		if (_uri.endsWith(StringPool.QUESTION)) {
+			_uri = _uri.substring(0, _uri.length() - 1);
 		}
 
-		return url + anchor;
+		_uri = _uri + anchor;
+
+		return this;
 	}
 
-	public static String setParameter(String url, String name, boolean value) {
-		return setParameter(url, name, String.valueOf(value));
+	public URIBuilder setParameter(String name, boolean value) {
+		return setParameter(name, String.valueOf(value));
 	}
 
-	public static String setParameter(String url, String name, double value) {
-		return setParameter(url, name, String.valueOf(value));
+	public URIBuilder setParameter(String name, double value) {
+		return setParameter(name, String.valueOf(value));
 	}
 
-	public static String setParameter(String url, String name, int value) {
-		return setParameter(url, name, String.valueOf(value));
+	public URIBuilder setParameter(String name, int value) {
+		return setParameter(name, String.valueOf(value));
 	}
 
-	public static String setParameter(String url, String name, long value) {
-		return setParameter(url, name, String.valueOf(value));
+	public URIBuilder setParameter(String name, long value) {
+		return setParameter(name, String.valueOf(value));
 	}
 
-	public static String setParameter(String url, String name, short value) {
-		return setParameter(url, name, String.valueOf(value));
+	public URIBuilder setParameter(String name, short value) {
+		return setParameter(name, String.valueOf(value));
 	}
 
-	public static String setParameter(String url, String name, String value) {
-		if (Validator.isNull(url) || Validator.isNull(name)) {
-			return url;
+	public URIBuilder setParameter(String name, String value) {
+		if (Validator.isNull(_uri) || Validator.isNull(name)) {
+			return this;
 		}
 
-		url = removeParameter(url, name);
+		removeParameter(name);
 
-		return addParameter(url, name, value);
+		return addParameter(name, value);
 	}
-	
-	private String _url;
+
+	private URIBuilder(String uri) {
+		_uri = uri;
+	}
+
+	private String _uri;
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/util/URIBuilder.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/URIBuilder.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.util;
+
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringPool;
+
+/**
+ * @author Julius Lee
+ */
+public class URLBuilder {
+
+	public static String addParameter(String url, String name, boolean value) {
+		return addParameter(url, name, String.valueOf(value));
+	}
+
+	public static String addParameter(String url, String name, double value) {
+		return addParameter(url, name, String.valueOf(value));
+	}
+
+	public static String addParameter(String url, String name, int value) {
+		return addParameter(url, name, String.valueOf(value));
+	}
+
+	public static String addParameter(String url, String name, long value) {
+		return addParameter(url, name, String.valueOf(value));
+	}
+
+	public static String addParameter(String url, String name, short value) {
+		return addParameter(url, name, String.valueOf(value));
+	}
+
+	public static String addParameter(String url, String name, String value) {
+		if (url == null) {
+			return null;
+		}
+
+		String[] urlArray = PortalUtil.stripURLAnchor(url, StringPool.POUND);
+
+		url = urlArray[0];
+
+		String anchor = urlArray[1];
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(url);
+
+		if (url.indexOf(CharPool.QUESTION) == -1) {
+			sb.append(StringPool.QUESTION);
+		}
+		else if (!url.endsWith(StringPool.QUESTION) &&
+				 !url.endsWith(StringPool.AMPERSAND)) {
+
+			sb.append(StringPool.AMPERSAND);
+		}
+
+		sb.append(name);
+		sb.append(StringPool.EQUAL);
+		sb.append(URLCodec.encodeURL(value));
+		sb.append(anchor);
+
+		return shortenURL(sb.toString());
+	}
+
+	public static String encodeParameters(String url) {
+		if (Validator.isNull(url)) {
+			return url;
+		}
+
+		String queryString = getQueryString(url);
+
+		if (Validator.isNull(queryString)) {
+			return url;
+		}
+
+		String encodedQueryString = parameterMapToString(
+			parameterMapFromString(queryString), false);
+
+		return StringUtil.replace(url, queryString, encodedQueryString);
+	}
+
+	public static String removeParameter(String url, String name) {
+		if (Validator.isNull(url) || Validator.isNull(name)) {
+			return url;
+		}
+
+		int pos = url.indexOf(CharPool.QUESTION);
+
+		if (pos == -1) {
+			return url;
+		}
+
+		String[] array = PortalUtil.stripURLAnchor(url, StringPool.POUND);
+
+		url = array[0];
+
+		String anchor = array[1];
+
+		StringBundler sb = new StringBundler();
+
+		sb.append(url.substring(0, pos + 1));
+
+		String[] parameters = StringUtil.split(
+			url.substring(pos + 1), CharPool.AMPERSAND);
+
+		for (String parameter : parameters) {
+			if (parameter.length() > 0) {
+				String[] kvp = StringUtil.split(parameter, CharPool.EQUAL);
+
+				String key = kvp[0];
+
+				String value = StringPool.BLANK;
+
+				if (kvp.length > 1) {
+					value = kvp[1];
+				}
+
+				if (!key.equals(name)) {
+					sb.append(key);
+					sb.append(StringPool.EQUAL);
+					sb.append(value);
+					sb.append(StringPool.AMPERSAND);
+				}
+			}
+		}
+
+		url = StringUtil.replace(
+			sb.toString(), StringPool.AMPERSAND + StringPool.AMPERSAND,
+			StringPool.AMPERSAND);
+
+		if (url.endsWith(StringPool.AMPERSAND)) {
+			url = url.substring(0, url.length() - 1);
+		}
+
+		if (url.endsWith(StringPool.QUESTION)) {
+			url = url.substring(0, url.length() - 1);
+		}
+
+		return url + anchor;
+	}
+
+	public static String setParameter(String url, String name, boolean value) {
+		return setParameter(url, name, String.valueOf(value));
+	}
+
+	public static String setParameter(String url, String name, double value) {
+		return setParameter(url, name, String.valueOf(value));
+	}
+
+	public static String setParameter(String url, String name, int value) {
+		return setParameter(url, name, String.valueOf(value));
+	}
+
+	public static String setParameter(String url, String name, long value) {
+		return setParameter(url, name, String.valueOf(value));
+	}
+
+	public static String setParameter(String url, String name, short value) {
+		return setParameter(url, name, String.valueOf(value));
+	}
+
+	public static String setParameter(String url, String name, String value) {
+		if (Validator.isNull(url) || Validator.isNull(name)) {
+			return url;
+		}
+
+		url = removeParameter(url, name);
+
+		return addParameter(url, name, value);
+	}
+	
+	private String _url;
+
+}

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/URIBuilderTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/URIBuilderTest.java
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.util;
+
+import com.liferay.petra.string.StringPool;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author Julius Lee
+ */
+public class URIBuilderTest {
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+
+		PortalUtil portalUtil = new PortalUtil();
+
+		portalUtil.setPortal(_portal);
+
+		Mockito.when(_portal.stripURLAnchor(Mockito.anyString(), Mockito.anyString())).then(invocationOnMock -> _stripURLAnchor(
+			(String) invocationOnMock.getArguments()[0], StringPool.POUND));
+	}
+
+	@Test
+	public void testAddParameter() {
+		String[] stripURLAnchor = _stripURLAnchor(
+			_BASE_URL_WITH_ANCHOR, StringPool.POUND);
+
+		String testParamKey = "testParamKey";
+		String testParamValue = "testParamValue";
+
+		String actualURL = URIBuilder.create(
+			_BASE_URL_WITH_ANCHOR
+		).addParameter(
+			testParamKey, testParamValue
+		).build();
+		String expectedURL = StringBundler.concat(
+			stripURLAnchor[0], StringPool.QUESTION, testParamKey,
+			StringPool.EQUAL, testParamValue, stripURLAnchor[1]);
+
+		Assert.assertEquals(expectedURL, actualURL);
+
+		stripURLAnchor = _stripURLAnchor(actualURL, StringPool.POUND);
+
+		actualURL = URIBuilder.create(
+			actualURL
+		).addParameter(
+			testParamKey, testParamValue
+		).build();
+
+		expectedURL = StringBundler.concat(
+			stripURLAnchor[0], StringPool.AMPERSAND, testParamKey,
+			StringPool.EQUAL, testParamValue, stripURLAnchor[1]);
+
+		Assert.assertEquals(expectedURL, actualURL);
+	}
+
+	@Test
+	public void testAddParameterWithEncodedParamValue() {
+		String testParamKey = "testParamKey";
+		String testParamValue = "test ParamValue";
+
+		String actualURL = URIBuilder.create(
+			_BASE_URL_WITH_ANCHOR
+		).addParameter(
+			testParamKey, testParamValue
+		).build();
+
+		String[] stripURLAnchor = _stripURLAnchor(
+			_BASE_URL_WITH_ANCHOR, StringPool.POUND);
+
+		String encodedExpectedValue = "test+ParamValue";
+
+		String expectedURL = StringBundler.concat(
+			stripURLAnchor[0], StringPool.QUESTION, testParamKey,
+			StringPool.EQUAL, encodedExpectedValue, stripURLAnchor[1]);
+
+		Assert.assertEquals(expectedURL, actualURL);
+	}
+
+	@Test
+	public void testCreatingURI() {
+		URIBuilder uriBuilder = URIBuilder.create(_BASE_URL);
+
+		Assert.assertEquals(_BASE_URL, uriBuilder.build());
+	}
+
+	@Test
+	public void testCreatingURIWithURIInput() throws URISyntaxException {
+		URIBuilder uriBuilder = URIBuilder.create(new URI(_BASE_URL));
+
+		Assert.assertEquals(_BASE_URL, uriBuilder.build());
+	}
+
+	@Test
+	public void testNullURL() {
+		String nullString = null;
+
+		Assert.assertNull(
+			URIBuilder.create(
+				nullString
+			).addParameter(
+				"test", "test"
+			).setParameter(
+				"test", "test"
+			).removeParameter(
+				"test"
+			).encodeParameters(
+			).build());
+
+		nullString = "null";
+
+		Assert.assertNull(
+			URIBuilder.create(
+				nullString
+			).addParameter(
+				"test", "test"
+			).setParameter(
+				"test", "test"
+			).removeParameter(
+				"test"
+			).encodeParameters(
+			).build());
+
+		nullString = "";
+
+		Assert.assertNull(
+			URIBuilder.create(
+				nullString
+			).addParameter(
+				"test", "test"
+			).setParameter(
+				"test", "test"
+			).removeParameter(
+				"test"
+			).encodeParameters(
+			).build());
+	}
+
+	@Test
+	public void testParamMethodsWithNullValue() {
+
+		// Param method should not be executed if value passed in is null
+
+		String nullValue = null;
+
+		Assert.assertEquals(
+			_BASE_URL,
+			URIBuilder.create(
+				_BASE_URL
+			).addParameter(
+				"test", nullValue
+			).build());
+		Assert.assertEquals(
+			_BASE_URL,
+			URIBuilder.create(
+				_BASE_URL
+			).setParameter(
+				"test", nullValue
+			).build());
+		Assert.assertEquals(
+			_BASE_URL,
+			URIBuilder.create(
+				_BASE_URL
+			).removeParameter(
+				nullValue
+			).build());
+
+		nullValue = "null";
+
+		Assert.assertEquals(
+			_BASE_URL,
+			URIBuilder.create(
+				_BASE_URL
+			).addParameter(
+				"test", nullValue
+			).build());
+		Assert.assertEquals(
+			_BASE_URL,
+			URIBuilder.create(
+				_BASE_URL
+			).setParameter(
+				"test", nullValue
+			).build());
+		Assert.assertEquals(
+			_BASE_URL,
+			URIBuilder.create(
+				_BASE_URL
+			).removeParameter(
+				nullValue
+			).build());
+
+		nullValue = "";
+
+		Assert.assertEquals(
+			_BASE_URL,
+			URIBuilder.create(
+				_BASE_URL
+			).addParameter(
+				"test", nullValue
+			).build());
+		Assert.assertEquals(
+			_BASE_URL,
+			URIBuilder.create(
+				_BASE_URL
+			).setParameter(
+				"test", nullValue
+			).build());
+		Assert.assertEquals(
+			_BASE_URL,
+			URIBuilder.create(
+				_BASE_URL
+			).removeParameter(
+				nullValue
+			).build());
+	}
+
+	@Test
+	public void testRemoveParameter() {
+		Assert.assertEquals(
+			_BASE_URL_WITH_ANCHOR,
+			URIBuilder.create(
+				_BASE_URL + "?testParamKey=testParamVal#TestAnchor"
+			).removeParameter(
+				"testParamKey"
+			).build());
+	}
+
+	@Test
+	public void testSetParameter() {
+		String[] stripAnchor = _stripURLAnchor(
+			_BASE_URL_WITH_ANCHOR, StringPool.POUND);
+
+		String testParamKey = "testParamKey";
+		String testParamValue = "testParamValue";
+
+		String actualURL = URIBuilder.create(
+			_BASE_URL_WITH_ANCHOR
+		).setParameter(
+			testParamKey, testParamValue
+		).build();
+
+		String expectedURL = StringBundler.concat(
+			stripAnchor[0], StringPool.QUESTION, testParamKey, StringPool.EQUAL,
+			testParamValue, stripAnchor[1]);
+
+		Assert.assertEquals(expectedURL, actualURL);
+
+		stripAnchor = _stripURLAnchor(actualURL, StringPool.POUND);
+
+		Assert.assertEquals(
+			expectedURL,
+			URIBuilder.create(
+				actualURL
+			).setParameter(
+				testParamKey, testParamValue
+			).build());
+	}
+
+	private String[] _stripURLAnchor(String url, String separator) {
+
+		// _stripURLAnchor is copied from PortalImpl for ease of testing
+
+		String anchor = StringPool.BLANK;
+
+		int pos = url.indexOf(separator);
+
+		if (pos != -1) {
+			anchor = url.substring(pos);
+			url = url.substring(0, pos);
+		}
+
+		return new String[] {url, anchor};
+	}
+
+	private static final String _BASE_URL = "http://test.test";
+
+	private static final String _BASE_URL_WITH_ANCHOR =
+		"http://test.test#TestAnchor";
+
+	@Mock
+	private Portal _portal;
+
+}


### PR DESCRIPTION
@tinatian Hi Tina,

This is what we discussed last week about applying builder pattern to HttpComponentUtil and to start with method related to parameters first.

I think by returning this, we will end up with some build() returning a null. But I think that the original usage of HttpComponentUtil also just return null as well. 

I plan to write unit test but it is more complicated since `PortalUtil.stripURLAnchor(_uri, StringPool.POUND);` is used. 
so my plan is to mock a PortalImpl and set it into PortalUtil.

