### PR TITLE
LPS 156136 Cache LayoutStructure for Processors

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-drop-zone/src/main/java/com/liferay/fragment/entry/processor/drop/zone/DropZoneFragmentEntryProcessor.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-drop-zone/src/main/java/com/liferay/fragment/entry/processor/drop/zone/DropZoneFragmentEntryProcessor.java
@@ -21,6 +21,7 @@ import com.liferay.fragment.processor.FragmentEntryProcessorContext;
 import com.liferay.fragment.renderer.FragmentDropZoneRenderer;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
+import com.liferay.layout.util.constants.LayoutStructureWebKeys;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -29,6 +30,8 @@ import com.liferay.portal.kernel.json.JSONUtil;
 
 import java.util.List;
 import java.util.Objects;
+
+import javax.servlet.http.HttpServletRequest;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -76,19 +79,28 @@ public class DropZoneFragmentEntryProcessor implements FragmentEntryProcessor {
 			return html;
 		}
 
-		LayoutPageTemplateStructure layoutPageTemplateStructure =
-			_layoutPageTemplateStructureLocalService.
-				fetchLayoutPageTemplateStructure(
-					fragmentEntryLink.getGroupId(),
-					fragmentEntryLink.getPlid());
+		HttpServletRequest httpServletRequest =
+			fragmentEntryProcessorContext.getHttpServletRequest();
 
