### PR TITLE
LPS-149147 Added breaking change info

### DIFF
--- a/readme/BREAKING_CHANGES.markdown
+++ b/readme/BREAKING_CHANGES.markdown
@@ -1255,3 +1255,28 @@ Replace usages of `<aui:container>` with `<clay:container>`.
 ### Why was this change made?
 
 The tag `<aui:container>` was deprecated in a previous version.
+
+---------------------------------------
+
+## Removed ContentUtil class and its module com.liferay.petra.content
+
+- **Date:** 2023-Jan-04
+- **JIRA Ticket:** [LPS-149147](https://issues.liferay.com/browse/LPS-149147)
+
+### What changed?
+
+The class `ContentUtil` and its related module, `com.liferay.petra.content`, have been deleted and are no longer available.
+
+### Who is affected?
+
+This affects any development that uses the `ContentUtil` class.
+
+### How should I update my code?
+
+If you still need to use this class, you can replace the calls to `com.liferay.petra.content.ContentUtil.get` with `com.liferay.petra.string.StringUtil.read` from `com.liferay.petra.string` module.
+
+### Why was this change made?
+
+ContentUtil class caches the content read from files, but there are several issues with this cache:
+- It is not thread safe.
+- It does not provide a way to clear, which may cause leaking.


### PR DESCRIPTION
Hi @tinatian,

This is an additional commit to include information about the breaking change caused by the removal of the module com.liferay.petra.content.

This commit has already been reviewed and approved by @dantewang in https://github.com/dantewang/liferay-portal/pull/2276.

According to [Core Infra Review Workflow](https://liferay.atlassian.net/wiki/spaces/ENGCOREINFRA/pages/2051376221/Pull+Requests+-+Guidelines#%E2%9B%B9%EF%B8%8F%E2%80%8D%E2%99%82%EF%B8%8FReview-workflow), this PR has to be sent for revision (second round).

Could you please review it? 

Thanks in advance!