### PR TITLE
LPS benchmark test

### DIFF
--- a/modules/apps/portal/portal-benchmark-test/bnd.bnd
+++ b/modules/apps/portal/portal-benchmark-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Portal Benchmark Test
+Bundle-SymbolicName: com.liferay.portal.benchmark.test
+Bundle-Version: 1.0.0

--- a/modules/apps/portal/portal-benchmark-test/build.gradle
+++ b/modules/apps/portal/portal-benchmark-test/build.gradle
@@ -1,6 +1,5 @@
 dependencies {
 	testImplementation group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
-
-	testImplementation project(":core:petra:petra-string")
 	testImplementation project(":core:petra:petra-lang")
+	testImplementation project(":core:petra:petra-string")
 }

--- a/modules/apps/portal/portal-benchmark-test/build.gradle
+++ b/modules/apps/portal/portal-benchmark-test/build.gradle
@@ -1,0 +1,6 @@
+dependencies {
+	testImplementation group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+
+	testImplementation project(":core:petra:petra-string")
+	testImplementation project(":core:petra:petra-lang")
+}

--- a/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/BaseBenchmarkTestCase.java
+++ b/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/BaseBenchmarkTestCase.java
@@ -1,0 +1,110 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.benchmark.test.internal;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+
+import org.junit.Assert;
+
+/**
+ * @author Tina Tian
+ */
+public abstract class BaseBenchmarkTestCase {
+
+	protected void homePage() throws Exception {
+		_assertResult(HttpUtil.doGet("/"), _KEY_HOME_PAGE);
+	}
+
+	protected void login() throws Exception {
+		String[][] parameters = {
+			{
+				_P_P_ID_PREFIX + "_formDate",
+				String.valueOf(System.currentTimeMillis())
+			},
+			{_P_P_ID_PREFIX + "_saveLastPath", "false"},
+			{_P_P_ID_PREFIX + "_redirect", ""},
+			{_P_P_ID_PREFIX + "_doActionAfterLogin", "false"},
+			{_P_P_ID_PREFIX + "_login", "test@liferay.com"},
+			{_P_P_ID_PREFIX + "_password", "test"},
+			{_P_P_ID_PREFIX + "_checkboxNames", "rememberMe"}
+		};
+
+		_assertRedirect(
+			HttpUtil.doPost(_URL_LOGIN_POST, parameters), _URL_REDIRECT);
+
+		_assertRedirect(HttpUtil.doGet(_URL_REDIRECT), _URL_LOGIN_REDIRECT);
+
+		_assertResult(HttpUtil.doGet(_URL_LOGIN_REDIRECT), _KEY_LOGIN);
+	}
+
+	protected void logout() throws Exception {
+		_assertResult(HttpUtil.doGet(_URL_LOGOUT), null);
+	}
+
+	protected void viewLoginPage() throws Exception {
+		_assertRedirect(
+			HttpUtil.doGet(_URL_LOGIN_POPUP), _URL_LOGIN_POPUP_REDIRECT);
+
+		_assertResult(
+			HttpUtil.doGet(_URL_LOGIN_POPUP_REDIRECT), _KEY_LOGIN_POPUP);
+	}
+
+	private void _assertRedirect(
+			HttpUtil.HttpResponse httpResponse, String expectedRedirect)
+		throws Exception {
+
+		Assert.assertEquals(302, httpResponse.getStatusCode());
+
+		Assert.assertEquals(
+			"http://localhost:8080" + expectedRedirect,
+			httpResponse.getRedirect());
+	}
+
+	private void _assertResult(HttpUtil.HttpResponse httpResponse, String key) {
+		Assert.assertEquals(200, httpResponse.getStatusCode());
+
+		if (key != null) {
+			String httpResponseString = httpResponse.toString();
+
+			Assert.assertTrue(httpResponseString.contains(key));
+		}
+	}
+
+	private static final String _KEY_HOME_PAGE = "Liferay.currentURL";
+
+	private static final String _KEY_LOGIN =
+		"ProductNavigationUserPersonalBarPortlet";
+
+	private static final String _KEY_LOGIN_POPUP = "Remember Me";
+
+	private static final String _P_P_ID =
+		"com_liferay_login_web_portlet_LoginPortlet";
+
+	private static final String _P_P_ID_PREFIX = "_" + _P_P_ID;
+
+	private static final String _URL_LOGIN_POPUP =
+		"/c/portal/login?windowState=exclusive";
+
+	private static final String _URL_LOGIN_POPUP_REDIRECT =
+		StringBundler.concat(
+			"/web/guest/welcome?p_p_id=", _P_P_ID, "&p_p_lifecycle=0&",
+			"p_p_state=exclusive&p_p_mode=view&", _P_P_ID_PREFIX,
+			"_mvcRenderCommandName=/login/login&saveLastPath=false");
+
+	private static final String _URL_LOGIN_POST = StringBundler.concat(
+		"/web/guest/welcome?p_p_id=", _P_P_ID, "&p_p_lifecycle=1&",
+		"p_p_state=normal&p_p_mode=view&", _P_P_ID_PREFIX,
+		"_javax.portlet.action=/login/login&", _P_P_ID_PREFIX,
+		"_mvcRenderCommandName=/login/login");
+
+	private static final String _URL_LOGIN_REDIRECT = StringPool.SLASH;
+
+	private static final String _URL_LOGOUT = "/c/portal/logout";
+
+	private static final String _URL_REDIRECT = "/c";
+
+}