-		if (layoutPageTemplateStructure == null) {
-			return html;
+		LayoutStructure layoutStructure =
+			(LayoutStructure)httpServletRequest.getAttribute(
+				LayoutStructureWebKeys.LAYOUT_STRUCTURE);
+
+		if (layoutStructure == null) {
+			LayoutPageTemplateStructure layoutPageTemplateStructure =
+				_layoutPageTemplateStructureLocalService.
+					fetchLayoutPageTemplateStructure(
+						fragmentEntryLink.getGroupId(),
+						fragmentEntryLink.getPlid());
+
+			if (layoutPageTemplateStructure == null) {
+				return html;
+			}
+
+			layoutStructure = LayoutStructure.of(
+				layoutPageTemplateStructure.getData(
+					fragmentEntryLink.getSegmentsExperienceId()));
 		}
-
-		LayoutStructure layoutStructure = LayoutStructure.of(
-			layoutPageTemplateStructure.getData(
-				fragmentEntryLink.getSegmentsExperienceId()));
 
 		LayoutStructureItem layoutStructureItem =
 			layoutStructure.getLayoutStructureItemByFragmentEntryLinkId(

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/PortletFragmentEntryProcessor.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/PortletFragmentEntryProcessor.java
@@ -26,6 +26,7 @@ import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
 import com.liferay.layout.service.LayoutClassedModelUsageLocalService;
+import com.liferay.layout.util.constants.LayoutStructureWebKeys;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.petra.string.CharPool;
@@ -184,6 +185,7 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 			}
 			else if (processedPortletIds.contains(portletName) ||
 					 _checkNoninstanceablePortletUsed(
+						 fragmentEntryProcessorContext.getHttpServletRequest(),
 						 fragmentEntryLink, portletName)) {
 
 				throw new FragmentEntryContentException(
@@ -246,6 +248,7 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 	}
 
 	private boolean _checkNoninstanceablePortletUsed(
+			HttpServletRequest httpServletRequest,
 			FragmentEntryLink currentFragmentEntryLink,
 			String currentPortletName)
 		throws PortalException {
@@ -263,15 +266,21 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 					currentFragmentEntryLink.getSegmentsExperienceId(),
 					currentFragmentEntryLink.getPlid());
 
-		LayoutPageTemplateStructure layoutPageTemplateStructure =
-			_layoutPageTemplateStructureLocalService.
-				fetchLayoutPageTemplateStructure(
-					currentFragmentEntryLink.getGroupId(),
-					currentFragmentEntryLink.getPlid(), true);
+		LayoutStructure layoutStructure =
+			(LayoutStructure)httpServletRequest.getAttribute(
+				LayoutStructureWebKeys.LAYOUT_STRUCTURE);
 
-		LayoutStructure layoutStructure = LayoutStructure.of(
-			layoutPageTemplateStructure.getData(
-				currentFragmentEntryLink.getSegmentsExperienceId()));
+		if (layoutStructure == null) {
+			LayoutPageTemplateStructure layoutPageTemplateStructure =
+				_layoutPageTemplateStructureLocalService.
+					fetchLayoutPageTemplateStructure(
+						currentFragmentEntryLink.getGroupId(),
+						currentFragmentEntryLink.getPlid(), true);
+
+			layoutStructure = LayoutStructure.of(
+				layoutPageTemplateStructure.getData(
+					currentFragmentEntryLink.getSegmentsExperienceId()));
+		}
 
 		for (FragmentEntryLink fragmentEntryLink : fragmentEntryLinks) {
 			if (currentFragmentEntryLink.getFragmentEntryLinkId() ==

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-styles/src/main/java/com/liferay/fragment/entry/processor/styles/StylesFragmentEntryProcessor.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-styles/src/main/java/com/liferay/fragment/entry/processor/styles/StylesFragmentEntryProcessor.java
@@ -20,6 +20,7 @@ import com.liferay.fragment.processor.FragmentEntryProcessor;
 import com.liferay.fragment.processor.FragmentEntryProcessorContext;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
+import com.liferay.layout.util.constants.LayoutStructureWebKeys;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructureItemCSSUtil;
@@ -33,6 +34,8 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PropsUtil;
+
+import javax.servlet.http.HttpServletRequest;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -97,6 +100,7 @@ public class StylesFragmentEntryProcessor implements FragmentEntryProcessor {
 		}
 
 		LayoutStructureItem layoutStructureItem = _getLayoutStructureItem(
+			fragmentEntryProcessorContext.getHttpServletRequest(),
 			fragmentEntryLink);
 
 		if (layoutStructureItem == null) {
@@ -158,25 +162,32 @@ public class StylesFragmentEntryProcessor implements FragmentEntryProcessor {
 	}
 
 	private LayoutStructureItem _getLayoutStructureItem(
+		HttpServletRequest httpServletRequest,
 		FragmentEntryLink fragmentEntryLink) {
 
-		try {
-			LayoutPageTemplateStructure layoutPageTemplateStructure =
-				_layoutPageTemplateStructureLocalService.
-					fetchLayoutPageTemplateStructure(
-						fragmentEntryLink.getGroupId(),
-						fragmentEntryLink.getPlid(), true);
+		LayoutStructure layoutStructure =
+			(LayoutStructure)httpServletRequest.getAttribute(
+				LayoutStructureWebKeys.LAYOUT_STRUCTURE);
 
-			LayoutStructure layoutStructure = LayoutStructure.of(
-				layoutPageTemplateStructure.getData(
-					fragmentEntryLink.getSegmentsExperienceId()));
+		if (layoutStructure == null) {
+			try {
+				LayoutPageTemplateStructure layoutPageTemplateStructure =
+					_layoutPageTemplateStructureLocalService.
+						fetchLayoutPageTemplateStructure(
+							fragmentEntryLink.getGroupId(),
+							fragmentEntryLink.getPlid(), true);
 
-			return layoutStructure.getLayoutStructureItemByFragmentEntryLinkId(
-				fragmentEntryLink.getFragmentEntryLinkId());
+				layoutStructure = LayoutStructure.of(
+					layoutPageTemplateStructure.getData(
+						fragmentEntryLink.getSegmentsExperienceId()));
+			}
+			catch (Exception exception) {
+				return null;
+			}
 		}
-		catch (Exception exception) {
-			return null;
-		}
+
+		return layoutStructure.getLayoutStructureItemByFragmentEntryLinkId(
+			fragmentEntryLink.getFragmentEntryLinkId());
 	}
 
 	@Reference

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/constants/LayoutStructureWebKeys.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/constants/LayoutStructureWebKeys.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.util.constants;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class LayoutStructureWebKeys {
+
+	public static final String LAYOUT_STRUCTURE = "LAYOUT_STRUCTURE";
+
+}

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderFragmentLayoutTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderFragmentLayoutTag.java
@@ -17,6 +17,7 @@ package com.liferay.layout.taglib.servlet.taglib;
 import com.liferay.fragment.constants.FragmentEntryLinkConstants;
 import com.liferay.layout.taglib.internal.servlet.ServletContextUtil;
 import com.liferay.layout.taglib.internal.util.LayoutStructureUtil;
+import com.liferay.layout.util.constants.LayoutStructureWebKeys;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -117,7 +118,7 @@ public class RenderFragmentLayoutTag extends IncludeTag {
 		}
 
 		_layoutStructure = (LayoutStructure)httpServletRequest.getAttribute(
-			RenderLayoutStructureTag.LAYOUT_STRUCTURE);
+			LayoutStructureWebKeys.LAYOUT_STRUCTURE);
 
 		if (_layoutStructure != null) {
 			return _layoutStructure;

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java
@@ -41,6 +41,7 @@ import com.liferay.layout.taglib.internal.display.context.RenderCollectionLayout
 import com.liferay.layout.taglib.internal.display.context.RenderLayoutStructureDisplayContext;
 import com.liferay.layout.taglib.internal.servlet.ServletContextUtil;
 import com.liferay.layout.util.constants.LayoutStructureConstants;
+import com.liferay.layout.util.constants.LayoutStructureWebKeys;
 import com.liferay.layout.util.structure.CollectionStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.ColumnLayoutStructureItem;
 import com.liferay.layout.util.structure.ContainerStyledLayoutStructureItem;
@@ -167,9 +168,6 @@ public class RenderLayoutStructureTag extends IncludeTag {
 
 	protected static final String COLLECTION_ELEMENT_INDEX =
 		RenderLayoutStructureTag.class.getName() + "#COLLECTION_ELEMENT_INDEX";
-
-	protected static final String LAYOUT_STRUCTURE =
-		RenderLayoutStructureTag.class.getName() + "#LAYOUT_STRUCTURE";
 
 	private InfoForm _getInfoForm(
 		FormStyledLayoutStructureItem formStyledLayoutStructureItem) {
@@ -1005,7 +1003,8 @@ public class RenderLayoutStructureTag extends IncludeTag {
 
 		HttpServletRequest httpServletRequest = getRequest();
 
-		httpServletRequest.setAttribute(LAYOUT_STRUCTURE, _layoutStructure);
+		httpServletRequest.setAttribute(
+			LayoutStructureWebKeys.LAYOUT_STRUCTURE, _layoutStructure);
 
 		_renderLayoutStructure(
 			childrenItemIds,


### PR DESCRIPTION
@tinatian

This pull attempts to reduce a large number of `FragmenEntryLinkLocalService` invocations (about 12000+ times with a single visit of the 110 tabs page, which is a big part in the profile I made for just opening the page).

With this change, the page loading time can be reduced from 40~60s to less than 20s.

Another thing I notice is that the 110 tabs page in the database dump put every next tab in the previous tab's drop zone (embedded in the previous tab), so the page structure becomes a very very deep tree which has 1 branch from each node.

This deep tree structure causes very deep stacks when running related Java code, and sometimes I encounter `StackOverflowError`. I'm not sure whether Brian Lee intended to create the page like this.