--- a/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/BaseBenchmarkTestCase.java
+++ b/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/BaseBenchmarkTestCase.java
@@ -8,10 +8,6 @@ package com.liferay.portal.benchmark.test.internal;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -20,6 +16,10 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
 
 /**
  * @author Tina Tian
@@ -37,6 +37,8 @@ public abstract class BaseBenchmarkTestCase {
 	public void tearDown() {
 		_executorService.shutdownNow();
 	}
+
+	protected abstract int getThreadPoolSize();
 
 	protected void homePage() throws Exception {
 		_assertResult(HttpUtil.doGet("/"), _KEY_HOME_PAGE);
@@ -81,8 +83,6 @@ public abstract class BaseBenchmarkTestCase {
 			future.get();
 		}
 	}
-
-	protected abstract int getThreadPoolSize();
 
 	protected void viewLoginPage() throws Exception {
 		_assertRedirect(

--- a/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/BaseBenchmarkTestCase.java
+++ b/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/BaseBenchmarkTestCase.java
@@ -17,6 +17,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -43,6 +44,8 @@ public abstract class BaseBenchmarkTestCase {
 
 	protected abstract int getThreadPoolSize();
 
+	protected abstract String[][] getUserData() throws Exception;
+
 	protected void homePage() throws Exception {
 		HttpUtil.HttpResponse httpResponse = HttpUtil.doGet("/");
 
@@ -56,6 +59,8 @@ public abstract class BaseBenchmarkTestCase {
 	}
 
 	protected void login() throws Exception {
+		String[] user = _getNextUser();
+
 		String[][] parameters = {
 			{
 				_P_P_ID_PREFIX + "_formDate",
@@ -64,7 +69,7 @@ public abstract class BaseBenchmarkTestCase {
 			{_P_P_ID_PREFIX + "_saveLastPath", "false"},
 			{_P_P_ID_PREFIX + "_redirect", ""},
 			{_P_P_ID_PREFIX + "_doActionAfterLogin", "false"},
-			{_P_P_ID_PREFIX + "_login", "test@liferay.com"},
+			{_P_P_ID_PREFIX + "_login", user[1]},
 			{_P_P_ID_PREFIX + "_password", "test"},
 			{_P_P_ID_PREFIX + "_checkboxNames", "rememberMe"}
 		};
@@ -133,6 +138,20 @@ public abstract class BaseBenchmarkTestCase {
 		}
 	}
 
+	private String[] _getNextUser() throws Exception {
+		String[][] userData = getUserData();
+
+		return userData
+			[_userCounter.getAndUpdate(
+				current -> {
+					if (current == (userData.length - 1)) {
+						return 0;
+					}
+
+					return current + 1;
+				})];
+	}
+
 	private static final String _KEY_HOME_PAGE = "Liferay.currentURL";
 
 	private static final String _KEY_LOGIN =
@@ -172,5 +191,6 @@ public abstract class BaseBenchmarkTestCase {
 		"Liferay\\.authToken = '(.*)';");
 
 	private ExecutorService _executorService;
+	private final AtomicInteger _userCounter = new AtomicInteger(0);
 
 }

--- a/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/BaseBenchmarkTestCase.java
+++ b/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/BaseBenchmarkTestCase.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.benchmark.test.internal;
 
+import com.liferay.petra.lang.CentralizedThreadLocal;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 
@@ -16,6 +17,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -41,7 +44,15 @@ public abstract class BaseBenchmarkTestCase {
 	protected abstract int getThreadPoolSize();
 
 	protected void homePage() throws Exception {
-		_assertResult(HttpUtil.doGet("/"), _KEY_HOME_PAGE);
+		HttpUtil.HttpResponse httpResponse = HttpUtil.doGet("/");
+
+		_assertResult(httpResponse, _KEY_HOME_PAGE);
+
+		Matcher matcher = _csrfTokenPattern.matcher(httpResponse.getText());
+
+		if (matcher.find()) {
+			_csrfToken.set(matcher.group(1));
+		}
 	}
 
 	protected void login() throws Exception {
@@ -58,8 +69,11 @@ public abstract class BaseBenchmarkTestCase {
 			{_P_P_ID_PREFIX + "_checkboxNames", "rememberMe"}
 		};
 
+		String[][] headers = {{"X-Csrf-Token", _csrfToken.get()}};
+
 		_assertRedirect(
-			HttpUtil.doPost(_URL_LOGIN_POST, parameters), _URL_REDIRECT);
+			HttpUtil.doPost(_URL_LOGIN_POST, headers, parameters, null),
+			_URL_REDIRECT);
 
 		_assertRedirect(HttpUtil.doGet(_URL_REDIRECT), _URL_LOGIN_REDIRECT);
 
@@ -68,6 +82,8 @@ public abstract class BaseBenchmarkTestCase {
 
 	protected void logout() throws Exception {
 		_assertResult(HttpUtil.doGet(_URL_LOGOUT), null);
+
+		_csrfToken.remove();
 	}
 
 	protected void runParallel(Callable<Void> callable, int runCount)
@@ -85,11 +101,15 @@ public abstract class BaseBenchmarkTestCase {
 	}
 
 	protected void viewLoginPage() throws Exception {
+		String[][] headers = {{"X-Csrf-Token", _csrfToken.get()}};
+
 		_assertRedirect(
-			HttpUtil.doGet(_URL_LOGIN_POPUP), _URL_LOGIN_POPUP_REDIRECT);
+			HttpUtil.doGet(_URL_LOGIN_POPUP, headers),
+			_URL_LOGIN_POPUP_REDIRECT);
 
 		_assertResult(
-			HttpUtil.doGet(_URL_LOGIN_POPUP_REDIRECT), _KEY_LOGIN_POPUP);
+			HttpUtil.doGet(_URL_LOGIN_POPUP_REDIRECT, headers),
+			_KEY_LOGIN_POPUP);
 	}
 
 	private void _assertRedirect(
@@ -145,6 +165,11 @@ public abstract class BaseBenchmarkTestCase {
 	private static final String _URL_LOGOUT = "/c/portal/logout";
 
 	private static final String _URL_REDIRECT = "/c";
+
+	private static final ThreadLocal<String> _csrfToken =
+		CentralizedThreadLocal.withInitial(() -> null);
+	private static final Pattern _csrfTokenPattern = Pattern.compile(
+		"Liferay\\.authToken = '(.*)';");
 
 	private ExecutorService _executorService;
 

--- a/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/BaseBenchmarkTestCase.java
+++ b/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/BaseBenchmarkTestCase.java
@@ -8,12 +8,35 @@ package com.liferay.portal.benchmark.test.internal;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author Tina Tian
  */
 public abstract class BaseBenchmarkTestCase {
+
+	@Before
+	public void setUp() {
+		_executorService = new ThreadPoolExecutor(
+			getThreadPoolSize(), getThreadPoolSize(), 0, TimeUnit.SECONDS,
+			new LinkedBlockingQueue<>());
+	}
+
+	@After
+	public void tearDown() {
+		_executorService.shutdownNow();
+	}
 
 	protected void homePage() throws Exception {
 		_assertResult(HttpUtil.doGet("/"), _KEY_HOME_PAGE);
@@ -44,6 +67,22 @@ public abstract class BaseBenchmarkTestCase {
 	protected void logout() throws Exception {
 		_assertResult(HttpUtil.doGet(_URL_LOGOUT), null);
 	}
+
+	protected void runParallel(Callable<Void> callable, int runCount)
+		throws Exception {
+
+		List<Future<Void>> futures = new ArrayList<>();
+
+		for (int i = 0; i < runCount; i++) {
+			futures.add(_executorService.submit(callable));
+		}
+
+		for (Future<Void> future : futures) {
+			future.get();
+		}
+	}
+
+	protected abstract int getThreadPoolSize();
 
 	protected void viewLoginPage() throws Exception {
 		_assertRedirect(
@@ -106,5 +145,7 @@ public abstract class BaseBenchmarkTestCase {
 	private static final String _URL_LOGOUT = "/c/portal/logout";
 
 	private static final String _URL_REDIRECT = "/c";
+
+	private ExecutorService _executorService;
 
 }

--- a/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/BaseBenchmarkTestCase.java
+++ b/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/BaseBenchmarkTestCase.java
@@ -130,12 +130,12 @@ public abstract class BaseBenchmarkTestCase {
 
 	private static final String _URL_LOGIN_POPUP_REDIRECT =
 		StringBundler.concat(
-			"/web/guest/welcome?p_p_id=", _P_P_ID, "&p_p_lifecycle=0&",
+			"/home?p_p_id=", _P_P_ID, "&p_p_lifecycle=0&",
 			"p_p_state=exclusive&p_p_mode=view&", _P_P_ID_PREFIX,
 			"_mvcRenderCommandName=/login/login&saveLastPath=false");
 
 	private static final String _URL_LOGIN_POST = StringBundler.concat(
-		"/web/guest/welcome?p_p_id=", _P_P_ID, "&p_p_lifecycle=1&",
+		"/home?p_p_id=", _P_P_ID, "&p_p_lifecycle=1&",
 		"p_p_state=normal&p_p_mode=view&", _P_P_ID_PREFIX,
 		"_javax.portlet.action=/login/login&", _P_P_ID_PREFIX,
 		"_mvcRenderCommandName=/login/login");

--- a/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/BaseBenchmarkTestCase.java
+++ b/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/BaseBenchmarkTestCase.java
@@ -54,12 +54,14 @@ public abstract class BaseBenchmarkTestCase {
 		Matcher matcher = _csrfTokenPattern.matcher(httpResponse.getText());
 
 		if (matcher.find()) {
-			_csrfToken.set(matcher.group(1));
+			ContextUtil.Context context = ContextUtil.getContext();
+
+			context.setCSRFToken(matcher.group(1));
 		}
 	}
 
 	protected void login() throws Exception {
-		String[] user = _getNextUser();
+		ContextUtil.Context context = ContextUtil.getContext();
 
 		String[][] parameters = {
 			{
@@ -69,16 +71,13 @@ public abstract class BaseBenchmarkTestCase {
 			{_P_P_ID_PREFIX + "_saveLastPath", "false"},
 			{_P_P_ID_PREFIX + "_redirect", ""},
 			{_P_P_ID_PREFIX + "_doActionAfterLogin", "false"},
-			{_P_P_ID_PREFIX + "_login", user[1]},
+			{_P_P_ID_PREFIX + "_login", context.getUserEmail()},
 			{_P_P_ID_PREFIX + "_password", "test"},
 			{_P_P_ID_PREFIX + "_checkboxNames", "rememberMe"}
 		};
 
-		String[][] headers = {{"X-Csrf-Token", _csrfToken.get()}};
-
 		_assertRedirect(
-			HttpUtil.doPost(_URL_LOGIN_POST, headers, parameters, null),
-			_URL_REDIRECT);
+			HttpUtil.doPost(_URL_LOGIN_POST, parameters), _URL_REDIRECT);
 
 		_assertRedirect(HttpUtil.doGet(_URL_REDIRECT), _URL_LOGIN_REDIRECT);
 
@@ -97,7 +96,18 @@ public abstract class BaseBenchmarkTestCase {
 		List<Future<Void>> futures = new ArrayList<>();
 
 		for (int i = 0; i < runCount; i++) {
-			futures.add(_executorService.submit(callable));
+			futures.add(
+				_executorService.submit(
+					() -> {
+						ContextUtil.setContext(
+							new ContextUtil.Context(_getNextUser()));
+
+						callable.call();
+
+						ContextUtil.setContext(null);
+
+						return null;
+					}));
 		}
 
 		for (Future<Void> future : futures) {
@@ -105,16 +115,24 @@ public abstract class BaseBenchmarkTestCase {
 		}
 	}
 
-	protected void viewLoginPage() throws Exception {
-		String[][] headers = {{"X-Csrf-Token", _csrfToken.get()}};
+	protected void runSequential(Callable<Void> callable, int runCount)
+		throws Exception {
 
+		for (int i = 0; i < runCount; i++) {
+			ContextUtil.setContext(new ContextUtil.Context(_getNextUser()));
+
+			callable.call();
+
+			ContextUtil.setContext(null);
+		}
+	}
+
+	protected void viewLoginPage() throws Exception {
 		_assertRedirect(
-			HttpUtil.doGet(_URL_LOGIN_POPUP, headers),
-			_URL_LOGIN_POPUP_REDIRECT);
+			HttpUtil.doGet(_URL_LOGIN_POPUP), _URL_LOGIN_POPUP_REDIRECT);
 
 		_assertResult(
-			HttpUtil.doGet(_URL_LOGIN_POPUP_REDIRECT, headers),
-			_KEY_LOGIN_POPUP);
+			HttpUtil.doGet(_URL_LOGIN_POPUP_REDIRECT), _KEY_LOGIN_POPUP);
 	}
 
 	private void _assertRedirect(

--- a/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/ContextUtil.java
+++ b/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/ContextUtil.java
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.benchmark.test.internal;
+
+import com.liferay.petra.lang.CentralizedThreadLocal;
+
+/**
+ * @author Dante Wang
+ */
+public class ContextUtil {
+
+	public static Context getContext() {
+		return _context.get();
+	}
+
+	public static void setContext(Context context) {
+		if (context == null) {
+			_context.remove();
+		}
+
+		_context.set(context);
+	}
+
+	public static class Context {
+
+		public Context(String[] user) {
+			_hostName = user[0];
+			_userEmail = user[1];
+		}
+
+		public String getCSRFToken() {
+			return _csrfToken;
+		}
+
+		public String getHostName() {
+			return _hostName;
+		}
+
+		public String getUserEmail() {
+			return _userEmail;
+		}
+
+		public void setCSRFToken(String csrfToken) {
+			_csrfToken = csrfToken;
+		}
+
+		private String _csrfToken;
+		private final String _hostName;
+		private final String _userEmail;
+
+	}
+
+	private static final ThreadLocal<Context> _context =
+		CentralizedThreadLocal.withInitial(() -> null);
+
+}

--- a/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/HttpUtil.java
+++ b/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/HttpUtil.java
@@ -34,12 +34,24 @@ import java.util.Map;
 public class HttpUtil {
 
 	public static HttpResponse doGet(String uri) throws Exception {
+		return doGet(uri, null);
+	}
+
+	public static HttpResponse doGet(String uri, String[][] headers)
+		throws Exception {
+
 		HttpURLConnection httpURLConnection = null;
 
 		long startTime = System.currentTimeMillis();
 
 		try {
 			httpURLConnection = _openConnection(uri);
+
+			if (headers != null) {
+				for (String[] header : headers) {
+					httpURLConnection.addRequestProperty(header[0], header[1]);
+				}
+			}
 
 			httpURLConnection.setRequestMethod("GET");
 

--- a/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/HttpUtil.java
+++ b/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/HttpUtil.java
@@ -1,0 +1,351 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.benchmark.test.internal;
+
+import com.liferay.petra.lang.CentralizedThreadLocal;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.ListUtil;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+
+import java.net.CookieHandler;
+import java.net.CookieManager;
+import java.net.CookiePolicy;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+
+import java.nio.ByteBuffer;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Tina Tian
+ */
+public class HttpUtil {
+
+	public static HttpResponse doGet(String uri) throws Exception {
+		HttpURLConnection httpURLConnection = null;
+
+		long startTime = System.currentTimeMillis();
+
+		try {
+			httpURLConnection = _openConnection(uri);
+
+			httpURLConnection.setRequestMethod("GET");
+
+			return _readConnection(httpURLConnection);
+		}
+		catch (IOException ioException) {
+			_consumeErrorConnection(httpURLConnection);
+
+			throw new IOException(
+				"Wait time : " + (System.currentTimeMillis() - startTime) +
+					"ms",
+				ioException);
+		}
+		finally {
+			if (httpURLConnection != null) {
+				httpURLConnection.disconnect();
+			}
+		}
+	}
+
+	public static HttpResponse doPost(
+			String uri, String content, String[] contentType)
+		throws Exception {
+
+		return doPost(uri, new String[][] {contentType}, null, content);
+	}
+
+	public static HttpResponse doPost(String uri, String[][] parameters)
+		throws Exception {
+
+		return doPost(uri, null, parameters, null);
+	}
+
+	public static HttpResponse doPost(
+			String uri, String[][] headers, String[][] parameters,
+			String content)
+		throws Exception {
+
+		long startTime = System.currentTimeMillis();
+
+		HttpURLConnection httpURLConnection = null;
+
+		try {
+			httpURLConnection = _openConnection(uri);
+
+			if (headers != null) {
+				for (String[] header : headers) {
+					httpURLConnection.addRequestProperty(header[0], header[1]);
+				}
+			}
+
+			httpURLConnection.setRequestMethod("POST");
+			httpURLConnection.setDoOutput(true);
+
+			PrintWriter printWriter = new PrintWriter(
+				httpURLConnection.getOutputStream());
+
+			if (parameters != null) {
+				boolean first = true;
+
+				for (String[] parameter : parameters) {
+					if (first) {
+						first = false;
+					}
+					else {
+						printWriter.print(CharPool.AMPERSAND);
+					}
+
+					printWriter.print(parameter[0]);
+					printWriter.print(CharPool.EQUAL);
+					printWriter.print(URLEncoder.encode(parameter[1], "UTF-8"));
+				}
+			}
+
+			if (content != null) {
+				printWriter.print(content);
+			}
+
+			printWriter.close();
+
+			return _readConnection(httpURLConnection);
+		}
+		catch (IOException ioException) {
+			_consumeErrorConnection(httpURLConnection);
+
+			throw new IOException(
+				"Wait time : " + (System.currentTimeMillis() - startTime) +
+					"ms",
+				ioException);
+		}
+		finally {
+			if (httpURLConnection != null) {
+				httpURLConnection.disconnect();
+			}
+		}
+	}
+
+	public static class HttpResponse {
+
+		public HttpResponse(
+			int statusCode, String statusLine,
+			Map<String, List<String>> headers, String text, long duration) {
+
+			_statusCode = statusCode;
+			_statusLine = statusLine;
+			_text = text;
+			_duration = duration;
+
+			_headersMap = headers;
+		}
+
+		public long getDuration() {
+			return _duration;
+		}
+
+		public String getHeader(String name) {
+			List<String> headers = _headersMap.get(name);
+
+			if (ListUtil.isEmpty(headers)) {
+				return StringPool.BLANK;
+			}
+
+			StringBundler sb = new StringBundler(headers.size() * 2);
+
+			for (String header : headers) {
+				sb.append(header);
+				sb.append(StringPool.COMMA);
+			}
+
+			sb.setIndex(sb.index() - 1);
+
+			return sb.toString();
+		}
+
+		public Map<String, List<String>> getHeaders() {
+			return _headersMap;
+		}
+
+		public InputStream getInputStream() {
+			return _inputStream;
+		}
+
+		public String getRedirect() throws Exception {
+			String location = getHeader("Location");
+
+			if (location.contains("%")) {
+				location = URLDecoder.decode(location, "UTF-8");
+			}
+
+			return location;
+		}
+
+		public int getStatusCode() {
+			return _statusCode;
+		}
+
+		public String getStatusLine() {
+			return _statusLine;
+		}
+
+		public String getText() {
+			return _text;
+		}
+
+		@Override
+		public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append(_statusCode);
+			sb.append(CharPool.SPACE);
+			sb.append(_statusLine);
+			sb.append(StringPool.NEW_LINE);
+
+			for (Map.Entry<String, List<String>> entry :
+					_headersMap.entrySet()) {
+
+				String key = entry.getKey();
+
+				if (key != null) {
+					sb.append(key);
+					sb.append(StringPool.COLON);
+				}
+
+				for (String value : entry.getValue()) {
+					sb.append(value);
+					sb.append(StringPool.COMMA);
+				}
+
+				sb.setStringAt(StringPool.NEW_LINE, sb.index() - 1);
+			}
+
+			sb.append(_text);
+
+			return sb.toString();
+		}
+
+		private final long _duration;
+		private final Map<String, List<String>> _headersMap;
+		private InputStream _inputStream;
+		private final int _statusCode;
+		private final String _statusLine;
+		private final String _text;
+
+	}
+
+	private static ByteBuffer _collect(InputStream inputStream)
+		throws Exception {
+
+		byte[] byteBuffer = _byteBuffer.get();
+
+		int offset = 0;
+
+		int length = -1;
+
+		int left = byteBuffer.length;
+
+		while ((length = inputStream.read(byteBuffer, offset, left)) != -1) {
+			left -= length;
+			offset += length;
+
+			if (left == 0) {
+				int newLength = byteBuffer.length * 6 / 5;
+
+				byte[] newBuffer = new byte[newLength];
+
+				System.arraycopy(
+					byteBuffer, 0, newBuffer, 0, byteBuffer.length);
+
+				left = newLength - byteBuffer.length;
+
+				byteBuffer = newBuffer;
+
+				_byteBuffer.set(byteBuffer);
+			}
+		}
+
+		inputStream.close();
+
+		return ByteBuffer.wrap(byteBuffer, 0, offset);
+	}
+
+	private static void _consumeErrorConnection(
+			HttpURLConnection httpURLConnection)
+		throws IOException {
+
+		if (httpURLConnection != null) {
+			try (InputStream inputStream = httpURLConnection.getErrorStream()) {
+				if (inputStream != null) {
+					while (inputStream.read() != -1);
+				}
+			}
+			catch (IOException ioException) {
+				throw new IOException(
+					"Failed to consume error connection data", ioException);
+			}
+		}
+	}
+
+	private static HttpURLConnection _openConnection(String uri)
+		throws IOException {
+
+		URL url = new URL("http", "localhost", 8080, uri);
+
+		HttpURLConnection httpURLConnection =
+			(HttpURLConnection)url.openConnection();
+
+		httpURLConnection.setConnectTimeout(0);
+		httpURLConnection.setReadTimeout(0);
+
+		return httpURLConnection;
+	}
+
+	private static HttpResponse _readConnection(
+			HttpURLConnection httpURLConnection)
+		throws Exception {
+
+		long startTime = System.currentTimeMillis();
+
+		httpURLConnection.connect();
+
+		int statusCode = httpURLConnection.getResponseCode();
+
+		String statusLine = httpURLConnection.getResponseMessage();
+
+		Map<String, List<String>> responseHeaders =
+			httpURLConnection.getHeaderFields();
+
+		ByteBuffer byteBuffer = _collect(httpURLConnection.getInputStream());
+
+		String text = new String(
+			byteBuffer.array(), 0, byteBuffer.limit(), "utf-8");
+
+		long duration = System.currentTimeMillis() - startTime;
+
+		return new HttpResponse(
+			statusCode, statusLine, responseHeaders, text, duration);
+	}
+
+	private static final ThreadLocal<byte[]> _byteBuffer =
+		CentralizedThreadLocal.withInitial(() -> new byte[8192]);
+
+	static {
+		HttpURLConnection.setFollowRedirects(false);
+
+		CookieHandler.setDefault(
+			new CookieManager(null, CookiePolicy.ACCEPT_ALL));
+	}
+
+}

--- a/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/HttpUtil.java
+++ b/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/HttpUtil.java
@@ -53,6 +53,8 @@ public class HttpUtil {
 				}
 			}
 
+			_setCSRFToken(httpURLConnection);
+
 			httpURLConnection.setRequestMethod("GET");
 
 			return _readConnection(httpURLConnection);
@@ -102,6 +104,8 @@ public class HttpUtil {
 					httpURLConnection.addRequestProperty(header[0], header[1]);
 				}
 			}
+
+			_setCSRFToken(httpURLConnection);
 
 			httpURLConnection.setRequestMethod("POST");
 			httpURLConnection.setDoOutput(true);
@@ -313,7 +317,9 @@ public class HttpUtil {
 	private static HttpURLConnection _openConnection(String uri)
 		throws IOException {
 
-		URL url = new URL("http", "localhost", 8080, uri);
+		ContextUtil.Context context = ContextUtil.getContext();
+
+		URL url = new URL("http", context.getHostName(), 8080, uri);
 
 		HttpURLConnection httpURLConnection =
 			(HttpURLConnection)url.openConnection();
@@ -348,6 +354,16 @@ public class HttpUtil {
 
 		return new HttpResponse(
 			statusCode, statusLine, responseHeaders, text, duration);
+	}
+
+	private static void _setCSRFToken(HttpURLConnection httpURLConnection) {
+		ContextUtil.Context context = ContextUtil.getContext();
+
+		String csrfToken = context.getCSRFToken();
+
+		if (csrfToken != null) {
+			httpURLConnection.addRequestProperty("X-Csrf-Token", csrfToken);
+		}
 	}
 
 	private static final ThreadLocal<byte[]> _byteBuffer =

--- a/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/LoginTest.java
+++ b/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/LoginTest.java
@@ -22,11 +22,22 @@ public class LoginTest extends BaseBenchmarkTestCase {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
-	public void test1() throws Exception {
-		homePage();
-		viewLoginPage();
-		login();
-		logout();
+	public void testLogin() throws Exception {
+		runParallel(
+			() -> {
+				homePage();
+				viewLoginPage();
+				login();
+				logout();
+
+				return null;
+			},
+			1);
+	}
+
+	@Override
+	protected int getThreadPoolSize() {
+		return 1;
 	}
 
 }

--- a/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/LoginTest.java
+++ b/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/LoginTest.java
@@ -5,8 +5,10 @@
 
 package com.liferay.portal.benchmark.test.internal;
 
+import com.liferay.portal.benchmark.test.internal.data.DatabaseDataUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -20,6 +22,11 @@ public class LoginTest extends BaseBenchmarkTestCase {
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_userData = DatabaseDataUtil.getUsersMap("", "root", "liferay");
+	}
 
 	@Test
 	public void testLogin() throws Exception {
@@ -39,5 +46,12 @@ public class LoginTest extends BaseBenchmarkTestCase {
 	protected int getThreadPoolSize() {
 		return 1;
 	}
+
+	@Override
+	protected String[][] getUserData() throws Exception {
+		return _userData;
+	}
+
+	private static String[][] _userData;
 
 }

--- a/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/LoginTest.java
+++ b/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/LoginTest.java
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.benchmark.test.internal;
+
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Tina Tian
+ */
+public class LoginTest extends BaseBenchmarkTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void test1() throws Exception {
+		homePage();
+		viewLoginPage();
+		login();
+		logout();
+	}
+
+}

--- a/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/data/DatabaseDataUtil.java
+++ b/modules/apps/portal/portal-benchmark-test/src/test/java/com/liferay/portal/benchmark/test/internal/data/DatabaseDataUtil.java
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.benchmark.test.internal.data;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Dante Wang
+ */
+public class DatabaseDataUtil {
+
+	public static String[][] getUsersMap(
+			String url, String user, String password)
+		throws Exception {
+
+		Class.forName(
+			"com.mysql.cj.jdbc.Driver"
+		).newInstance();
+
+		List<String[]> users = new ArrayList<>();
+
+		try (Connection connection = DriverManager.getConnection(
+				url, user, password);
+			PreparedStatement preparedStatement1 = connection.prepareStatement(
+				"select companyId, emailAddress from User_ where " +
+					"emailAddress like 'test%'");
+			PreparedStatement preparedStatement2 = connection.prepareStatement(
+				"select webId from Company where companyId = ?");
+			ResultSet resultSet1 = preparedStatement1.executeQuery()) {
+
+			while (resultSet1.next()) {
+				long companyId = resultSet1.getLong("companyId");
+				String emailAddress = resultSet1.getString("emailAddress");
+
+				preparedStatement2.setLong(1, companyId);
+
+				try (ResultSet resultSet2 = preparedStatement2.executeQuery()) {
+					String webId = resultSet2.getString(1);
+
+					users.add(new String[] {webId, emailAddress});
+				}
+			}
+		}
+
+		return users.toArray(new String[0][0]);
+	}
+
+}


### PR DESCRIPTION
- Step 1
- Step-2 Run tests in a thread pool
- Step-2 Auto SF
- Correct the URL. There's no `/web/guest` part on vanilla portal, as well as benchmark portal using localhost.
- Parse csrf-token and send it in header
- Get users from database and iterate them in tests; the fetched data contains company hostname, but the support on test side is not implemented yet.
- Introduce a simple "Context" to make it possible to support multi-company hostnames and handle csrf tokens transparently.
